### PR TITLE
refactor(types): replace tuple returns with ModeResult enum

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -22,13 +22,14 @@ pub enum AnalyzeError {
 }
 
 /// Result of directory analysis containing both formatted output and file data.
+#[derive(Debug)]
 pub struct AnalysisOutput {
     pub formatted: String,
     pub files: Vec<FileInfo>,
 }
 
 /// Result of file-level semantic analysis.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FileAnalysisOutput {
     pub formatted: String,
     pub semantic: SemanticAnalysis,
@@ -154,6 +155,7 @@ pub fn analyze_file(
 }
 
 /// Result of focused symbol analysis.
+#[derive(Debug)]
 pub struct FocusedAnalysisOutput {
     pub formatted: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,20 +56,19 @@ impl CodeAnalyzer {
             .mode
             .unwrap_or_else(|| analyze::determine_mode(&params.path, params.focus.as_deref()));
 
-        // Dispatch based on mode
-        let (result_text, files, functions, classes, references, import_count) = match mode {
+        // Dispatch based on mode and construct ModeResult
+        let mode_result = match mode {
             AnalysisMode::Overview => {
                 let path = Path::new(&params.path);
                 match analyze::analyze_directory(path, params.max_depth) {
-                    Ok(output) => (output.formatted, output.files, vec![], vec![], vec![], 0),
-                    Err(e) => (
-                        format!("Error analyzing directory: {}", e),
-                        vec![],
-                        vec![],
-                        vec![],
-                        vec![],
-                        0,
-                    ),
+                    Ok(output) => types::ModeResult::Overview(output),
+                    Err(e) => {
+                        let output = analyze::AnalysisOutput {
+                            formatted: format!("Error analyzing directory: {}", e),
+                            files: vec![],
+                        };
+                        types::ModeResult::Overview(output)
+                    }
                 }
             }
             AnalysisMode::FileDetails => {
@@ -106,44 +105,22 @@ impl CodeAnalyzer {
                 };
 
                 match output_result {
-                    Ok(output) => {
-                        let import_count = output.semantic.imports.len();
-                        let functions = output
-                            .semantic
-                            .functions
-                            .iter()
-                            .map(|f| types::FunctionInfo {
-                                name: f.name.clone(),
-                                line: f.line,
-                                end_line: f.end_line,
-                                parameters: f.parameters.clone(),
-                                return_type: f.return_type.clone(),
-                            })
-                            .collect();
-                        let classes = output
-                            .semantic
-                            .classes
-                            .iter()
-                            .map(|c| types::ClassInfo {
-                                name: c.name.clone(),
-                                line: c.line,
-                                end_line: c.end_line,
-                                methods: c.methods.clone(),
-                                fields: c.fields.clone(),
-                            })
-                            .collect();
-                        // references now carry accurate location + line data (set by analyze_file)
-                        let references = output.semantic.references.clone();
-                        (
-                            output.formatted.clone(),
-                            vec![],
-                            functions,
-                            classes,
-                            references,
-                            import_count,
-                        )
+                    Ok(output) => types::ModeResult::FileDetails((*output).clone()),
+                    Err(e) => {
+                        let output = analyze::FileAnalysisOutput {
+                            formatted: e,
+                            semantic: types::SemanticAnalysis {
+                                functions: vec![],
+                                classes: vec![],
+                                imports: vec![],
+                                references: vec![],
+                                call_frequency: std::collections::HashMap::new(),
+                                calls: vec![],
+                            },
+                            line_count: 0,
+                        };
+                        types::ModeResult::FileDetails(output)
                     }
-                    Err(e) => (e, vec![], vec![], vec![], vec![], 0),
                 }
             }
             AnalysisMode::SymbolFocus => {
@@ -156,16 +133,60 @@ impl CodeAnalyzer {
                     params.max_depth,
                     params.ast_recursion_limit,
                 ) {
-                    Ok(output) => (output.formatted, vec![], vec![], vec![], vec![], 0),
-                    Err(e) => (
-                        format!("Error analyzing symbol focus: {}", e),
-                        vec![],
-                        vec![],
-                        vec![],
-                        vec![],
-                        0,
-                    ),
+                    Ok(output) => types::ModeResult::SymbolFocus(output),
+                    Err(e) => {
+                        let output = analyze::FocusedAnalysisOutput {
+                            formatted: format!("Error analyzing symbol focus: {}", e),
+                        };
+                        types::ModeResult::SymbolFocus(output)
+                    }
                 }
+            }
+        };
+
+        // Extract fields from ModeResult
+        let (result_text, files, functions, classes, references, import_count) = match mode_result {
+            types::ModeResult::Overview(output) => {
+                (output.formatted, output.files, vec![], vec![], vec![], 0)
+            }
+            types::ModeResult::FileDetails(output) => {
+                let import_count = output.semantic.imports.len();
+                let functions = output
+                    .semantic
+                    .functions
+                    .iter()
+                    .map(|f| types::FunctionInfo {
+                        name: f.name.clone(),
+                        line: f.line,
+                        end_line: f.end_line,
+                        parameters: f.parameters.clone(),
+                        return_type: f.return_type.clone(),
+                    })
+                    .collect();
+                let classes = output
+                    .semantic
+                    .classes
+                    .iter()
+                    .map(|c| types::ClassInfo {
+                        name: c.name.clone(),
+                        line: c.line,
+                        end_line: c.end_line,
+                        methods: c.methods.clone(),
+                        fields: c.fields.clone(),
+                    })
+                    .collect();
+                let references = output.semantic.references.clone();
+                (
+                    output.formatted,
+                    vec![],
+                    functions,
+                    classes,
+                    references,
+                    import_count,
+                )
+            }
+            types::ModeResult::SymbolFocus(output) => {
+                (output.formatted, vec![], vec![], vec![], vec![], 0)
             }
         };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,16 @@
+use crate::analyze::{AnalysisOutput, FileAnalysisOutput, FocusedAnalysisOutput};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+/// Internal enum wrapping the three analysis output types.
+/// Not serialized; used for type-safe dispatch in lib.rs.
+#[derive(Debug)]
+pub enum ModeResult {
+    Overview(AnalysisOutput),
+    FileDetails(FileAnalysisOutput),
+    SymbolFocus(FocusedAnalysisOutput),
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeParams {


### PR DESCRIPTION
## Summary

Replace the 6-element tuple return in the `analyze` tool handler with a type-safe `ModeResult` enum. Three variants (`Overview`, `FileDetails`, `SymbolFocus`) wrap the existing output structs from `analyze.rs`.

## Changes

- **src/types.rs**: Add `ModeResult` enum with three variants (internal type, no serde/JsonSchema)
- **src/lib.rs**: Refactor match block to construct `ModeResult` variants, then extract fields via pattern matching
- **src/analyze.rs**: Add `Debug` derives to `AnalysisOutput`, `FileAnalysisOutput`, `FocusedAnalysisOutput`

## Why

Tuples are fragile: adding a field means updating every call site, and positional access obscures intent. Named enum variants are self-documenting and extensible.

## Testing

Pure refactor; no behavioral changes. All 46 existing tests pass (6 unit + 37 integration + 3 acceptance).

Closes #30