### PR TITLE
chore: align release profile with aptu for performance and size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,13 @@ name = "analysis"
 harness = false
 
 [profile.release]
-opt-level = 3
+opt-level = "z"
 lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.ci]
+inherits = "release"
+lto = false
+codegen-units = 16


### PR DESCRIPTION
## Summary

Align release profile settings with aptu (tested and validated for performance + size):

| Setting | Before | After |
|---|---|---|
| `opt-level` | `3` | `"z"` |
| `codegen-units` | 16 (default) | `1` |
| `panic` | `"unwind"` (default) | `"abort"` |
| `strip` | `false` (default) | `true` |

Binary size reduced **~15%** (19.4 MB to 16.5 MB).

`opt-level = "z"` was faster than `"3"` in aptu benchmarks, likely due to better instruction cache utilization. For a tool that does bounded tree-sitter work rather than heavy compute loops, smaller code wins on both size and speed.

Also adds `[profile.ci]` that inherits from release but disables LTO and uses 16 codegen units for faster CI builds.

## Testing

- `cargo build --release` succeeds
- Binary size verified: 16.5 MB (down from 19.4 MB)

Refs: #60