### PR TITLE
fix(formatter): skip binary files and fix max_depth=0 display

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -37,7 +37,7 @@ pub fn analyze_directory(
     // Parallel analysis of files
     let analysis_results: Vec<FileInfo> = file_entries
         .par_iter()
-        .map(|entry| {
+        .filter_map(|entry| {
             let path_str = entry.path.display().to_string();
 
             // Detect language from extension
@@ -47,14 +47,8 @@ pub fn analyze_directory(
             let source = match std::fs::read_to_string(&entry.path) {
                 Ok(content) => content,
                 Err(_) => {
-                    // Binary file or unreadable - include with LOC only
-                    return FileInfo {
-                        path: path_str,
-                        line_count: 0,
-                        function_count: 0,
-                        class_count: 0,
-                        language: "unknown".to_string(),
-                    };
+                    // Binary file or unreadable - exclude from output
+                    return None;
                 }
             };
 
@@ -76,13 +70,13 @@ pub fn analyze_directory(
                 ("unknown".to_string(), 0, 0)
             };
 
-            FileInfo {
+            Some(FileInfo {
                 path: path_str,
                 line_count,
                 function_count,
                 class_count,
                 language,
-            }
+            })
         })
         .collect();
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -32,10 +32,13 @@ pub fn format_structure(
 
     // SUMMARY block
     output.push_str("SUMMARY:\n");
-    let max_depth_display = max_depth.unwrap_or(0);
+    let depth_label = match max_depth {
+        Some(n) if n > 0 => format!(" (max_depth={})", n),
+        _ => String::new(),
+    };
     output.push_str(&format!(
-        "Shown: {} files, {}L, {}F, {}C (max_depth={})\n",
-        total_files, total_loc, total_functions, total_classes, max_depth_display
+        "Shown: {} files, {}L, {}F, {}C{}\n",
+        total_files, total_loc, total_functions, total_classes, depth_label
     ));
 
     if !lang_counts.is_empty() {
@@ -98,9 +101,8 @@ pub fn format_structure(
                 } else {
                     output.push_str(&format!("{}{} [{}]\n", indent, name, info_parts.join(", ")));
                 }
-            } else {
-                output.push_str(&format!("{}{}\n", indent, name));
             }
+            // Skip files not in analysis_map (binary/unreadable files)
         } else {
             output.push_str(&format!("{}{}/\n", indent, name));
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -120,11 +120,13 @@ fn test_analyze_directory_binary_file_skipping() {
     fs::write(root.join("image.png"), b"\x89PNG\r\n\x1a\n").unwrap();
     fs::write(root.join("lib.rs"), "fn test() {}").unwrap();
 
-    // Should not panic, should include binary file with LOC only
+    // Should not panic, should exclude binary file from output
     let output = analyze_directory(root, None).unwrap();
     assert!(output.formatted.contains("SUMMARY:"));
-    // Binary file should be included with 0 LOC
-    assert!(output.formatted.contains("image.png"));
+    // Binary file should be excluded from analysis results
+    assert!(!output.formatted.contains("image.png"));
+    // Only the readable Rust file should be included
+    assert!(output.formatted.contains("lib.rs"));
 }
 
 #[test]
@@ -225,7 +227,8 @@ fn distance() -> f64 {
     assert!(output.formatted.contains("Shown: 1 files"));
     assert!(output.formatted.contains("L,"));
     assert!(output.formatted.contains("F,"));
-    assert!(output.formatted.contains("C (max_depth=0)"));
+    // When max_depth is None (unlimited), max_depth label should be omitted
+    assert!(!output.formatted.contains("max_depth="));
 
     // Verify PATH header format
     assert!(output.formatted.contains("PATH [LOC, FUNCTIONS, CLASSES]"));


### PR DESCRIPTION
## Summary

Fixes two UX bugs identified in issue #14 (follow-up from PR #11 review).

### Changes

1. **Binary files excluded from output** -- Changed `par_iter().map()` to `par_iter().filter_map()` in `analyze.rs`. Unreadable files (binary/non-UTF-8) now return `None` and are excluded entirely, instead of appearing as `[0L]`.

2. **max_depth label omitted when unlimited** -- Updated `formatter.rs` to conditionally format the `max_depth=N` label only when `max_depth` is `Some(n)` and `n > 0`. When depth is unlimited (`None`), the label is omitted.

3. **Tests updated** -- Both `test_analyze_directory_binary_file_skipping` and `test_output_format_compliance` updated to verify the new behavior.

### Testing

- 15/15 tests passing (13 integration + 2 unit)
- `cargo clippy`: clean
- `cargo fmt`: clean
- No security findings

Closes #14