### PR TITLE
feat(mcp): cooperative cancellation for long-running analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tree-sitter-java = "0.23.5"
 tree-sitter-ruby = "0.23.1"
 tree-sitter-typescript = "0.23.2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 async-trait = "0.1"
 rayon = "1"
 ignore = "0.4"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 #[derive(Debug, Error)]
@@ -21,6 +22,8 @@ pub enum AnalyzeError {
     Graph(#[from] crate::graph::GraphError),
     #[error("Formatter error: {0}")]
     Formatter(#[from] crate::formatter::FormatterError),
+    #[error("Analysis cancelled")]
+    Cancelled,
 }
 
 /// Result of directory analysis containing both formatted output and file data.
@@ -44,7 +47,13 @@ pub fn analyze_directory_with_progress(
     root: &Path,
     max_depth: Option<u32>,
     progress: Arc<AtomicUsize>,
+    ct: CancellationToken,
 ) -> Result<AnalysisOutput, AnalyzeError> {
+    // Check if already cancelled
+    if ct.is_cancelled() {
+        return Err(AnalyzeError::Cancelled);
+    }
+
     // Walk the directory
     let entries = walk_directory(root, max_depth)?;
 
@@ -55,6 +64,11 @@ pub fn analyze_directory_with_progress(
     let analysis_results: Vec<FileInfo> = file_entries
         .par_iter()
         .filter_map(|entry| {
+            // Check cancellation per file
+            if ct.is_cancelled() {
+                return None;
+            }
+
             let path_str = entry.path.display().to_string();
 
             // Detect language from extension
@@ -100,6 +114,11 @@ pub fn analyze_directory_with_progress(
         })
         .collect();
 
+    // Check if cancelled after parallel processing
+    if ct.is_cancelled() {
+        return Err(AnalyzeError::Cancelled);
+    }
+
     // Format output
     let formatted = format_structure(&entries, &analysis_results, max_depth);
 
@@ -116,7 +135,8 @@ pub fn analyze_directory(
     max_depth: Option<u32>,
 ) -> Result<AnalysisOutput, AnalyzeError> {
     let counter = Arc::new(AtomicUsize::new(0));
-    analyze_directory_with_progress(root, max_depth, counter)
+    let ct = CancellationToken::new();
+    analyze_directory_with_progress(root, max_depth, counter, ct)
 }
 
 /// Determine analysis mode based on parameters and path.
@@ -185,7 +205,13 @@ pub fn analyze_focused_with_progress(
     max_depth: Option<u32>,
     ast_recursion_limit: Option<usize>,
     progress: Arc<AtomicUsize>,
+    ct: CancellationToken,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
+    // Check if already cancelled
+    if ct.is_cancelled() {
+        return Err(AnalyzeError::Cancelled);
+    }
+
     // Check if path is a file (hint to use directory)
     if root.is_file() {
         let formatted =
@@ -203,6 +229,11 @@ pub fn analyze_focused_with_progress(
     let analysis_results: Vec<(PathBuf, SemanticAnalysis)> = file_entries
         .par_iter()
         .filter_map(|entry| {
+            // Check cancellation per file
+            if ct.is_cancelled() {
+                return None;
+            }
+
             let ext = entry.path.extension().and_then(|e| e.to_str());
 
             // Try to read file content
@@ -240,6 +271,11 @@ pub fn analyze_focused_with_progress(
         })
         .collect();
 
+    // Check if cancelled after parallel processing
+    if ct.is_cancelled() {
+        return Err(AnalyzeError::Cancelled);
+    }
+
     // Build call graph
     let graph = CallGraph::build_from_results(analysis_results)?;
 
@@ -259,6 +295,7 @@ pub fn analyze_focused(
     ast_recursion_limit: Option<usize>,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
     let counter = Arc::new(AtomicUsize::new(0));
+    let ct = CancellationToken::new();
     analyze_focused_with_progress(
         root,
         focus,
@@ -266,5 +303,6 @@ pub fn analyze_focused(
         max_depth,
         ast_recursion_limit,
         counter,
+        ct,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,10 @@ use cache::AnalysisCache;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
-    CompleteRequestParams, CompleteResult, CompletionInfo, ErrorData, Implementation,
-    InitializeResult, LoggingLevel, Notification, NumberOrString, ProgressNotificationParam,
-    ProgressToken, ProtocolVersion, ServerCapabilities, ServerNotification, SetLevelRequestParams,
+    CancelledNotificationParam, CompleteRequestParams, CompleteResult, CompletionInfo, ErrorData,
+    Implementation, InitializeResult, LoggingLevel, Notification, NumberOrString,
+    ProgressNotificationParam, ProgressToken, ProtocolVersion, ServerCapabilities,
+    ServerNotification, SetLevelRequestParams,
 };
 use rmcp::service::{NotificationContext, RequestContext};
 use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -74,7 +75,7 @@ impl CodeAnalyzer {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, context))]
     #[tool(
         description = "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.",
         annotations(
@@ -87,8 +88,10 @@ impl CodeAnalyzer {
     async fn analyze(
         &self,
         params: Parameters<AnalyzeParams>,
+        context: RequestContext<RoleServer>,
     ) -> Result<Json<AnalysisResult>, ErrorData> {
         let params = params.0;
+        let ct = context.ct.clone();
 
         // Determine mode if not provided
         let mode = params
@@ -103,6 +106,7 @@ impl CodeAnalyzer {
                 let counter_clone = counter.clone();
                 let path_owned = path.to_path_buf();
                 let max_depth = params.max_depth;
+                let ct_clone = ct.clone();
 
                 // Get total file count for progress reporting
                 let total_files = match walk_directory(path, max_depth) {
@@ -112,7 +116,12 @@ impl CodeAnalyzer {
 
                 // Spawn blocking analysis with progress tracking
                 let handle = tokio::task::spawn_blocking(move || {
-                    analyze::analyze_directory_with_progress(&path_owned, max_depth, counter_clone)
+                    analyze::analyze_directory_with_progress(
+                        &path_owned,
+                        max_depth,
+                        counter_clone,
+                        ct_clone,
+                    )
                 });
 
                 // Poll and emit progress every 100ms
@@ -127,8 +136,13 @@ impl CodeAnalyzer {
                     .into(),
                 ));
                 let mut last_progress = 0usize;
+                let mut cancelled = false;
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    if ct.is_cancelled() {
+                        cancelled = true;
+                        break;
+                    }
                     let current = counter.load(std::sync::atomic::Ordering::Relaxed);
                     if current != last_progress && total_files > 0 {
                         self.emit_progress(
@@ -145,8 +159,8 @@ impl CodeAnalyzer {
                     }
                 }
 
-                // Emit final 100% progress
-                if total_files > 0 {
+                // Emit final 100% progress only if not cancelled
+                if !cancelled && total_files > 0 {
                     self.emit_progress(
                         &token,
                         total_files as f64,
@@ -158,6 +172,13 @@ impl CodeAnalyzer {
 
                 match handle.await {
                     Ok(Ok(output)) => types::ModeResult::Overview(output),
+                    Ok(Err(analyze::AnalyzeError::Cancelled)) => {
+                        let output = analyze::AnalysisOutput {
+                            formatted: "Analysis cancelled".to_string(),
+                            files: vec![],
+                        };
+                        types::ModeResult::Overview(output)
+                    }
                     Ok(Err(e)) => {
                         let output = analyze::AnalysisOutput {
                             formatted: format!("Error analyzing directory: {}", e),
@@ -236,6 +257,7 @@ impl CodeAnalyzer {
                 let max_depth = params.max_depth;
                 let focus_owned = focus.to_string();
                 let ast_recursion_limit = params.ast_recursion_limit;
+                let ct_clone = ct.clone();
 
                 // Get total file count for progress reporting
                 let total_files = match walk_directory(path, max_depth) {
@@ -252,6 +274,7 @@ impl CodeAnalyzer {
                         max_depth,
                         ast_recursion_limit,
                         counter_clone,
+                        ct_clone,
                     )
                 });
 
@@ -267,8 +290,13 @@ impl CodeAnalyzer {
                     .into(),
                 ));
                 let mut last_progress = 0usize;
+                let mut cancelled = false;
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    if ct.is_cancelled() {
+                        cancelled = true;
+                        break;
+                    }
                     let current = counter.load(std::sync::atomic::Ordering::Relaxed);
                     if current != last_progress && total_files > 0 {
                         self.emit_progress(
@@ -288,8 +316,8 @@ impl CodeAnalyzer {
                     }
                 }
 
-                // Emit final 100% progress
-                if total_files > 0 {
+                // Emit final 100% progress only if not cancelled
+                if !cancelled && total_files > 0 {
                     self.emit_progress(
                         &token,
                         total_files as f64,
@@ -304,6 +332,12 @@ impl CodeAnalyzer {
 
                 match handle.await {
                     Ok(Ok(output)) => types::ModeResult::SymbolFocus(output),
+                    Ok(Err(analyze::AnalyzeError::Cancelled)) => {
+                        let output = analyze::FocusedAnalysisOutput {
+                            formatted: "Analysis cancelled".to_string(),
+                        };
+                        types::ModeResult::SymbolFocus(output)
+                    }
                     Ok(Err(e)) => {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Error analyzing symbol focus: {}", e),
@@ -428,6 +462,19 @@ impl ServerHandler for CodeAnalyzer {
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
         let mut peer_lock = self.peer.lock().await;
         *peer_lock = Some(context.peer);
+    }
+
+    #[instrument(skip(self, _context))]
+    async fn on_cancelled(
+        &self,
+        notification: CancelledNotificationParam,
+        _context: NotificationContext<RoleServer>,
+    ) {
+        tracing::info!(
+            request_id = ?notification.request_id,
+            reason = ?notification.reason,
+            "Received cancellation notification"
+        );
     }
 
     #[instrument(skip(self, _context))]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 mod fixtures;
 
 use code_analyze_mcp::analyze::{
-    analyze_directory, analyze_directory_with_progress, analyze_file, determine_mode,
+    AnalyzeError, analyze_directory, analyze_directory_with_progress, analyze_file, determine_mode,
 };
 use code_analyze_mcp::cache::{AnalysisCache, CacheKey};
 use code_analyze_mcp::completion::{path_completions, symbol_completions};
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
 
 #[test]
 fn test_walk_directory_basic() {
@@ -1091,7 +1092,8 @@ fn test_analyze_directory_with_progress_increments_counter() {
 
     // Analyze with progress counter
     let counter = Arc::new(AtomicUsize::new(0));
-    let output = analyze_directory_with_progress(root, None, counter.clone()).unwrap();
+    let ct = CancellationToken::new();
+    let output = analyze_directory_with_progress(root, None, counter.clone(), ct).unwrap();
 
     // Verify counter was incremented for each file
     let final_count = counter.load(Ordering::Relaxed);
@@ -1115,7 +1117,8 @@ fn test_analyze_directory_with_progress_empty_directory() {
 
     // Analyze empty directory with progress counter
     let counter = Arc::new(AtomicUsize::new(0));
-    let output = analyze_directory_with_progress(root, None, counter.clone()).unwrap();
+    let ct = CancellationToken::new();
+    let output = analyze_directory_with_progress(root, None, counter.clone(), ct).unwrap();
 
     // Verify counter is 0 for empty directory
     let final_count = counter.load(Ordering::Relaxed);
@@ -1401,4 +1404,45 @@ fn test_logging_level_filter_update() {
             assert_eq!(*filter, LevelFilter::ERROR);
         }
     });
+}
+
+// Cancellation tests
+
+#[test]
+fn test_cancellation_during_directory_walk() {
+    // Arrange: Create temp dir with a Rust file
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+
+    // Create a pre-cancelled token
+    let ct = CancellationToken::new();
+    ct.cancel();
+
+    // Act: Call analyze_directory_with_progress with cancelled token
+    let counter = Arc::new(AtomicUsize::new(0));
+    let result = analyze_directory_with_progress(root, None, counter, ct);
+
+    // Assert: Should return Cancelled error
+    assert!(matches!(result, Err(AnalyzeError::Cancelled)));
+}
+
+#[test]
+fn test_cancellation_noop_after_completion() {
+    // Arrange: Create temp dir with a Rust file
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    fs::write(root.join("main.rs"), "fn main() {}").unwrap();
+
+    // Create a non-cancelled token
+    let ct = CancellationToken::new();
+
+    // Act: Call analyze_directory_with_progress with active token
+    let counter = Arc::new(AtomicUsize::new(0));
+    let result = analyze_directory_with_progress(root, None, counter, ct);
+
+    // Assert: Should succeed (existing behavior unchanged)
+    assert!(result.is_ok());
+    let output = result.unwrap();
+    assert_eq!(output.files.len(), 1);
 }


### PR DESCRIPTION
## Summary

Implement MCP cancellation support so clients can abort long-running directory analysis mid-flight via `notifications/cancelled`.

Closes #48

## Changes

### `src/analyze.rs`
- Add `AnalyzeError::Cancelled` variant for clean error propagation
- Add `CancellationToken` parameter to `analyze_directory_with_progress` and `analyze_focused_with_progress`
- Check `is_cancelled()` at three points: start of analysis, per-file in rayon `par_iter` closure, and after parallel processing
- Update wrapper functions (`analyze_directory`, `analyze_focused`) to pass `CancellationToken::new()`

### `src/lib.rs`
- Extract `CancellationToken` from `RequestContext<RoleServer>` in the `analyze` tool handler
- Pass token to `spawn_blocking` closures for Overview and SymbolFocus modes
- Break progress polling loops early on cancellation; skip final progress emission
- Handle `AnalyzeError::Cancelled` in match arms with descriptive error message
- Override `on_cancelled` handler with `tracing::info!` for observability

### `Cargo.toml`
- Add explicit `tokio-util` dependency (was transitive via rmcp)

### `tests/integration_tests.rs`
- `test_cancellation_during_directory_walk`: pre-cancelled token returns `AnalyzeError::Cancelled`
- `test_cancellation_noop_after_completion`: non-cancelled token succeeds (existing behavior unchanged)
- Update existing progress tests to pass `CancellationToken::new()`

## Design Decisions

- **Direct token passing** over request tracking map (DashMap): rmcp 0.17 automatically cancels the `CancellationToken` when clients send `notifications/cancelled` (verified in rmcp service.rs lines 874-879). No manual request tracking needed.
- **Per-file granularity** for cancellation checks in rayon closures: balances responsiveness with overhead.
- **Cooperative cancellation**: rayon does not support forced cancellation; the token is checked at strategic points and remaining work is skipped.

## Testing

```
cargo test       # 52 passed, 0 failed
cargo clippy     # clean
cargo fmt        # clean
cargo deny       # clean
```