### PR TITLE
fix(mcp): protocol compliance for version, capabilities, instructions, and annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     AnnotateAble, CallToolResult, ErrorData, Implementation, InitializeResult, ProtocolVersion,
-    RawContent, Role,
+    RawContent, Role, ServerCapabilities,
 };
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use std::path::Path;
@@ -32,7 +32,13 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self))]
     #[tool(
-        description = "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N."
+        description = "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn analyze(
         &self,
@@ -156,8 +162,8 @@ impl Default for CodeAnalyzer {
 impl ServerHandler for CodeAnalyzer {
     fn get_info(&self) -> InitializeResult {
         InitializeResult {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: Default::default(),
+            protocol_version: ProtocolVersion::V_2025_06_18,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
                 name: "code-analyze-mcp".into(),
                 version: "0.1.0".into(),
@@ -168,7 +174,7 @@ impl ServerHandler for CodeAnalyzer {
                 icons: None,
                 website_url: None,
             },
-            instructions: None,
+            instructions: Some("Analyze code structure using three modes: directory overview (file tree with metrics), file details (functions/classes/imports), or symbol focus (call graphs). Provide a path and optionally specify mode and max_depth.".into()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes 4 of 5 MCP protocol compliance issues from #33, validated against rmcp 0.17.0 source and MCP spec 2025-06-18.

## Changes

| Item | Before | After |
|---|---|---|
| Protocol version | `V_2024_11_05` (hardcoded, 2 versions behind) | `V_2025_06_18` (explicit, current) |
| Capabilities | `Default::default()` (all None) | `ServerCapabilities::builder().enable_tools().build()` |
| Instructions | `None` | Concise 2-sentence usage guide |
| Tool annotations | None | `read_only=true, destructive=false, idempotent=true, open_world=false` |

## Item 5 (remove mode) excluded

Removing `mode` from `AnalyzeParams` would prevent LLM clients from overriding auto-detection. The current description already says "(auto-detected if not provided)". See [review comment](https://github.com/clouatre-labs/code-analyze-mcp/issues/33#issuecomment-3987347496) for full rationale.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo test`: 15 passed, 0 failed
- Security scan: no findings

Closes #33