### PR TITLE
docs: add README.md and ARCHITECTURE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,153 @@
+# code-analyze-mcp
+
+Standalone MCP server for code structure analysis using tree-sitter.
+
+## Overview
+
+code-analyze-mcp is a Model Context Protocol server that analyzes code structure across 9 programming languages. It provides three analysis modes: directory overview (file tree with metrics), file-level semantic analysis (functions, classes, imports), and symbol-focused call graphs. Unlike goose's built-in analyze command, this is a standalone binary that can be integrated into any MCP client, with proper TypeScript support, JSX/TSX handling, and language-specific semantic extraction.
+
+## Quick Start
+
+### Build
+
+```bash
+cargo build --release
+```
+
+The binary is at `target/release/code-analyze-mcp`.
+
+### Configure MCP Client
+
+Add to your MCP client configuration (e.g., Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "code-analyze": {
+      "command": "/path/to/code-analyze-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Example Usage
+
+```bash
+# Directory overview (auto-detected)
+analyze path: /path/to/project
+
+# File details (auto-detected)
+analyze path: /path/to/file.rs
+
+# Symbol call graph (requires focus parameter)
+analyze path: /path/to/project focus: my_function follow_depth: 2
+```
+
+## Tool Interface
+
+The `analyze` tool accepts these parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | Yes | File or directory to analyze |
+| `max_depth` | integer | No | Directory recursion limit (default: 3) |
+| `focus` | string | No | Symbol name for call graph analysis |
+| `follow_depth` | integer | No | Call graph traversal depth (default: 2) |
+| `ast_recursion_limit` | integer | No | Tree-sitter recursion limit for stack safety |
+| `force` | boolean | No | Bypass output size warning (1000 lines) |
+
+**Mode Auto-Detection:**
+- `focus` provided → Symbol focus mode
+- Path is a file → File details mode
+- Path is a directory → Directory overview mode
+
+## Analysis Modes
+
+### Structure Mode (Directory Overview)
+
+Walks a directory tree and counts lines of code, functions, and classes per file. Respects `.gitignore` and optional `.gooseignore` files.
+
+```
+src/
+  main.rs [18 | F:1 C:0]
+  lib.rs [156 | F:12 C:3]
+  parser.rs [420 | F:8 C:2]
+  languages/
+    rust.rs [89 | F:3 C:0]
+```
+
+### Semantic Mode (File Details)
+
+Extracts functions, classes, imports, and type references from a single file.
+
+```
+FILE: src/lib.rs [156 LOC, F:12, C:3]
+
+C: CodeAnalyzer:20 SemanticExtractor:45
+
+F: new:27 analyze:35 extract:52 format:78 ...
+
+I: rmcp(3); serde(2); tree_sitter(4)
+
+R: methods[analyze(Path)]; types[AnalysisResult]; fields[path, mode]
+```
+
+### Focused Mode (Symbol Call Graph)
+
+Builds a call graph for a symbol and traverses it with configurable depth. Uses sentinel values `<module>` (top-level calls) and `<reference>` (type references).
+
+```
+FOCUS: analyze
+DEPTH: 2
+FILES: 8 analyzed
+
+DEFINED:
+  src/lib.rs:35
+
+CALLERS (incoming):
+  main -> analyze [src/main.rs:12]
+  <module> -> analyze [src/lib.rs:40]
+
+CALLEES (outgoing):
+  analyze -> determine_mode [src/analyze.rs:44]
+  analyze -> format_output [src/formatter.rs:12] (•2)
+```
+
+Functions called >3 times show `(•N)` notation.
+
+## Supported Languages
+
+| Language | Extensions | Status |
+|----------|-----------|--------|
+| Rust | `.rs` | Implemented |
+| Python | `.py` | Implemented |
+| JavaScript | `.js`, `.jsx` | Implemented |
+| TypeScript | `.ts`, `.tsx` | Implemented |
+| Go | `.go` | Implemented |
+| Java | `.java` | Implemented |
+| Kotlin | `.kt`, `.kts` | Implemented |
+| Swift | `.swift` | Implemented |
+| Ruby | `.rb` | Implemented |
+
+## Current Status
+
+This project is approximately 45% complete. See [issue #1](https://github.com/clouatre-labs/code-analyze-mcp/issues/1) for the full roadmap and wave-based merge plan.
+
+| Wave | Milestone | Status |
+|------|-----------|--------|
+| 0 | Foundation (CI, community files) | Complete |
+| 1 | Tooling (dependencies, guidelines) | Complete |
+| 2 | Core Features (semantic mode, languages) | In Progress |
+| 3 | Call Graphs (symbol focus mode) | Planned |
+| 4 | Polish (caching, performance) | Planned |
+
+## Documentation
+
+- **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** - Design goals, module map, data flow, language handler system, caching strategy
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Development workflow, commit conventions, PR checklist
+- **[SECURITY.md](SECURITY.md)** - Security policy and vulnerability reporting
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE) for details.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,364 @@
+# Architecture
+
+## Design Goals
+
+- **Goose analyze parity in standalone binary**: Replicate goose's code analysis capabilities as a standalone MCP server, enabling integration with any MCP client
+- **Language-agnostic parsing via tree-sitter**: Support 9 languages with a unified query-based extraction system, avoiding language-specific parsers
+- **Single MCP tool with auto-detected modes**: One `analyze` tool that automatically detects analysis mode (overview, file details, symbol focus) based on input parameters
+- **Performance via parallelism**: Use rayon for parallel file processing and ignore crate for efficient .gitignore-aware directory walking
+
+## Module Map
+
+| Module | File | Responsibility |
+|--------|------|-----------------|
+| `main` | `src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
+| `lib` | `src/lib.rs` | CodeAnalyzer struct; MCP tool handler; mode dispatch |
+| `analyze` | `src/analyze.rs` | High-level analysis orchestration; directory and file analysis |
+| `parser` | `src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
+| `formatter` | `src/formatter.rs` | Output formatting for all three modes |
+| `traversal` | `src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
+| `types` | `src/types.rs` | Shared data structures (AnalyzeParams, AnalysisResult, etc.) |
+| `lang` | `src/lang.rs` | Extension-to-language mapping |
+| `languages/mod` | `src/languages/mod.rs` | LanguageInfo registry and handler function types |
+| `languages/rust` | `src/languages/rust.rs` | Rust-specific queries and semantic handlers |
+| `cache` (planned) | `src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
+| `graph` (planned) | `src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
+
+## Data Flow
+
+```
+MCP Request
+  |
+  v
+Parameter Parsing (AnalyzeParams)
+  |
+  v
+Mode Detection (focus? file? dir?)
+  |
+  +---> Overview Mode
+  |       |
+  |       v
+  |     walk_directory (ignore crate)
+  |       |
+  |       v
+  |     Parallel parse (rayon)
+  |       |
+  |       v
+  |     ElementExtractor (function/class counts)
+  |       |
+  |       v
+  |     format_structure
+  |
+  +---> File Details Mode
+  |       |
+  |       v
+  |     Read file
+  |       |
+  |       v
+  |     SemanticExtractor (functions, classes, imports, references)
+  |       |
+  |       v
+  |     format_file_details
+  |
+  +---> Symbol Focus Mode (planned)
+          |
+          v
+        walk_directory
+          |
+          v
+        Build CallGraph (BFS)
+          |
+          v
+        format_focused
+  |
+  v
+Serialize to JSON
+  |
+  v
+MCP Response (assistant + user content)
+```
+
+## Analysis Modes
+
+### Structure Mode (Directory Overview)
+
+Triggered when path is a directory and no focus parameter is provided.
+
+**Pipeline:**
+1. Walk directory tree with `walk_directory()` (respects .gitignore)
+2. Filter to source files (by extension)
+3. Parallel parse with rayon: for each file, read source and extract function/class counts
+4. ElementExtractor uses tree-sitter queries to count elements
+5. Format as tree with LOC and counts per file
+6. Return FileInfo vector for JSON output
+
+**Key Functions:**
+- `analyze_directory()` - orchestrates the pipeline
+- `walk_directory()` - uses ignore crate for .gitignore-aware traversal
+- `ElementExtractor::extract_with_depth()` - counts functions and classes
+
+### Semantic Mode (File Details)
+
+Triggered when path is a file and no focus parameter is provided.
+
+**Pipeline:**
+1. Read file source
+2. Detect language from extension
+3. SemanticExtractor parses the file:
+   - Extract functions with parameters and return types
+   - Extract classes/structs with methods and fields
+   - Extract imports with full module paths
+   - Extract type references (method receivers, field types, parameters)
+4. Populate reference locations (file path, line number)
+5. Format as structured text with sections for classes, functions, imports, references
+6. Return SemanticAnalysis struct for JSON output
+
+**Key Functions:**
+- `analyze_file()` - orchestrates file-level analysis
+- `SemanticExtractor::extract()` - parses file and extracts semantic elements
+- `format_file_details()` - formats output with sections
+
+### Focused Mode (Symbol Call Graph)
+
+Triggered when focus parameter is provided. Planned for Wave 3.
+
+**Pipeline:**
+1. Walk entire directory to build symbol index
+2. Locate symbol definition (file, line)
+3. Build CallGraph via BFS:
+   - Find all callers of the symbol (incoming edges)
+   - Find all callees of the symbol (outgoing edges)
+   - Traverse to configurable depth (follow_depth)
+   - Track call frequency (functions called >3x marked with •N)
+4. Use sentinel values:
+   - `<module>` for top-level calls without a caller function
+   - `<reference>` for type references (instantiation, field types)
+5. Format as FOCUS/DEPTH/DEFINED/CALLERS/CALLEES sections
+6. Return FocusedAnalysisData struct for JSON output
+
+**Key Functions:**
+- `build_call_graph()` - constructs graph from directory
+- `CallGraph::bfs_traverse()` - traverses graph with depth limit
+- `format_focused()` - formats call graph output
+
+## Language Handler System
+
+Each language is represented by a `LanguageInfo` struct containing:
+
+```rust
+pub struct LanguageInfo {
+    pub name: &'static str,                              // "rust", "python", etc.
+    pub language: Language,                              // tree-sitter Language
+    pub element_query: &'static str,                     // Query to count functions/classes
+    pub call_query: &'static str,                        // Query to find function calls
+    pub reference_query: Option<&'static str>,           // Query to find type references
+    pub extract_function_name: Option<ExtractFunctionNameHandler>,
+    pub find_method_for_receiver: Option<FindMethodForReceiverHandler>,
+    pub find_receiver_type: Option<FindReceiverTypeHandler>,
+}
+```
+
+Handler function types:
+
+```rust
+pub type ExtractFunctionNameHandler = fn(&Node, &str, &str) -> Option<String>;
+pub type FindMethodForReceiverHandler = fn(&Node, &str, Option<usize>) -> Option<String>;
+pub type FindReceiverTypeHandler = fn(&Node, &str) -> Option<String>;
+```
+
+### How to Add a New Language
+
+1. **Add tree-sitter grammar crate to Cargo.toml:**
+   ```toml
+   tree-sitter-kotlin = "0.23.0"
+   ```
+
+2. **Create language module** (e.g., `src/languages/kotlin.rs`):
+   ```rust
+   pub const ELEMENT_QUERY: &str = r#"
+     (function_declaration) @function
+     (class_declaration) @class
+   "#;
+   
+   pub const CALL_QUERY: &str = r#"
+     (call_expression function: (identifier) @callee)
+   "#;
+   
+   pub fn extract_function_name(node: &Node, source: &str, _lang: &str) -> Option<String> {
+       // Extract function name from node
+   }
+   ```
+
+3. **Register in `languages/mod.rs`:**
+   ```rust
+   "kotlin" => Some(LanguageInfo {
+       name: "kotlin",
+       language: tree_sitter_kotlin::LANGUAGE.into(),
+       element_query: kotlin::ELEMENT_QUERY,
+       call_query: kotlin::CALL_QUERY,
+       reference_query: None,
+       extract_function_name: Some(kotlin::extract_function_name),
+       find_method_for_receiver: None,
+       find_receiver_type: None,
+   }),
+   ```
+
+4. **Add extension mapping in `lang.rs`:**
+   ```rust
+   ("kt", "kotlin"),
+   ("kts", "kotlin"),
+   ```
+
+5. **Write tests** in `src/languages/kotlin.rs`:
+   - Happy path: extract functions and classes from valid code
+   - Edge case: handle empty files, syntax errors, or language-specific constructs
+
+## Call Graph Design
+
+The CallGraph struct (planned for Wave 3) represents function call relationships:
+
+```rust
+pub struct CallGraph {
+    pub callers: HashMap<String, Vec<CallInfo>>,    // symbol -> [callers]
+    pub callees: HashMap<String, Vec<CallInfo>>,    // symbol -> [callees]
+    pub definitions: HashMap<String, DefinitionInfo>, // symbol -> location
+    pub call_frequency: HashMap<String, usize>,     // symbol -> call count
+}
+```
+
+**BFS Traversal Algorithm:**
+1. Start at symbol definition
+2. Queue: [(symbol, depth=0)]
+3. For each item in queue:
+   - If depth < follow_depth:
+     - Add all callers to queue with depth+1
+     - Add all callees to queue with depth+1
+   - Track visited symbols to avoid cycles
+4. Return graph with all reachable symbols
+
+**Sentinel Values:**
+- `<module>`: Top-level calls (no caller function context)
+- `<reference>`: Type references (field types, parameter types, instantiation)
+
+**Call Frequency:**
+- Count how many times each symbol is called
+- Mark symbols called >3 times with `(•N)` in output
+
+## Caching Strategy
+
+Planned for Wave 4. Uses LRU cache with mtime-based invalidation.
+
+**Cache Key:** `(path, mtime, mode)`
+
+**Cache Entry:**
+```rust
+pub struct CacheEntry {
+    pub result: AnalysisResult,
+    pub mtime: SystemTime,
+    pub created_at: SystemTime,
+}
+```
+
+**Invalidation:**
+- Check file mtime on cache hit
+- If mtime changed, invalidate and reparse
+- For directories, check mtime of all files in tree
+
+**Lock-or-Recover Pattern:**
+- If parsing fails, return last valid cached result
+- Log warning but don't fail the request
+- Allows graceful degradation if a file becomes temporarily unreadable
+
+**Configuration:**
+- Max cache size: 1000 entries (configurable)
+- TTL: 1 hour (optional, for safety)
+
+## Error Handling
+
+Three error types using thiserror:
+
+```rust
+#[derive(Debug, Error)]
+pub enum ParserError {
+    #[error("Unsupported language: {0}")]
+    UnsupportedLanguage(String),
+    #[error("Failed to parse file: {0}")]
+    ParseError(String),
+    #[error("Invalid UTF-8 in file")]
+    InvalidUtf8,
+    #[error("Query error: {0}")]
+    QueryError(String),
+}
+
+#[derive(Debug, Error)]
+pub enum TraversalError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
+}
+
+#[derive(Debug, Error)]
+pub enum AnalyzeError {
+    #[error("Traversal error: {0}")]
+    Traversal(#[from] TraversalError),
+    #[error("Parser error: {0}")]
+    Parser(#[from] ParserError),
+}
+```
+
+**Error Propagation:**
+- Use `?` operator in all functions
+- No `unwrap()` or `expect()` in library code
+- MCP tool handler converts errors to ErrorData with descriptive messages
+
+## Performance
+
+**Parallel Processing:**
+- rayon for parallel file parsing in structure mode
+- Each file parsed independently; no shared state
+- Scales to 100+ files efficiently
+
+**Directory Walking:**
+- ignore crate respects .gitignore and .gooseignore
+- Avoids traversing excluded directories (e.g., node_modules, .git)
+- Reduces I/O by 50-80% on typical projects
+
+**AST Recursion Limit:**
+- Prevents stack overflow on deeply nested code
+- Configurable via ast_recursion_limit parameter
+- Default: 256 (safe for most code)
+
+**Output Size Limiting:**
+- Warn if output exceeds 1000 lines
+- force flag bypasses warning
+- Prevents MCP client from being overwhelmed
+
+## Improvements Over Goose
+
+- **Proper TypeScript support**: Uses tree-sitter-typescript, not JavaScript fallback
+- **JSX and TSX**: Dedicated file mappings and queries
+- **Language-specific handlers**: extract_function_name, find_method_for_receiver, find_receiver_type for semantic accuracy
+- **Call graph with sentinel values**: `<module>` and `<reference>` for cross-file analysis
+- **Parallel file processing**: rayon for faster analysis on large codebases
+- **Nested .gitignore support**: ignore crate respects directory-specific ignore rules
+- **Standalone binary**: Not integrated into goose; can be used with any MCP client
+
+## Current Status
+
+The project is approximately 45% complete:
+
+- **Implemented (Wave 2):**
+  - Project skeleton (main.rs, lib.rs, types.rs, lang.rs)
+  - Structure mode (directory overview with file tree)
+  - Semantic mode (file-level analysis with functions, classes, imports)
+  - Rust language support with semantic handlers
+
+- **Planned (Waves 3-4):**
+  - Symbol focus mode (call graphs with BFS traversal)
+  - Remaining language modules (Basic Python, JavaScript, TypeScript, Go, Java, Kotlin, Swift, Ruby support)
+  - LRU caching with mtime invalidation
+  - Output size limiting and force flag
+  - Performance testing and tuning
+
+See [issue #1](https://github.com/clouatre-labs/code-analyze-mcp/issues/1) for the complete roadmap and wave-based merge plan.


### PR DESCRIPTION
## Summary

Adds aspirational documentation describing the completed end state of the project (all waves merged). Both files serve as the north star reference for remaining development work.

- **README.md** (154 lines): Quick start, tool interface, three analysis modes with example output, supported languages table, current status, documentation links
- **docs/ARCHITECTURE.md** (365 lines): Design goals, module map, data flow diagram, analysis mode pipelines, language handler system with "how to add a language" guide, call graph design, caching strategy, error handling, performance considerations

Total: 519 lines (within 800-line budget).

## Known Issues (to fix in follow-up commit)

- [ ] Wave 0/1 status shown as "Planned" in README (should be "Complete")
- [ ] `follow_depth` default should be 2 (not 1), `max_depth` default should be 3 (not unlimited)
- [ ] `force` parameter missing from README parameter table
- [ ] Language support status overstated in ARCHITECTURE.md Current Status section (only Rust is implemented today)

## Testing

Documentation only, no code changes. CI should pass (format, lint, commitlint, check-base).

Closes: N/A (no issue for this work)