### PR TITLE
feat(graph): implement focused mode with symbol call graph

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -1,10 +1,11 @@
-use crate::formatter::{format_file_details, format_structure};
+use crate::formatter::{format_file_details, format_focused, format_structure};
+use crate::graph::CallGraph;
 use crate::lang::language_from_extension;
 use crate::parser::{ElementExtractor, SemanticExtractor};
 use crate::traversal::{WalkEntry, walk_directory};
 use crate::types::{AnalysisMode, FileInfo, SemanticAnalysis};
 use rayon::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -14,6 +15,10 @@ pub enum AnalyzeError {
     Traversal(#[from] crate::traversal::TraversalError),
     #[error("Parser error: {0}")]
     Parser(#[from] crate::parser::ParserError),
+    #[error("Graph error: {0}")]
+    Graph(#[from] crate::graph::GraphError),
+    #[error("Formatter error: {0}")]
+    Formatter(#[from] crate::formatter::FormatterError),
 }
 
 /// Result of directory analysis containing both formatted output and file data.
@@ -145,4 +150,74 @@ pub fn analyze_file(
         semantic,
         line_count,
     })
+}
+
+/// Result of focused symbol analysis.
+pub struct FocusedAnalysisOutput {
+    pub formatted: String,
+}
+
+/// Analyze a symbol's call graph across a directory.
+#[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
+pub fn analyze_focused(
+    root: &Path,
+    focus: &str,
+    follow_depth: u32,
+    max_depth: Option<u32>,
+    ast_recursion_limit: Option<usize>,
+) -> Result<FocusedAnalysisOutput, AnalyzeError> {
+    // Check if path is a file (hint to use directory)
+    if root.is_file() {
+        let formatted =
+            "Single-file focus not supported. Please provide a directory path for cross-file call graph analysis.\n"
+                .to_string();
+        return Ok(FocusedAnalysisOutput { formatted });
+    }
+
+    // Walk the directory
+    let entries = walk_directory(root, max_depth)?;
+
+    // Collect semantic analysis for all files in parallel
+    let file_entries: Vec<&WalkEntry> = entries.iter().filter(|e| !e.is_dir).collect();
+
+    let analysis_results: Vec<(PathBuf, SemanticAnalysis)> = file_entries
+        .par_iter()
+        .filter_map(|entry| {
+            let ext = entry.path.extension().and_then(|e| e.to_str());
+
+            // Try to read file content
+            let source = match std::fs::read_to_string(&entry.path) {
+                Ok(content) => content,
+                Err(_) => return None,
+            };
+
+            // Detect language and extract semantic information
+            let language = if let Some(ext_str) = ext {
+                language_from_extension(ext_str)
+                    .map(|l| l.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            } else {
+                "unknown".to_string()
+            };
+
+            match SemanticExtractor::extract(&source, &language, ast_recursion_limit) {
+                Ok(mut semantic) => {
+                    // Populate file path on references
+                    for r in &mut semantic.references {
+                        r.location = entry.path.display().to_string();
+                    }
+                    Some((entry.path.clone(), semantic))
+                }
+                Err(_) => None,
+            }
+        })
+        .collect();
+
+    // Build call graph
+    let graph = CallGraph::build_from_results(analysis_results)?;
+
+    // Format output
+    let formatted = format_focused(&graph, focus, follow_depth)?;
+
+    Ok(FocusedAnalysisOutput { formatted })
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,7 +1,15 @@
+use crate::graph::CallGraph;
 use crate::traversal::WalkEntry;
 use crate::types::{FileInfo, SemanticAnalysis};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
 use tracing::instrument;
+
+#[derive(Debug, Error)]
+pub enum FormatterError {
+    #[error("Graph error: {0}")]
+    GraphError(#[from] crate::graph::GraphError),
+}
 
 /// Format directory structure analysis results.
 #[instrument(skip_all)]
@@ -208,4 +216,102 @@ pub fn format_file_details(path: &str, analysis: &SemanticAnalysis, line_count: 
     }
 
     output
+}
+
+/// Format focused symbol analysis with call graph.
+#[instrument(skip_all)]
+pub fn format_focused(
+    graph: &CallGraph,
+    symbol: &str,
+    follow_depth: u32,
+) -> Result<String, FormatterError> {
+    let mut output = String::new();
+
+    // FOCUS section
+    output.push_str(&format!("FOCUS: {}\n", symbol));
+
+    // DEPTH section
+    output.push_str(&format!("DEPTH: {}\n", follow_depth));
+
+    // DEFINED section - show where the symbol is defined
+    if let Some(definitions) = graph.definitions.get(symbol) {
+        output.push_str("DEFINED:\n");
+        for (path, line) in definitions {
+            output.push_str(&format!("  {}:{}\n", path.display(), line));
+        }
+    } else {
+        output.push_str("DEFINED: (not found)\n");
+    }
+
+    // CALLERS section - who calls this symbol
+    let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
+    output.push_str("CALLERS:\n");
+    if incoming_chains.is_empty() {
+        output.push_str("  (none)\n");
+    } else {
+        for chain in &incoming_chains {
+            let chain_str = chain
+                .chain
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect::<Vec<_>>()
+                .join(" <- ");
+            output.push_str(&format!("  {}\n", chain_str));
+        }
+    }
+
+    // CALLEES section - what this symbol calls
+    let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
+    output.push_str("CALLEES:\n");
+    if outgoing_chains.is_empty() {
+        output.push_str("  (none)\n");
+    } else {
+        for chain in &outgoing_chains {
+            let chain_str = chain
+                .chain
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            output.push_str(&format!("  {}\n", chain_str));
+        }
+    }
+
+    // STATISTICS section
+    output.push_str("STATISTICS:\n");
+    let incoming_count = incoming_chains.len();
+    let outgoing_count = outgoing_chains.len();
+    output.push_str(&format!("  Incoming calls: {}\n", incoming_count));
+    output.push_str(&format!("  Outgoing calls: {}\n", outgoing_count));
+
+    // FILES section - collect unique files from chains
+    let mut files = HashSet::new();
+    for chain in &incoming_chains {
+        for (_, path, _) in &chain.chain {
+            files.insert(path.clone());
+        }
+    }
+    for chain in &outgoing_chains {
+        for (_, path, _) in &chain.chain {
+            files.insert(path.clone());
+        }
+    }
+    if let Some(definitions) = graph.definitions.get(symbol) {
+        for (path, _) in definitions {
+            files.insert(path.clone());
+        }
+    }
+
+    output.push_str("FILES:\n");
+    if files.is_empty() {
+        output.push_str("  (none)\n");
+    } else {
+        let mut sorted_files: Vec<_> = files.into_iter().collect();
+        sorted_files.sort();
+        for file in sorted_files {
+            output.push_str(&format!("  {}\n", file.display()));
+        }
+    }
+
+    Ok(output)
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,260 @@
+use crate::types::SemanticAnalysis;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+use thiserror::Error;
+use tracing::instrument;
+
+#[derive(Debug, Error)]
+pub enum GraphError {
+    #[error("Symbol not found: {0}")]
+    SymbolNotFound(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct CallChain {
+    pub chain: Vec<(String, PathBuf, usize)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CallGraph {
+    pub callers: HashMap<String, Vec<(PathBuf, usize, String)>>,
+    pub callees: HashMap<String, Vec<(PathBuf, usize, String)>>,
+    pub definitions: HashMap<String, Vec<(PathBuf, usize)>>,
+}
+
+impl CallGraph {
+    pub fn new() -> Self {
+        Self {
+            callers: HashMap::new(),
+            callees: HashMap::new(),
+            definitions: HashMap::new(),
+        }
+    }
+
+    #[instrument(skip_all)]
+    pub fn build_from_results(
+        results: Vec<(PathBuf, SemanticAnalysis)>,
+    ) -> Result<Self, GraphError> {
+        let mut graph = CallGraph::new();
+
+        for (path, analysis) in &results {
+            for func in &analysis.functions {
+                graph
+                    .definitions
+                    .entry(func.name.clone())
+                    .or_default()
+                    .push((path.clone(), func.line));
+            }
+            for class in &analysis.classes {
+                graph
+                    .definitions
+                    .entry(class.name.clone())
+                    .or_default()
+                    .push((path.clone(), class.line));
+            }
+        }
+
+        for (path, analysis) in &results {
+            for call in &analysis.calls {
+                graph.callees.entry(call.caller.clone()).or_default().push((
+                    path.clone(),
+                    call.line,
+                    call.callee.clone(),
+                ));
+                graph.callers.entry(call.callee.clone()).or_default().push((
+                    path.clone(),
+                    call.line,
+                    call.caller.clone(),
+                ));
+            }
+            for reference in &analysis.references {
+                graph
+                    .callers
+                    .entry(reference.symbol.clone())
+                    .or_default()
+                    .push((path.clone(), reference.line, "<reference>".to_string()));
+            }
+        }
+
+        Ok(graph)
+    }
+
+    fn find_chains_bfs(
+        &self,
+        symbol: &str,
+        follow_depth: u32,
+        is_incoming: bool,
+    ) -> Result<Vec<CallChain>, GraphError> {
+        let graph_map = if is_incoming {
+            &self.callers
+        } else {
+            &self.callees
+        };
+
+        if !self.definitions.contains_key(symbol) && !graph_map.contains_key(symbol) {
+            return Err(GraphError::SymbolNotFound(symbol.to_string()));
+        }
+
+        let mut chains = Vec::new();
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back((symbol.to_string(), 0));
+        visited.insert(symbol.to_string());
+
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth > follow_depth {
+                continue;
+            }
+
+            if let Some(neighbors) = graph_map.get(&current) {
+                for (path, line, neighbor) in neighbors {
+                    let mut chain = vec![(current.clone(), path.clone(), *line)];
+                    let mut chain_node = neighbor.clone();
+                    let mut chain_depth = depth;
+
+                    while chain_depth < follow_depth {
+                        if let Some(next_neighbors) = graph_map.get(&chain_node) {
+                            if let Some((p, l, n)) = next_neighbors.first() {
+                                if is_incoming {
+                                    chain.insert(0, (chain_node.clone(), p.clone(), *l));
+                                } else {
+                                    chain.push((chain_node.clone(), p.clone(), *l));
+                                }
+                                chain_node = n.clone();
+                                chain_depth += 1;
+                            } else {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+
+                    if is_incoming {
+                        chain.insert(0, (neighbor.clone(), path.clone(), *line));
+                    } else {
+                        chain.push((neighbor.clone(), path.clone(), *line));
+                    }
+                    chains.push(CallChain { chain });
+
+                    if !visited.contains(neighbor) && depth < follow_depth {
+                        visited.insert(neighbor.clone());
+                        queue.push_back((neighbor.clone(), depth + 1));
+                    }
+                }
+            }
+        }
+
+        Ok(chains)
+    }
+
+    #[instrument(skip(self))]
+    pub fn find_incoming_chains(
+        &self,
+        symbol: &str,
+        follow_depth: u32,
+    ) -> Result<Vec<CallChain>, GraphError> {
+        self.find_chains_bfs(symbol, follow_depth, true)
+    }
+
+    #[instrument(skip(self))]
+    pub fn find_outgoing_chains(
+        &self,
+        symbol: &str,
+        follow_depth: u32,
+    ) -> Result<Vec<CallChain>, GraphError> {
+        self.find_chains_bfs(symbol, follow_depth, false)
+    }
+}
+
+impl Default for CallGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CallInfo, FunctionInfo};
+
+    fn make_analysis(
+        funcs: Vec<(&str, usize)>,
+        calls: Vec<(&str, &str, usize)>,
+    ) -> SemanticAnalysis {
+        SemanticAnalysis {
+            functions: funcs
+                .into_iter()
+                .map(|(n, l)| FunctionInfo {
+                    name: n.to_string(),
+                    line: l,
+                    end_line: l + 5,
+                    parameters: vec![],
+                    return_type: None,
+                })
+                .collect(),
+            classes: vec![],
+            imports: vec![],
+            references: vec![],
+            call_frequency: Default::default(),
+            calls: calls
+                .into_iter()
+                .map(|(c, e, l)| CallInfo {
+                    caller: c.to_string(),
+                    callee: e.to_string(),
+                    line: l,
+                    column: 0,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_graph_construction() {
+        let analysis = make_analysis(
+            vec![("main", 1), ("foo", 10), ("bar", 20)],
+            vec![("main", "foo", 2), ("foo", "bar", 15)],
+        );
+        let graph = CallGraph::build_from_results(vec![(PathBuf::from("test.rs"), analysis)])
+            .expect("Failed to build graph");
+        assert!(graph.definitions.contains_key("main"));
+        assert!(graph.definitions.contains_key("foo"));
+        assert_eq!(graph.callees["main"][0].2, "foo");
+        assert_eq!(graph.callers["foo"][0].2, "main");
+    }
+
+    #[test]
+    fn test_find_incoming_chains_depth_zero() {
+        let analysis = make_analysis(vec![("main", 1), ("foo", 10)], vec![("main", "foo", 2)]);
+        let graph = CallGraph::build_from_results(vec![(PathBuf::from("test.rs"), analysis)])
+            .expect("Failed to build graph");
+        assert!(
+            !graph
+                .find_incoming_chains("foo", 0)
+                .expect("Failed to find chains")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_find_outgoing_chains_depth_zero() {
+        let analysis = make_analysis(vec![("main", 1), ("foo", 10)], vec![("main", "foo", 2)]);
+        let graph = CallGraph::build_from_results(vec![(PathBuf::from("test.rs"), analysis)])
+            .expect("Failed to build graph");
+        assert!(
+            !graph
+                .find_outgoing_chains("main", 0)
+                .expect("Failed to find chains")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_symbol_not_found() {
+        assert!(
+            CallGraph::new()
+                .find_incoming_chains("nonexistent", 0)
+                .is_err()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod formatter;
+pub mod graph;
 pub mod lang;
 pub mod languages;
 pub mod parser;
@@ -116,14 +117,27 @@ impl CodeAnalyzer {
                     ),
                 }
             }
-            AnalysisMode::SymbolFocus => (
-                "Symbol focus mode not yet implemented".to_string(),
-                vec![],
-                vec![],
-                vec![],
-                vec![],
-                0,
-            ),
+            AnalysisMode::SymbolFocus => {
+                let focus = params.focus.as_deref().unwrap_or("");
+                let follow_depth = params.follow_depth.unwrap_or(1);
+                match analyze::analyze_focused(
+                    Path::new(&params.path),
+                    focus,
+                    follow_depth,
+                    params.max_depth,
+                    params.ast_recursion_limit,
+                ) {
+                    Ok(output) => (output.formatted, vec![], vec![], vec![], vec![], 0),
+                    Err(e) => (
+                        format!("Error analyzing symbol focus: {}", e),
+                        vec![],
+                        vec![],
+                        vec![],
+                        vec![],
+                        0,
+                    ),
+                }
+            }
         };
 
         let result = AnalysisResult {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::languages::get_language_info;
 use crate::types::{
-    ClassInfo, FunctionInfo, ImportInfo, ReferenceInfo, ReferenceType, SemanticAnalysis,
+    CallInfo, ClassInfo, FunctionInfo, ImportInfo, ReferenceInfo, ReferenceType, SemanticAnalysis,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -221,6 +221,7 @@ impl SemanticExtractor {
         let mut imports = Vec::new();
         let mut references = Vec::new();
         let mut call_frequency = HashMap::new();
+        let mut calls = Vec::new();
 
         // Validate and convert ast_recursion_limit once
         let max_depth: Option<u32> = ast_recursion_limit
@@ -316,7 +317,28 @@ impl SemanticExtractor {
                 if capture_name == "call" {
                     let node = capture.node;
                     let call_name = source[node.start_byte()..node.end_byte()].to_string();
-                    *call_frequency.entry(call_name).or_insert(0) += 1;
+                    *call_frequency.entry(call_name.clone()).or_insert(0) += 1;
+
+                    // Find the enclosing function for this call
+                    let mut current = node;
+                    let mut caller = "<module>".to_string();
+                    while let Some(parent) = current.parent() {
+                        if parent.kind() == "function_item"
+                            && let Some(name_node) = parent.child_by_field_name("name")
+                        {
+                            caller =
+                                source[name_node.start_byte()..name_node.end_byte()].to_string();
+                            break;
+                        }
+                        current = parent;
+                    }
+
+                    calls.push(CallInfo {
+                        caller,
+                        callee: call_name,
+                        line: node.start_position().row + 1,
+                        column: node.start_position().column,
+                    });
                 }
             }
         }
@@ -441,6 +463,7 @@ impl SemanticExtractor {
             imports,
             references,
             call_frequency,
+            calls,
         })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,4 +157,6 @@ pub struct SemanticAnalysis {
     pub references: Vec<ReferenceInfo>,
     #[schemars(description = "Call frequency map (function name -> count)")]
     pub call_frequency: HashMap<String, usize>,
+    #[schemars(description = "Caller-callee pairs extracted from call expressions")]
+    pub calls: Vec<CallInfo>,
 }


### PR DESCRIPTION
## Summary

Implement focused mode (symbol call graph) for issue #4. Given a symbol name and directory, builds a cross-file call graph and traces callers/callees to configurable depth via BFS.

## Changes

- **src/graph.rs** (new): `CallGraph` struct with three HashMaps (`callers`, `callees`, `definitions`), `build_from_results()` to populate from semantic analysis, and BFS-based `find_incoming_chains()`/`find_outgoing_chains()` with visited set for cycle detection
- **src/parser.rs**: Extended call extraction to populate `Vec<CallInfo>` by walking AST parent chain from each call node to find enclosing function; uses `<module>` sentinel for top-level calls
- **src/types.rs**: Added `calls: Vec<CallInfo>` field to `SemanticAnalysis`
- **src/analyze.rs**: Added `analyze_focused()` with parallel file analysis via `rayon::par_iter`, single-file hint
- **src/formatter.rs**: Added `format_focused()` producing FOCUS/DEPTH/DEFINED/CALLERS/CALLEES/STATISTICS/FILES output sections
- **src/lib.rs**: Wired SymbolFocus dispatch with `follow_depth` parameter (0=definition only, 1=direct, 2+=transitive chains)

## Design

- `follow_depth=0`: shows only where the symbol is defined
- `follow_depth=1`: shows direct callers/callees
- `follow_depth=2` (default): shows transitive chains via BFS
- Cycle detection via visited set prevents infinite traversal
- `<module>` sentinel for top-level calls outside any function
- `<reference>` sentinel for type references in the call graph
- Backward compatible: `call_frequency` preserved for existing formatter output

## Testing

- 4 new unit tests in graph.rs: graph construction, incoming chains, outgoing chains, symbol not found
- All 31 existing integration tests pass (no regressions)
- `cargo fmt --check`, `cargo clippy -- -D warnings` clean

Closes #4