### PR TITLE
fix(mcp): use ProtocolVersion::LATEST instead of hardcoded V_2024_11_05

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ impl Default for CodeAnalyzer {
 impl ServerHandler for CodeAnalyzer {
     fn get_info(&self) -> InitializeResult {
         InitializeResult {
-            protocol_version: ProtocolVersion::V_2024_11_05,
+            protocol_version: ProtocolVersion::LATEST,
             capabilities: Default::default(),
             server_info: Implementation {
                 name: "code-analyze-mcp".into(),


### PR DESCRIPTION
## Summary

Use `ProtocolVersion::LATEST` (resolves to `V_2025_06_18` in rmcp 0.17.0) instead of the hardcoded `V_2024_11_05`.

The MCP spec says the server SHOULD respond with the latest version it supports. The previous value was two versions behind.

## Changes

- `src/lib.rs`: Replace `ProtocolVersion::V_2024_11_05` with `ProtocolVersion::LATEST`

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo test`: 15 passed, 0 failed

Partially addresses #33 (item 1 of 5).