### PR TITLE
feat(mcp): add progress notifications during directory analysis

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -6,6 +6,8 @@ use crate::traversal::{WalkEntry, walk_directory};
 use crate::types::{AnalysisMode, FileInfo, SemanticAnalysis};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -36,11 +38,12 @@ pub struct FileAnalysisOutput {
     pub line_count: usize,
 }
 
-/// Analyze a directory structure and return formatted output and file data.
+/// Analyze a directory structure with progress tracking.
 #[instrument(skip_all, fields(path = %root.display()))]
-pub fn analyze_directory(
+pub fn analyze_directory_with_progress(
     root: &Path,
     max_depth: Option<u32>,
+    progress: Arc<AtomicUsize>,
 ) -> Result<AnalysisOutput, AnalyzeError> {
     // Walk the directory
     let entries = walk_directory(root, max_depth)?;
@@ -62,6 +65,7 @@ pub fn analyze_directory(
                 Ok(content) => content,
                 Err(_) => {
                     // Binary file or unreadable - exclude from output
+                    progress.fetch_add(1, Ordering::Relaxed);
                     return None;
                 }
             };
@@ -84,6 +88,8 @@ pub fn analyze_directory(
                 ("unknown".to_string(), 0, 0)
             };
 
+            progress.fetch_add(1, Ordering::Relaxed);
+
             Some(FileInfo {
                 path: path_str,
                 line_count,
@@ -101,6 +107,16 @@ pub fn analyze_directory(
         formatted,
         files: analysis_results,
     })
+}
+
+/// Analyze a directory structure and return formatted output and file data.
+#[instrument(skip_all, fields(path = %root.display()))]
+pub fn analyze_directory(
+    root: &Path,
+    max_depth: Option<u32>,
+) -> Result<AnalysisOutput, AnalyzeError> {
+    let counter = Arc::new(AtomicUsize::new(0));
+    analyze_directory_with_progress(root, max_depth, counter)
 }
 
 /// Determine analysis mode based on parameters and path.
@@ -160,14 +176,15 @@ pub struct FocusedAnalysisOutput {
     pub formatted: String,
 }
 
-/// Analyze a symbol's call graph across a directory.
+/// Analyze a symbol's call graph across a directory with progress tracking.
 #[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
-pub fn analyze_focused(
+pub fn analyze_focused_with_progress(
     root: &Path,
     focus: &str,
     follow_depth: u32,
     max_depth: Option<u32>,
     ast_recursion_limit: Option<usize>,
+    progress: Arc<AtomicUsize>,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
     // Check if path is a file (hint to use directory)
     if root.is_file() {
@@ -191,7 +208,10 @@ pub fn analyze_focused(
             // Try to read file content
             let source = match std::fs::read_to_string(&entry.path) {
                 Ok(content) => content,
-                Err(_) => return None,
+                Err(_) => {
+                    progress.fetch_add(1, Ordering::Relaxed);
+                    return None;
+                }
             };
 
             // Detect language and extract semantic information
@@ -209,9 +229,13 @@ pub fn analyze_focused(
                     for r in &mut semantic.references {
                         r.location = entry.path.display().to_string();
                     }
+                    progress.fetch_add(1, Ordering::Relaxed);
                     Some((entry.path.clone(), semantic))
                 }
-                Err(_) => None,
+                Err(_) => {
+                    progress.fetch_add(1, Ordering::Relaxed);
+                    None
+                }
             }
         })
         .collect();
@@ -223,4 +247,24 @@ pub fn analyze_focused(
     let formatted = format_focused(&graph, focus, follow_depth)?;
 
     Ok(FocusedAnalysisOutput { formatted })
+}
+
+/// Analyze a symbol's call graph across a directory.
+#[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
+pub fn analyze_focused(
+    root: &Path,
+    focus: &str,
+    follow_depth: u32,
+    max_depth: Option<u32>,
+    ast_recursion_limit: Option<usize>,
+) -> Result<FocusedAnalysisOutput, AnalyzeError> {
+    let counter = Arc::new(AtomicUsize::new(0));
+    analyze_focused_with_progress(
+        root,
+        focus,
+        follow_depth,
+        max_depth,
+        ast_recursion_limit,
+        counter,
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,24 @@ use cache::AnalysisCache;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
-    ErrorData, Implementation, InitializeResult, ProtocolVersion, ServerCapabilities,
+    ErrorData, Implementation, InitializeResult, Notification, NumberOrString,
+    ProgressNotificationParam, ProgressToken, ProtocolVersion, ServerCapabilities,
+    ServerNotification,
 };
-use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use rmcp::service::NotificationContext;
+use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 use std::path::Path;
-use tracing::instrument;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{instrument, warn};
+use traversal::walk_directory;
 use types::{AnalysisMode, AnalysisResult, AnalyzeParams};
 
 #[derive(Clone)]
 pub struct CodeAnalyzer {
     tool_router: ToolRouter<Self>,
     cache: AnalysisCache,
+    peer: Arc<Mutex<Option<Peer<RoleServer>>>>,
 }
 
 #[tool_router]
@@ -31,6 +38,31 @@ impl CodeAnalyzer {
         CodeAnalyzer {
             tool_router: Self::tool_router(),
             cache: AnalysisCache::new(100),
+            peer: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn emit_progress(
+        &self,
+        token: &ProgressToken,
+        progress: f64,
+        total: f64,
+        message: String,
+    ) {
+        let peer = self.peer.lock().await.clone();
+        if let Some(peer) = peer {
+            let notification = ServerNotification::ProgressNotification(Notification::new(
+                ProgressNotificationParam {
+                    progress_token: token.clone(),
+                    progress,
+                    total: Some(total),
+                    message: Some(message),
+                },
+            ));
+            if let Err(e) = peer.send_notification(notification).await {
+                warn!("Failed to send progress notification: {}", e);
+            }
         }
     }
 
@@ -59,11 +91,75 @@ impl CodeAnalyzer {
         let mode_result = match mode {
             AnalysisMode::Overview => {
                 let path = Path::new(&params.path);
-                match analyze::analyze_directory(path, params.max_depth) {
-                    Ok(output) => types::ModeResult::Overview(output),
-                    Err(e) => {
+                let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let counter_clone = counter.clone();
+                let path_owned = path.to_path_buf();
+                let max_depth = params.max_depth;
+
+                // Get total file count for progress reporting
+                let total_files = match walk_directory(path, max_depth) {
+                    Ok(entries) => entries.iter().filter(|e| !e.is_dir).count(),
+                    Err(_) => 0,
+                };
+
+                // Spawn blocking analysis with progress tracking
+                let handle = tokio::task::spawn_blocking(move || {
+                    analyze::analyze_directory_with_progress(&path_owned, max_depth, counter_clone)
+                });
+
+                // Poll and emit progress every 100ms
+                let token = ProgressToken(NumberOrString::String(
+                    format!(
+                        "analyze-overview-{}",
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_nanos())
+                            .unwrap_or(0)
+                    )
+                    .into(),
+                ));
+                let mut last_progress = 0usize;
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    let current = counter.load(std::sync::atomic::Ordering::Relaxed);
+                    if current != last_progress && total_files > 0 {
+                        self.emit_progress(
+                            &token,
+                            current as f64,
+                            total_files as f64,
+                            format!("Analyzing {}/{} files", current, total_files),
+                        )
+                        .await;
+                        last_progress = current;
+                    }
+                    if handle.is_finished() {
+                        break;
+                    }
+                }
+
+                // Emit final 100% progress
+                if total_files > 0 {
+                    self.emit_progress(
+                        &token,
+                        total_files as f64,
+                        total_files as f64,
+                        format!("Completed analyzing {} files", total_files),
+                    )
+                    .await;
+                }
+
+                match handle.await {
+                    Ok(Ok(output)) => types::ModeResult::Overview(output),
+                    Ok(Err(e)) => {
                         let output = analyze::AnalysisOutput {
                             formatted: format!("Error analyzing directory: {}", e),
+                            files: vec![],
+                        };
+                        types::ModeResult::Overview(output)
+                    }
+                    Err(e) => {
+                        let output = analyze::AnalysisOutput {
+                            formatted: format!("Task join error: {}", e),
                             files: vec![],
                         };
                         types::ModeResult::Overview(output)
@@ -125,17 +221,90 @@ impl CodeAnalyzer {
             AnalysisMode::SymbolFocus => {
                 let focus = params.focus.as_deref().unwrap_or("");
                 let follow_depth = params.follow_depth.unwrap_or(1);
-                match analyze::analyze_focused(
-                    Path::new(&params.path),
-                    focus,
-                    follow_depth,
-                    params.max_depth,
-                    params.ast_recursion_limit,
-                ) {
-                    Ok(output) => types::ModeResult::SymbolFocus(output),
-                    Err(e) => {
+                let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let counter_clone = counter.clone();
+                let path = Path::new(&params.path);
+                let path_owned = path.to_path_buf();
+                let max_depth = params.max_depth;
+                let focus_owned = focus.to_string();
+                let ast_recursion_limit = params.ast_recursion_limit;
+
+                // Get total file count for progress reporting
+                let total_files = match walk_directory(path, max_depth) {
+                    Ok(entries) => entries.iter().filter(|e| !e.is_dir).count(),
+                    Err(_) => 0,
+                };
+
+                // Spawn blocking analysis with progress tracking
+                let handle = tokio::task::spawn_blocking(move || {
+                    analyze::analyze_focused_with_progress(
+                        &path_owned,
+                        &focus_owned,
+                        follow_depth,
+                        max_depth,
+                        ast_recursion_limit,
+                        counter_clone,
+                    )
+                });
+
+                // Poll and emit progress every 100ms
+                let token = ProgressToken(NumberOrString::String(
+                    format!(
+                        "analyze-symbol-{}",
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_nanos())
+                            .unwrap_or(0)
+                    )
+                    .into(),
+                ));
+                let mut last_progress = 0usize;
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    let current = counter.load(std::sync::atomic::Ordering::Relaxed);
+                    if current != last_progress && total_files > 0 {
+                        self.emit_progress(
+                            &token,
+                            current as f64,
+                            total_files as f64,
+                            format!(
+                                "Analyzing {}/{} files for symbol '{}'",
+                                current, total_files, focus
+                            ),
+                        )
+                        .await;
+                        last_progress = current;
+                    }
+                    if handle.is_finished() {
+                        break;
+                    }
+                }
+
+                // Emit final 100% progress
+                if total_files > 0 {
+                    self.emit_progress(
+                        &token,
+                        total_files as f64,
+                        total_files as f64,
+                        format!(
+                            "Completed analyzing {} files for symbol '{}'",
+                            total_files, focus
+                        ),
+                    )
+                    .await;
+                }
+
+                match handle.await {
+                    Ok(Ok(output)) => types::ModeResult::SymbolFocus(output),
+                    Ok(Err(e)) => {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Error analyzing symbol focus: {}", e),
+                        };
+                        types::ModeResult::SymbolFocus(output)
+                    }
+                    Err(e) => {
+                        let output = analyze::FocusedAnalysisOutput {
+                            formatted: format!("Task join error: {}", e),
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
@@ -248,5 +417,10 @@ impl ServerHandler for CodeAnalyzer {
             },
             instructions: Some("Analyze code structure using three modes: directory overview (file tree with metrics), file details (functions/classes/imports), or symbol focus (call graphs). Provide a path and optionally specify mode and max_depth.".into()),
         }
+    }
+
+    async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
+        let mut peer_lock = self.peer.lock().await;
+        *peer_lock = Some(context.peer);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,11 +1,14 @@
 mod fixtures;
 
-use code_analyze_mcp::analyze::{analyze_directory, analyze_file, determine_mode};
+use code_analyze_mcp::analyze::{
+    analyze_directory, analyze_directory_with_progress, analyze_file, determine_mode,
+};
 use code_analyze_mcp::cache::{AnalysisCache, CacheKey};
 use code_analyze_mcp::traversal::walk_directory;
 use code_analyze_mcp::types::AnalysisMode;
 use std::fs;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -1072,4 +1075,55 @@ fn test_output_limiting_below_threshold() {
         output.formatted.contains("FILE:"),
         "Should contain FILE header"
     );
+}
+
+#[test]
+fn test_analyze_directory_with_progress_increments_counter() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Create test structure with known file count
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn lib_fn() {}").unwrap();
+    fs::write(root.join("README.md"), "# Test").unwrap();
+
+    // Analyze with progress counter
+    let counter = Arc::new(AtomicUsize::new(0));
+    let output = analyze_directory_with_progress(root, None, counter.clone()).unwrap();
+
+    // Verify counter was incremented for each file
+    let final_count = counter.load(Ordering::Relaxed);
+    assert_eq!(
+        final_count, 3,
+        "Counter should equal number of files analyzed"
+    );
+
+    // Verify analysis output is correct
+    assert!(
+        !output.formatted.is_empty(),
+        "Formatted output should not be empty"
+    );
+    assert_eq!(output.files.len(), 3, "Should have analyzed 3 files");
+}
+
+#[test]
+fn test_analyze_directory_with_progress_empty_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Analyze empty directory with progress counter
+    let counter = Arc::new(AtomicUsize::new(0));
+    let output = analyze_directory_with_progress(root, None, counter.clone()).unwrap();
+
+    // Verify counter is 0 for empty directory
+    let final_count = counter.load(Ordering::Relaxed);
+    assert_eq!(final_count, 0, "Counter should be 0 for empty directory");
+
+    // Verify analysis output is valid
+    assert!(
+        !output.formatted.is_empty(),
+        "Formatted output should not be empty"
+    );
+    assert_eq!(output.files.len(), 0, "Should have no files");
 }


### PR DESCRIPTION
## Summary

Emit MCP progress notifications during directory walks so clients can display a progress bar instead of a spinner.

Closes #43

## Changes

### Peer Handle Storage (`src/lib.rs`)
- Add `peer` field to `CodeAnalyzer` as `Arc<tokio::sync::Mutex<Option<Peer<RoleServer>>>>`
- Implement `on_initialized` on `ServerHandler` to capture and store the peer handle
- Add `emit_progress` helper that constructs `ProgressNotification` and sends via peer

### Progress Counter (`src/analyze.rs`)
- Add `analyze_directory_with_progress` variant accepting `Arc<AtomicUsize>` counter
- Add `analyze_focused_with_progress` variant with same pattern
- Original functions delegate to new variants with a fresh counter (backward compatible)
- Rayon workers increment the counter after processing each file

### Async Polling (`src/lib.rs`)
- Overview and SymbolFocus modes wrap analysis in `tokio::task::spawn_blocking`
- Async polling loop checks counter every 100ms and emits progress notifications
- Only emits when counter changes (avoids spam)
- Final 100% progress emitted on completion

### Error Handling
- None peer handled gracefully (progress silently skipped before initialization)
- Notification errors logged with `warn!`, never propagated
- No `unwrap()` or `expect()` on notification results

## Testing

- 2 new integration tests verify counter increments correctly
- Happy path: directory with 3 Rust files, counter reaches 3
- Edge case: empty directory, counter stays at 0
- All 39 tests pass (0 failed)

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo deny check advisories licenses`: clean
- Security scan: no findings