### PR TITLE
test(bench): add criterion benchmark suite for analysis modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,10 +132,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "code-analyze-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "criterion",
  "ignore",
  "lru",
  "rayon",
@@ -150,6 +221,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +280,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -375,6 +488,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +523,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -462,6 +592,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -579,6 +729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +768,34 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "prettyplease"
@@ -994,6 +1178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1777,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ tree-sitter-swift = "0.7.1"
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "analysis"
+harness = false
 
 [profile.release]
 opt-level = 3

--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -1,0 +1,78 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use tokio_util::sync::CancellationToken;
+
+fn overview_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("overview");
+    group.sample_size(10);
+
+    group.bench_function("analyze_directory_src", |b| {
+        b.iter(|| {
+            let path = black_box(Path::new("src"));
+            let max_depth = black_box(None);
+            let progress = Arc::new(AtomicUsize::new(0));
+            let ct = CancellationToken::new();
+
+            code_analyze_mcp::analyze::analyze_directory_with_progress(
+                path, max_depth, progress, ct,
+            )
+        });
+    });
+
+    group.finish();
+}
+
+fn file_details_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("file_details");
+    group.sample_size(10);
+
+    group.bench_function("analyze_file_parser_rs", |b| {
+        b.iter(|| {
+            let path = black_box("src/parser.rs");
+            let ast_recursion_limit = black_box(None);
+
+            code_analyze_mcp::analyze::analyze_file(path, ast_recursion_limit)
+        });
+    });
+
+    group.finish();
+}
+
+fn symbol_focus_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("symbol_focus");
+    group.sample_size(10);
+
+    group.bench_function("analyze_focused_src", |b| {
+        b.iter(|| {
+            let path = black_box(Path::new("src"));
+            let focus = black_box("analyze_directory");
+            let follow_depth = black_box(2);
+            let max_depth = black_box(None);
+            let ast_recursion_limit = black_box(None);
+            let progress = Arc::new(AtomicUsize::new(0));
+            let ct = CancellationToken::new();
+
+            code_analyze_mcp::analyze::analyze_focused_with_progress(
+                path,
+                focus,
+                follow_depth,
+                max_depth,
+                ast_recursion_limit,
+                progress,
+                ct,
+            )
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    overview_benchmark,
+    file_details_benchmark,
+    symbol_focus_benchmark
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add criterion benchmark suite measuring wall-clock time for Overview, FileDetails, and SymbolFocus analysis modes against the project's own `src/` directory. Establishes baseline measurements for future optimization work in Wave 4.

No app code changes. Benchmarks only.

## Benchmark Groups

| Group | Function | Input | Description |
|---|---|---|---|
| overview | `analyze_directory_with_progress` | `src/` (~20 files) | Directory analysis with element extraction |
| file_details | `analyze_file` | `src/parser.rs` (469 LOC) | Single-file semantic extraction |
| symbol_focus | `analyze_focused_with_progress` | `src/` + `analyze_directory` | Cross-file call graph, follow_depth=2 |

## Baseline Results (M-series Mac, sample_size=10)

| Mode | Time |
|---|---|
| Overview | ~9.0-9.4 ms |
| FileDetails | ~12.7-13.2 ms |
| SymbolFocus | ~34.8-36.6 ms |

All modes are well within the target latency defined in issue #7. Future optimization PRs (query caching, cache metrics instrumentation) will use these baselines for before/after comparison.

## Changes

- `Cargo.toml`: Added `criterion` dev-dependency with `html_reports` feature; added `[[bench]]` target
- `benches/analysis.rs`: Criterion benchmark suite with three groups

## Testing

- `cargo test`: 52 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo bench --bench analysis`: all three benchmarks execute with timing data

## Usage

```bash
# Run all benchmarks
cargo bench --bench analysis

# Run a specific group
cargo bench --bench analysis -- overview
cargo bench --bench analysis -- file_details
cargo bench --bench analysis -- symbol_focus
```

HTML reports are generated in `target/criterion/`.

Closes #7