### PR TITLE
docs: align AGENTS.md and copilot-instructions with aspirational docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,17 +12,25 @@ UI method: use the issue sidebar to assign to `copilot-swe-agent[bot]`.
 
 ## PR iteration
 
-Comment `@copilot` with specific feedback; agent pushes follow-up commits.
-If the agent cannot resolve after 2 iterations: close the PR, amend the issue with clarifications, and re-assign.
+- Comment `@copilot` with specific feedback; agent pushes follow-up commits
+- If unresolved after 2 iterations: close PR, amend issue, re-assign
 
 ## Copilot code review
 
 Flag:
-- Hallucinated APIs (methods that do not exist in the installed crate versions)
+- Hallucinated APIs; verify against `Cargo.lock` and `cargo doc --open`
 - Scope creep beyond the issue deliverables
 - Missing error handling
+- Only Rust is implemented; SymbolFocus mode is stubbed (Wave 3)
+- rmcp, tree-sitter, schemars version assumptions; verify against installed versions
+
+## Design references
+
+- [ARCHITECTURE.md](../docs/ARCHITECTURE.md) - design, language handlers, "How to add a language"
+- [AGENTS.md](../AGENTS.md) - project conventions and implementation status
 
 ## Firewall
 
-Copilot coding agent runs in a firewalled GitHub Actions environment and cannot fetch arbitrary URLs.
-If a build or test step needs a URL not in the default allow list, document it in the PR so the maintainer can update `.github/copilot/firewall.yml`.
+- Copilot runs in a firewalled GitHub Actions environment; no arbitrary URLs
+- If a build step needs a URL not in the allow list, document it in the PR
+- Maintainer updates `.github/copilot/firewall.yml`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,12 @@
 
 ## Project overview
 
-Rust MCP server providing code structure analysis tools (directory overview, file details, symbol call graphs) using tree-sitter.
-Rust edition 2024, async with tokio, MCP protocol via `rmcp` crate.
-Single crate, Apache-2.0 licensed.
+- Rust MCP server for code structure analysis using tree-sitter
+- 9 languages planned; only Rust is implemented
+- Three analysis modes: Overview, FileDetails (implemented); SymbolFocus (planned Wave 3)
+- Rust edition 2024, async with tokio, MCP protocol via `rmcp`
+- Single crate, Apache-2.0 licensed
+- See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for design and module map
 
 ## Commands
 
@@ -18,9 +21,11 @@ cargo deny check advisories licenses
 
 ## API verification (critical)
 
-Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. These crates evolve rapidly.
-Before using any API: check `Cargo.lock` for the installed version, then verify the method exists in the crate source under `~/.cargo/registry/src/` or by running `cargo doc --open`.
-If the repo has existing source code, follow the patterns already established there. Existing code is the most reliable reference.
+- Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs
+- These crates evolve rapidly
+- Check `Cargo.lock` for the installed version before using any API
+- Verify the method exists in crate source under `~/.cargo/registry/src/` or via `cargo doc --open`
+- Follow patterns already established in existing code; it is the most reliable reference
 
 ## rmcp patterns (verify against installed version)
 
@@ -56,7 +61,8 @@ impl MyServer {
 }
 ```
 
-- Tool annotations: `read_only_hint`, `destructive_hint`, `idempotent_hint`, `open_world_hint` (all `Option<bool>`)
+- Tool annotations (all `Option<bool>`):
+  `read_only_hint`, `destructive_hint`, `idempotent_hint`, `open_world_hint`
 - `ServerHandler` impl with `#[tool_handler]` macro for `call_tool` and `list_tools`
 - Transport: `transport-io` feature for stdio
 
@@ -85,7 +91,10 @@ impl MyServer {
 
 - `Parameters<T>` struct pattern for tool parameters (see rmcp example above)
 - MCP tool annotations: `read_only_hint = true` for all tools (this server is read-only)
-- Three analysis modes: directory overview, file details, symbol focus (call graphs)
+- Analysis modes: Overview (directory tree), FileDetails (semantic extraction) are implemented
+- SymbolFocus (call graphs) is planned for Wave 3
+- Language handler system: `LanguageInfo` registry with tree-sitter queries and semantic handlers
+- Adding a language: see [ARCHITECTURE.md](docs/ARCHITECTURE.md#language-handler-system)
 - `rayon` for parallel file processing; `ignore` crate for .gitignore-aware directory walking
 
 ## Code style
@@ -103,8 +112,21 @@ impl MyServer {
 - DCO sign-off all commits: `--signoff` flag
 - Do not add co-author trailers for AI agents
 
-## Reference documentation (for agents with web access)
+## Project status
 
+- Only Rust language support is implemented
+- README.md shows 9 languages; that is aspirational
+- Roadmap: [issue #1](https://github.com/clouatre-labs/code-analyze-mcp/issues/1)
+- Wave 0 (Foundation): complete
+- Wave 1 (Tooling): complete
+- Wave 2 (Overview, FileDetails modes; Rust): in progress
+- Wave 3 (SymbolFocus / call graphs): planned
+- Wave 4 (Caching, performance): planned
+
+## Design references
+
+- [ARCHITECTURE.md](docs/ARCHITECTURE.md) - design, module map, data flow, language handlers
+- [README.md](README.md) - Quick start, tool interface, analysis modes, supported languages
 - rmcp: https://docs.rs/rmcp/latest/rmcp/
 - MCP specification: https://spec.modelcontextprotocol.io/
 - tree-sitter: https://tree-sitter.github.io/tree-sitter/


### PR DESCRIPTION
## Summary

Aligns AGENTS.md and `.github/copilot-instructions.md` with the aspirational README.md and ARCHITECTURE.md introduced in PR #32.

## Changes

### AGENTS.md
- Expanded project overview: 9 planned languages, three analysis modes, ARCHITECTURE.md link
- Clarified implemented (Overview, FileDetails) vs. planned (SymbolFocus, Wave 3) modes
- Added project status wave table with link to issue #1
- Added design references section cross-linking ARCHITECTURE.md and README.md
- Documented language handler system with ARCHITECTURE.md cross-reference
- Kept under 150 lines (136 lines); no content duplication from ARCHITECTURE.md

### .github/copilot-instructions.md
- Added project-specific hallucination checks: Rust-only language support, SymbolFocus stubbed
- Added design references section pointing to ARCHITECTURE.md and AGENTS.md
- Expanded API verification guidance (Cargo.lock, cargo doc)

## Design decisions
- Cross-references over duplication: detailed guides ("How to add a language", sentinel values, call frequency marking) remain in ARCHITECTURE.md
- Inline only what agents need to avoid scope creep: implementation status and mode availability
- Style matches global AGENTS.md model (terse bullet points, imperative voice)

## Testing
- Documentation-only change; no code changes
- All relative links verified to resolve correctly
- Security scan: clean