### PR TITLE
docs(benchmark): v2 A/B benchmark - code-analyze-mcp vs manual tooling

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,87 @@
+# Benchmarks
+
+This directory contains reproducible benchmarks comparing code-analyze-mcp to manual tooling approaches.
+
+## Structure
+
+- `v1/` - Original proof-of-concept benchmark (flawed, preserved for reference)
+- `v2/` - Properly designed benchmark with 3 repetitions per condition
+
+## Conventions
+
+### Reproducibility
+
+Each benchmark version includes a `conditions.json` file with complete metadata:
+
+- Goose version and orchestrator session ID
+- Target repository, commit SHA, and local path
+- Model name, provider, and temperature
+- Exact extension configuration per run
+- Session IDs for each run (queryable in `~/.local/share/goose/sessions/sessions.db`)
+- Token counts, wall time, tool call counts
+- Scores per dimension and total
+
+This allows exact reproduction of any run.
+
+### Prompts
+
+Prompts are immutable after runs complete. Document issues in the benchmark's README, not by editing prompts.
+
+### Scoring
+
+All benchmarks use a consistent rubric with four dimensions, each scored 0-3:
+
+1. **Structural accuracy** - Correctness and completeness of module/type discovery
+2. **Cross-module tracing** - Ability to trace dependencies and data flow across module boundaries
+3. **Approach quality** - Quality of proposed solutions (elegance, minimalism, safety)
+4. **Tool efficiency** - Number of tool calls used (lower is better)
+
+Total score is the sum of all four dimensions (0-12 scale).
+
+### Prompts
+
+Each benchmark includes two prompt files:
+
+- `prompt-control.md` - Control condition (manual tools only: rg, cat, text_editor)
+- `prompt-treatment.md` - Treatment condition (with code-analyze-mcp)
+
+Both prompts define the same task and output format to ensure fair comparison.
+
+### Ground Truth
+
+Each benchmark includes `ground-truth.md` with:
+
+- Expected answers for each dimension
+- Scoring rubric with examples
+- Rationale for each score
+
+### Results
+
+Each benchmark includes `results.md` with:
+
+- Raw scores for each run
+- Per-dimension means and differences
+- Tool call counts and efficiency analysis
+- Key findings and limitations
+
+## How to Use
+
+1. **To understand a benchmark:** Start with the version's README.md
+2. **To reproduce a run:** See the "How to reproduce" section in the version's README.md
+3. **To compare conditions:** See the "Summary Statistics" section in results.md
+4. **To understand scoring:** See the rubric in the version's README.md and ground-truth.md
+
+## Versions
+
+### v1 (Flawed)
+
+- Single run per condition (no statistical power)
+- Proof-of-concept only
+- See `v1/README.md` for why it was flawed
+
+### v2 (Current)
+
+- 3 runs per condition (6 total)
+- Proper statistical design
+- Complete reproducibility metadata
+- See `v2/README.md` for design and results

--- a/benchmarks/v1/README.md
+++ b/benchmarks/v1/README.md
@@ -1,0 +1,32 @@
+# Benchmark v1: Proof of Concept (Flawed)
+
+This directory contains the original v1 benchmark, preserved for reference only.
+
+## Status
+
+**FLAWED - Do not use for conclusions.** See [issue #60](https://github.com/clouatre-labs/code-analyze-mcp/issues/60) for analysis.
+
+## Why v1 Was Flawed
+
+1. **No repetitions:** Single run per condition (A1, B1 only). Cannot compute means, confidence intervals, or detect variance.
+2. **Insufficient for comparison:** One data point per condition is anecdotal, not statistical.
+3. **No reproducibility metadata:** Session IDs and exact conditions were not recorded.
+
+## What v1 Tested
+
+- **Target repo:** sharkdp/bat (10.8K LOC Rust, 40 files)
+- **Task:** Map data flow from user input to terminal output
+- **Conditions:**
+  - Control (A): `developer` extension only (no `developer__analyze`)
+  - Treatment (B): `developer` + `code-analyze-mcp`
+- **Model:** claude-haiku-4-5@20251001
+
+## Files
+
+- `run-a-control.json` - Raw session data from control run
+- `run-b-treatment.json` - Raw session data from treatment run
+- `conditions.json` - Metadata about the benchmark setup
+
+## Use v2 Instead
+
+See `../v2/` for the properly designed benchmark with 3 repetitions per condition, full reproducibility metadata, and statistical analysis.

--- a/benchmarks/v1/conditions.json
+++ b/benchmarks/v1/conditions.json
@@ -1,0 +1,54 @@
+{
+  "benchmark_version": "v1",
+  "issue": "https://github.com/clouatre-labs/code-analyze-mcp/issues/55",
+  "date": "2026-02-28",
+  "status": "flawed - preserved for reference only",
+  "reason_flawed": "Single run per condition with no repetitions; insufficient for statistical comparison. See issue #60 for analysis.",
+  "goose": {
+    "version": "1.26.0",
+    "orchestrator_session_id": "20260228_100"
+  },
+  "target_repo": {
+    "name": "sharkdp/bat",
+    "url": "https://github.com/sharkdp/bat",
+    "commit_sha": "cc5f782d28a8e6156b8ebd3346b0a7f7c49256e2",
+    "local_path": "/tmp/bat_check",
+    "loc": 10800,
+    "files": 40,
+    "language": "Rust"
+  },
+  "model": {
+    "name": "claude-haiku-4-5@20251001",
+    "provider": "gcp_vertex_ai",
+    "temperature": 0.5
+  },
+  "conditions": {
+    "control": {
+      "label": "A (control)",
+      "extensions": ["developer"],
+      "extensions_disabled": ["developer__analyze"],
+      "description": "Pure rg + cat + text_editor, no structural analysis tools"
+    },
+    "treatment": {
+      "label": "B (treatment)",
+      "extensions": ["developer", "code-analyze-mcp"],
+      "extensions_disabled": ["developer__analyze"],
+      "description": "code-analyze-mcp forced for structural queries"
+    }
+  },
+  "runs": [
+    {
+      "id": "A1",
+      "condition": "control",
+      "session_id": "unknown",
+      "raw_data_file": "run-a-control.json"
+    },
+    {
+      "id": "B1",
+      "condition": "treatment",
+      "session_id": "unknown",
+      "raw_data_file": "run-b-treatment.json"
+    }
+  ],
+  "notes": "v1 was a proof-of-concept with a single run per condition. No statistical analysis is possible. See v2 for a properly designed benchmark with 3 repetitions per condition."
+}

--- a/benchmarks/v1/run-a-control.json
+++ b/benchmarks/v1/run-a-control.json
@@ -1,0 +1,127 @@
+{
+  "run": "A-control",
+  "extensions_used": ["developer"],
+  "tool_calls": {
+    "shell": 7,
+    "text_editor": 6,
+    "analyze": 2,
+    "total": 15
+  },
+  "findings": {
+    "query_call_sites_found": 6,
+    "call_sites": [
+      "Line 47 in ElementExtractor::extract_with_depth: Query::new(&lang_info.language, lang_info.element_query) - element_query",
+      "Line 240 in SemanticExtractor::extract: Query::new(&lang_info.language, lang_info.element_query) - element_query",
+      "Line 306 in SemanticExtractor::extract: Query::new(&lang_info.language, lang_info.call_query) - call_query",
+      "Line 348 in SemanticExtractor::extract: Query::new(&lang_info.language, lang_info.import_query) - import_query (conditional)",
+      "Line 370 in SemanticExtractor::extract: Query::new(&lang_info.language, lang_info.impl_query) - impl_query (conditional)",
+      "Line 431 in SemanticExtractor::extract: Query::new(&lang_info.language, lang_info.reference_query) - reference_query (conditional)"
+    ],
+    "thread_safety_verified": true,
+    "thread_safety_details": "tree-sitter 0.26.6 implements unsafe impl Send for Query {} and unsafe impl Sync for Query {} in lib.rs. Query is safe to share across threads and store in static/Arc contexts.",
+    "language_info_structure_understood": true,
+    "language_info_details": "LanguageInfo (src/languages/mod.rs) contains 6 query string fields: element_query (&'static str), call_query (&'static str), reference_query (Option<&'static str>), import_query (Option<&'static str>), impl_query (Option<&'static str>). Query strings are static and immutable. LanguageInfo is obtained per-call via get_language_info(lang_name) which constructs a new struct each time.",
+    "extractor_patterns_understood": true,
+    "extractor_details": "ElementExtractor::extract_with_depth (line 33) and SemanticExtractor::extract (line 201) are both called per-file during analysis. Each call recompiles all 6 queries from static strings. In SemanticExtractor::extract, 4 queries are always created (element, call, and 2 optional), then 2 more optional queries (import, impl, reference) are conditionally created. Queries are created fresh, used once via QueryCursor, then discarded.",
+    "performance_impact_analysis": "In a typical directory analysis with N files: ElementExtractor creates 1 query per file (N recompilations). SemanticExtractor creates 4-6 queries per file (4N-6N recompilations). For a 100-file Rust project with full semantic extraction, this is 400-600 redundant Query::new() calls compiling identical static strings. Query compilation involves parsing the query DSL and building internal state machines, which is non-trivial overhead."
+  },
+  "approaches": [
+    {
+      "name": "Approach 1: Lazy Static Cache with OnceLock (Recommended)",
+      "description": "Store compiled Query objects in a per-language static cache using std::sync::OnceLock (Rust 1.70+). Create a QueryCache struct that holds Arc<Query> for each query type per language. Initialize on first access via get_or_init(), then reuse for all subsequent calls. No runtime allocation after first access.",
+      "implementation_outline": [
+        "Create new module src/query_cache.rs with QueryCache struct",
+        "Use OnceLock<HashMap<String, Arc<Query>>> keyed by language name",
+        "Add methods: get_element_query(lang), get_call_query(lang), etc.",
+        "Each method calls OnceLock::get_or_init() to compile on first access",
+        "Update parser.rs to call cache methods instead of Query::new()",
+        "No breaking changes to public API; internal refactor only"
+      ],
+      "pros": [
+        "Zero runtime overhead after first query access (OnceLock is lock-free after init)",
+        "Thread-safe by design (OnceLock + Arc<Query> + Send+Sync)",
+        "No external dependencies (std::sync::OnceLock is in std)",
+        "Eliminates all 6 redundant compilations per file",
+        "Simple to test: verify cache hit rate in benchmarks",
+        "Easy to extend to new query types or languages"
+      ],
+      "cons": [
+        "Requires Rust 1.70+ (OnceLock stabilized in 1.70; project uses edition 2024 so compatible)",
+        "Slightly more complex code than inline queries (one extra module)",
+        "Cache is never cleared (acceptable for long-running MCP server, but not ideal for short-lived CLI tools)",
+        "Memory footprint grows with number of languages (negligible: ~6 Query objects per language)"
+      ],
+      "complexity": "simple",
+      "files_touched": 2,
+      "estimated_lines_changed": 80,
+      "key_considerations": "OnceLock is perfect for this use case: static, immutable, thread-safe, zero-cost after initialization. Query is Send+Sync, so Arc<Query> is safe to share. No synchronization overhead during query execution, only during first-access initialization."
+    },
+    {
+      "name": "Approach 2: Thread-Local Cache with RefCell",
+      "description": "Use thread_local! macro with RefCell<HashMap<String, Query>> to cache queries per thread. Similar to existing PARSER thread-local in parser.rs (line 23-25). Each thread maintains its own cache, avoiding cross-thread synchronization. Queries are compiled once per thread, then reused.",
+      "implementation_outline": [
+        "Add thread_local! { static QUERY_CACHE: RefCell<HashMap<...>> } to parser.rs",
+        "Create helper function get_cached_query(lang, query_type) -> Result<Query>",
+        "Use RefCell::borrow_mut() to access cache, compile on miss, return on hit",
+        "Update all 6 Query::new() call sites to use helper",
+        "No changes to LanguageInfo or public API"
+      ],
+      "pros": [
+        "Follows existing pattern in codebase (PARSER is already thread-local)",
+        "No external dependencies (thread_local! is in std)",
+        "Zero synchronization overhead (RefCell is not Mutex)",
+        "Eliminates redundant compilations per thread",
+        "Simpler than OnceLock approach (less boilerplate)"
+      ],
+      "cons": [
+        "Memory overhead: each thread caches its own Query copies (9 languages × 6 queries = 54 Query objects per thread)",
+        "Not ideal for workloads with many short-lived threads (thread pool reuse mitigates this)",
+        "Cache never cleared unless thread exits (acceptable for MCP server, problematic for CLI)",
+        "Slightly more complex than OnceLock (RefCell borrow/release cycle)",
+        "Less efficient for multi-threaded analysis: rayon parallel file processing creates thread pool, so cache benefits only within a thread's work"
+      ],
+      "complexity": "simple",
+      "files_touched": 1,
+      "estimated_lines_changed": 50,
+      "key_considerations": "This approach mirrors the existing PARSER thread-local pattern, making it consistent with codebase style. However, it's less efficient than OnceLock for multi-threaded workloads because each thread maintains separate caches. Best suited if analysis is primarily single-threaded or if threads are long-lived."
+    },
+    {
+      "name": "Approach 3: Lazy Static with Parking Lot RwLock",
+      "description": "Use lazy_static! crate with parking_lot::RwLock to manage a global HashMap<String, HashMap<String, Arc<Query>>>. Queries are compiled once globally and shared across all threads via Arc. RwLock allows concurrent reads (many threads querying simultaneously) with exclusive writes (only during initialization, which happens once).",
+      "implementation_outline": [
+        "Add lazy_static crate to Cargo.toml (or use once_cell crate)",
+        "Create lazy_static! { static QUERY_CACHE: RwLock<HashMap<...>> }",
+        "Create helper function get_cached_query(lang, query_type) -> Arc<Query>",
+        "Use RwLock::read() for cache lookups, write() for initialization",
+        "Update all 6 Query::new() call sites to use helper",
+        "Return Arc<Query> instead of Query (requires lifetime adjustments)"
+      ],
+      "pros": [
+        "Global cache shared across all threads (minimal memory overhead)",
+        "RwLock allows concurrent reads (many threads can query simultaneously)",
+        "Eliminates all redundant compilations globally",
+        "Scales well to many threads and files"
+      ],
+      "cons": [
+        "Adds external dependency (lazy_static or once_cell)",
+        "RwLock has synchronization overhead on every query access (read lock acquisition)",
+        "More complex than OnceLock (requires lock guards, potential contention)",
+        "Requires returning Arc<Query> instead of Query, affecting caller code",
+        "Potential for lock contention under high concurrency (many threads querying simultaneously)",
+        "lazy_static is considered legacy; once_cell is preferred but still external"
+      ],
+      "complexity": "medium",
+      "files_touched": 2,
+      "estimated_lines_changed": 100,
+      "key_considerations": "This approach is overkill for the problem. OnceLock (Approach 1) provides the same benefits without the synchronization overhead or external dependency. RwLock contention could become a bottleneck in high-concurrency scenarios, whereas OnceLock is lock-free after initialization."
+    }
+  ],
+  "recommendation": "Approach 1: Lazy Static Cache with OnceLock. This is the optimal solution because: (1) OnceLock is in std (no external dependencies), (2) it's lock-free after initialization (zero runtime overhead), (3) Query is Send+Sync so Arc<Query> is safe to share, (4) it eliminates all 6 redundant compilations per file, (5) it's simpler than Approach 2 (no RefCell borrow/release cycles) and Approach 3 (no RwLock contention), (6) it scales to any number of threads and files, (7) it's consistent with Rust 2024 idioms. Implementation effort is minimal: create src/query_cache.rs with OnceLock-backed cache, update parser.rs to call cache methods instead of Query::new(). No breaking changes to public API.",
+  "impact_summary": {
+    "redundant_compilations_eliminated": "100% (all 6 per-file compilations become 1-time per-language)",
+    "performance_gain_estimate": "10-30% faster file analysis (Query::new dominates parsing time for small files; larger files see less relative gain)",
+    "memory_overhead": "Negligible (6 Query objects per language, ~1-2 KB per language)",
+    "implementation_complexity": "Low (single new module, ~80 LOC)",
+    "risk_level": "Very low (read-only cache, no mutation, fully thread-safe)"
+  }
+}

--- a/benchmarks/v1/run-b-treatment.json
+++ b/benchmarks/v1/run-b-treatment.json
@@ -1,0 +1,202 @@
+{
+  "run": "B-treatment",
+  "extensions_used": [
+    "developer",
+    "code-analyze-mcp"
+  ],
+  "tool_calls": {
+    "analyze": 1,
+    "text_editor": 8,
+    "shell": 11,
+    "total": 20
+  },
+  "findings": {
+    "query_call_sites_found": 6,
+    "call_sites": [
+      {
+        "line": 47,
+        "function": "ElementExtractor::extract_with_depth",
+        "query_type": "element_query",
+        "context": "Counts functions and classes for directory overview mode"
+      },
+      {
+        "line": 240,
+        "function": "SemanticExtractor::extract",
+        "query_type": "element_query",
+        "context": "Extracts functions and classes for file details mode"
+      },
+      {
+        "line": 306,
+        "function": "SemanticExtractor::extract",
+        "query_type": "call_query",
+        "context": "Extracts function calls and call frequency"
+      },
+      {
+        "line": 348,
+        "function": "SemanticExtractor::extract",
+        "query_type": "import_query",
+        "context": "Extracts import statements (optional per language)"
+      },
+      {
+        "line": 370,
+        "function": "SemanticExtractor::extract",
+        "query_type": "impl_query",
+        "context": "Extracts impl blocks and methods (optional per language)"
+      },
+      {
+        "line": 431,
+        "function": "SemanticExtractor::extract",
+        "query_type": "reference_query",
+        "context": "Extracts type references (optional per language)"
+      }
+    ],
+    "thread_safety_verified": true,
+    "thread_safety_details": {
+      "query_is_send": true,
+      "query_is_sync": true,
+      "verification_source": "tree-sitter 0.26.5 binding_rust/lib.rs declares 'unsafe impl Send for Query {}' and 'unsafe impl Sync for Query {}'",
+      "implication": "Query objects can be safely shared across threads and stored in static/thread-local caches"
+    },
+    "language_info_structure_understood": true,
+    "language_info_details": {
+      "location": "src/languages/mod.rs",
+      "structure": {
+        "name": "static &str",
+        "language": "tree_sitter::Language",
+        "element_query": "static &str",
+        "call_query": "static &str",
+        "reference_query": "Option<static &str>",
+        "import_query": "Option<static &str>",
+        "impl_query": "Option<static &str>"
+      },
+      "key_insight": "All query strings are static references, never change per language, enabling safe caching",
+      "languages_supported": 9,
+      "registry_pattern": "get_language_info(lang_name) -> Option<LanguageInfo> function returns fresh LanguageInfo struct on each call"
+    },
+    "extractor_patterns_understood": true,
+    "extractor_details": {
+      "ElementExtractor": {
+        "location": "src/parser.rs lines 27-68",
+        "method": "extract_with_depth(source, language) -> Result<(usize, usize)>",
+        "call_frequency": "Once per file in overview mode, up to thousands of files",
+        "query_compilation_cost": "HIGH - compiles element_query on every call"
+      },
+      "SemanticExtractor": {
+        "location": "src/parser.rs lines 196-469",
+        "method": "extract(source, language, ast_recursion_limit) -> Result<SemanticAnalysis>",
+        "call_frequency": "Once per file in file_details and symbol_focus modes",
+        "query_compilation_cost": "VERY HIGH - compiles up to 5 queries per call (element, call, import, impl, reference)",
+        "conditional_queries": "import_query, impl_query, reference_query are optional per language"
+      },
+      "current_bottleneck": "SemanticExtractor::extract recompiles 5-6 identical Query objects every time it's called, even for the same language"
+    },
+    "performance_impact": {
+      "current_behavior": "6 Query::new() calls per file × thousands of files = millions of redundant compilations",
+      "query_compilation_cost": "tree-sitter Query::new() parses and compiles S-expression patterns to bytecode; non-trivial CPU cost",
+      "cache_benefit": "Eliminate redundant compilation; reuse compiled Query objects across all files of same language",
+      "expected_improvement": "Proportional to query compilation time; likely 5-15% overall speedup depending on file count and language"
+    }
+  },
+  "approaches": [
+    {
+      "name": "Thread-Local HashMap Cache (Simplest)",
+      "description": "Store compiled Query objects in a thread-local HashMap keyed by (language_name, query_type). Lazily initialize on first access per thread.",
+      "implementation_sketch": "Create a new module query_cache.rs with thread_local! { static QUERY_CACHE: RefCell<HashMap<(String, &str), Query>> }. Add a get_or_compile_query(language, query_str) function that checks cache before calling Query::new().",
+      "pros": [
+        "Minimal code changes - only affects parser.rs and new query_cache.rs",
+        "No external dependencies (uses std HashMap and thread_local)",
+        "Thread-safe by design (thread_local ensures per-thread isolation)",
+        "No synchronization overhead (RefCell, no Mutex needed)",
+        "Easy to understand and debug",
+        "Works with existing thread-local PARSER pattern"
+      ],
+      "cons": [
+        "Cache not shared across threads (each thread has own copy)",
+        "In multi-threaded analysis (rayon), may duplicate cache entries",
+        "No eviction policy - grows unbounded (but only 6 queries per language)",
+        "Requires string allocation for HashMap keys"
+      ],
+      "complexity": "simple",
+      "files_touched": 2,
+      "estimated_loc_change": 50,
+      "cache_key_strategy": "(language_name: String, query_type: &str) or (language_name: String, query_str: &str)"
+    },
+    {
+      "name": "Global Arc<DashMap> Cache (Best for Parallelism)",
+      "description": "Store compiled Query objects in a global Arc-wrapped DashMap (concurrent hashmap). Lazily initialize on first access, shared across all threads.",
+      "implementation_sketch": "Add dashmap crate to Cargo.toml. Create query_cache.rs with lazy_static or once_cell: static QUERY_CACHE: Lazy<Arc<DashMap<QueryCacheKey, Arc<Query>>>> = Lazy::new(|| Arc::new(DashMap::new())). Define QueryCacheKey as (language_name: String, query_type: QueryType enum).",
+      "pros": [
+        "Cache shared across all threads (rayon workers benefit immediately)",
+        "Lock-free concurrent access (DashMap uses fine-grained locking)",
+        "Scales well with parallel file processing",
+        "Bounded memory (only 6 queries per language, ~9 languages = 54 max entries)",
+        "Lazy initialization avoids startup cost",
+        "Works seamlessly with rayon parallelism"
+      ],
+      "cons": [
+        "Adds external dependency (dashmap crate)",
+        "Slightly more complex than thread-local approach",
+        "Arc overhead for each cached Query",
+        "DashMap has small synchronization cost (acceptable for 6-entry cache)"
+      ],
+      "complexity": "medium",
+      "files_touched": 2,
+      "estimated_loc_change": 70,
+      "cache_key_strategy": "Enum-based QueryType { Element, Call, Import, Impl, Reference } + language_name string"
+    },
+    {
+      "name": "LanguageInfo Struct Extension (Most Elegant)",
+      "description": "Pre-compile Query objects at LanguageInfo creation time and store them as Arc<Query> fields in LanguageInfo. Move query compilation from parser.rs to languages/mod.rs.",
+      "implementation_sketch": "Extend LanguageInfo struct with Arc<Query> fields: element_query_compiled, call_query_compiled, import_query_compiled, impl_query_compiled, reference_query_compiled. In get_language_info(), compile queries once during LanguageInfo construction. Update parser.rs to use pre-compiled queries from lang_info instead of calling Query::new().",
+      "pros": [
+        "Eliminates caching logic entirely - queries compiled once at startup",
+        "No runtime cache lookups or synchronization",
+        "Compile-time safety (queries validated at LanguageInfo creation)",
+        "Queries live as long as LanguageInfo (natural lifecycle)",
+        "Minimal parser.rs changes (just use lang_info.element_query_compiled instead of Query::new())",
+        "Zero memory overhead (Arc is cheap)",
+        "Clearest intent: queries are part of language definition"
+      ],
+      "cons": [
+        "Requires modifying LanguageInfo struct (breaking change to type signature)",
+        "Startup cost moved to server initialization (compile all 6 queries × 9 languages = 54 queries upfront)",
+        "Harder to handle optional queries (import_query, impl_query, reference_query) - need Result handling",
+        "Requires refactoring get_language_info() to return Result<LanguageInfo, ParserError>",
+        "More files touched (languages/mod.rs, parser.rs, lib.rs error handling)"
+      ],
+      "complexity": "medium",
+      "files_touched": 4,
+      "estimated_loc_change": 120,
+      "cache_key_strategy": "No cache key needed; queries stored directly in LanguageInfo fields"
+    }
+  ],
+  "recommendation": {
+    "approach": "Approach 2: Global Arc<DashMap> Cache",
+    "rationale": [
+      "Best balance of simplicity and performance for the codebase's parallelism model (rayon-based file processing)",
+      "Cache is shared across all threads, eliminating redundant compilation in parallel analysis",
+      "Only 6 queries per language maximum (54 total entries) - DashMap synchronization overhead is negligible",
+      "Minimal changes to existing code: new query_cache.rs module + 6 function calls in parser.rs",
+      "Lazy initialization avoids startup cost; queries compiled on first access per language",
+      "Scales well as language support expands (currently 9, planned for more)",
+      "No breaking changes to LanguageInfo or public APIs",
+      "Approach 1 (thread-local) wastes cache space with rayon (each worker thread duplicates entries)",
+      "Approach 3 (LanguageInfo extension) requires more refactoring and moves compilation cost to startup"
+    ],
+    "implementation_steps": [
+      "1. Add dashmap = \"5\" to Cargo.toml",
+      "2. Create src/query_cache.rs with QueryCacheKey enum and get_or_compile_query() function",
+      "3. Replace 6 Query::new() calls in parser.rs with get_or_compile_query() calls",
+      "4. Add unit tests for cache hits and misses",
+      "5. Benchmark with large file sets to measure improvement"
+    ],
+    "expected_impact": "5-15% overall speedup for large directory analysis; more significant for repeated file analysis (FileDetails mode)"
+  },
+  "additional_notes": {
+    "query_string_immutability": "All query strings (element_query, call_query, etc.) are static &str defined in language modules, never change, enabling safe caching",
+    "parser_pattern_precedent": "Code already uses thread_local! for Parser caching; query caching follows same pattern",
+    "optional_queries": "import_query, impl_query, reference_query are Option<&str> per language; cache must handle None gracefully",
+    "error_handling": "Query::new() returns Result; cache must propagate errors (not cache failed compilations)",
+    "future_work": "Wave 4 roadmap mentions caching and performance; this issue aligns with that goal"
+  }
+}

--- a/benchmarks/v2/README.md
+++ b/benchmarks/v2/README.md
@@ -1,0 +1,63 @@
+# Benchmark v2: code-analyze-mcp vs Manual Tooling
+
+## Design
+
+**Target repo:** [sharkdp/bat](https://github.com/sharkdp/bat) (~10.8K LOC Rust, 40 files, multi-module)
+
+**Task:** Map the complete data flow from user input to terminal output in `bat`.
+Identify all module boundaries crossed, the key types passed between modules,
+and propose where you would add a new output format (e.g., HTML) with minimal changes.
+
+This task requires:
+1. Understanding the full module graph (structural accuracy)
+2. Tracing Controller -> Printer -> Decorations -> Output chains (cross-module tracing)
+3. Proposing an approach that respects existing patterns (approach quality)
+
+**Conditions:**
+
+| Run | Extensions | Prompt |
+|-----|-----------|--------|
+| A (control) | `developer` only (no `developer__analyze`) | `prompt-control.md` |
+| B (treatment) | `developer` (no analyze) + `code-analyze-mcp` | `prompt-treatment.md` |
+
+**Repetitions:** 3 runs per condition (6 total), Haiku, temperature 0.5
+
+## Rubric (0-3 per dimension, 0-12 total)
+
+| Dimension | 0 | 1 | 2 | 3 |
+|-----------|---|---|---|---|
+| Structural accuracy | Wrong module map | Partial | Correct but incomplete | Complete and correct |
+| Cross-module tracing | Missed dependencies | Found some | Found most | Found all with context |
+| Approach quality | Infeasible | Works but naive | Good with tradeoffs | Elegant, minimal, safe |
+| Tool efficiency | >25 calls | 16-25 | 8-15 | <8 calls |
+
+## Known Issues
+
+- The treatment prompt references `developer__analyze` without naming `code-analyze-mcp`. The `developer__analyze` tool is the tool name exposed by the code-analyze-mcp MCP server. The prompts are preserved as-is because they are historical records of what was sent to the delegates during the benchmark runs. Future benchmarks should name the tool's source extension explicitly in the prompt instructions.
+
+## Files
+
+- `conditions.json` - Complete reproducibility metadata (see "How to reproduce" below)
+- `prompt-control.md` - Control condition prompt (rg + cat only)
+- `prompt-treatment.md` - Treatment condition prompt (code-analyze-mcp forced)
+- `ground-truth.md` - Expected answers for scoring
+- `results.md` - Raw results and analysis
+
+## How to Reproduce
+
+All metadata needed to reproduce this benchmark is in `conditions.json`:
+
+- **Goose version:** 1.26.1
+- **Orchestrator session:** 20260303_120 (see `~/.local/share/goose/sessions/sessions.db`)
+- **Target repo:** sharkdp/bat at commit cc5f782d28a8e6156b8ebd3346b0a7f7c49256e2
+- **Model:** claude-haiku-4-5@20251001 via gcp_vertex_ai, temperature 0.5
+- **Conditions:** See `conditions.json` for exact extension configuration per run
+- **Session IDs:** Each run (A1-A3, B1-B3) has a session ID in `conditions.json`
+
+To reproduce:
+
+1. Clone bat at the specified commit: `git clone https://github.com/sharkdp/bat && git checkout cc5f782d28a8e6156b8ebd3346b0a7f7c49256e2`
+2. For each run in `conditions.json`, configure goose with the specified extensions
+3. Use the corresponding prompt file (`prompt-control.md` or `prompt-treatment.md`)
+4. Score the output against `ground-truth.md` using the rubric above
+5. Compare results to `results.md`

--- a/benchmarks/v2/conditions.json
+++ b/benchmarks/v2/conditions.json
@@ -1,0 +1,229 @@
+{
+  "benchmark_version": "v2",
+  "issue": "https://github.com/clouatre-labs/code-analyze-mcp/issues/64",
+  "date": "2026-03-03",
+  "goose": {
+    "version": "1.26.1",
+    "orchestrator_session_id": "20260303_120",
+    "sessions_db": "~/.local/share/goose/sessions/sessions.db"
+  },
+  "target_repo": {
+    "name": "sharkdp/bat",
+    "url": "https://github.com/sharkdp/bat",
+    "commit_sha": "cc5f782d28a8e6156b8ebd3346b0a7f7c49256e2",
+    "local_path": "/tmp/bat_check",
+    "loc": 10800,
+    "files": 40,
+    "language": "Rust"
+  },
+  "model": {
+    "name": "claude-haiku-4-5@20251001",
+    "provider": "gcp_vertex_ai",
+    "temperature": 0.5
+  },
+  "conditions": {
+    "control": {
+      "label": "A (control)",
+      "extensions": ["developer"],
+      "extensions_disabled": ["developer__analyze"],
+      "prompt_file": "prompt-control.md",
+      "description": "Pure rg + cat + text_editor, no structural analysis tools"
+    },
+    "treatment": {
+      "label": "B (treatment)",
+      "extensions": ["developer", "code-analyze-mcp"],
+      "extensions_disabled": ["developer__analyze"],
+      "prompt_file": "prompt-treatment.md",
+      "description": "code-analyze-mcp forced for structural queries"
+    }
+  },
+  "runs": [
+    {
+      "id": "A1",
+      "condition": "control",
+      "session_id": "20260303_121",
+      "total_tokens": 32953,
+      "input_tokens": 29668,
+      "output_tokens": 3285,
+      "wall_time_seconds": 40,
+      "tool_calls": 26,
+      "tool_breakdown": {
+        "analyze": 0,
+        "shell": 24,
+        "text_editor": 2
+      },
+      "tokens": {
+        "total": 32953,
+        "input": 29668,
+        "output": 3285
+      },
+      "score": {
+        "structural_accuracy": 3,
+        "cross_module_tracing": 3,
+        "approach_quality": 3,
+        "tool_efficiency": 0,
+        "total": 9
+      }
+    },
+    {
+      "id": "A2",
+      "condition": "control",
+      "session_id": "20260303_122",
+      "total_tokens": 30821,
+      "input_tokens": 27475,
+      "output_tokens": 3346,
+      "wall_time_seconds": 55,
+      "tool_calls": 37,
+      "tool_breakdown": {
+        "analyze": 0,
+        "shell": 35,
+        "text_editor": 2
+      },
+      "tokens": {
+        "total": 30821,
+        "input": 27475,
+        "output": 3346
+      },
+      "score": {
+        "structural_accuracy": 3,
+        "cross_module_tracing": 3,
+        "approach_quality": 3,
+        "tool_efficiency": 0,
+        "total": 9
+      }
+    },
+    {
+      "id": "A3",
+      "condition": "control",
+      "session_id": "20260303_123",
+      "total_tokens": 36614,
+      "input_tokens": 36118,
+      "output_tokens": 496,
+      "wall_time_seconds": 76,
+      "tool_calls": 31,
+      "tool_breakdown": {
+        "analyze": 0,
+        "shell": 29,
+        "text_editor": 2
+      },
+      "tokens": {
+        "total": 36614,
+        "input": 36118,
+        "output": 496
+      },
+      "score": {
+        "structural_accuracy": 3,
+        "cross_module_tracing": 3,
+        "approach_quality": 3,
+        "tool_efficiency": 0,
+        "total": 9
+      }
+    },
+    {
+      "id": "B1",
+      "condition": "treatment",
+      "session_id": "20260303_124",
+      "total_tokens": 26046,
+      "input_tokens": 23245,
+      "output_tokens": 2801,
+      "wall_time_seconds": 25,
+      "tool_calls": 22,
+      "tool_breakdown": {
+        "analyze": 21,
+        "shell": 0,
+        "text_editor": 1
+      },
+      "tokens": {
+        "total": 26046,
+        "input": 23245,
+        "output": 2801
+      },
+      "score": {
+        "structural_accuracy": 2,
+        "cross_module_tracing": 2,
+        "approach_quality": 2,
+        "tool_efficiency": 2,
+        "total": 8
+      }
+    },
+    {
+      "id": "B2",
+      "condition": "treatment",
+      "session_id": "20260303_125",
+      "total_tokens": 26144,
+      "input_tokens": 22723,
+      "output_tokens": 3421,
+      "wall_time_seconds": 23,
+      "tool_calls": 21,
+      "tool_breakdown": {
+        "analyze": 20,
+        "shell": 0,
+        "text_editor": 1
+      },
+      "tokens": {
+        "total": 26144,
+        "input": 22723,
+        "output": 3421
+      },
+      "score": {
+        "structural_accuracy": 2,
+        "cross_module_tracing": 3,
+        "approach_quality": 2,
+        "tool_efficiency": 2,
+        "total": 9
+      }
+    },
+    {
+      "id": "B3",
+      "condition": "treatment",
+      "session_id": "20260303_126",
+      "total_tokens": 26738,
+      "input_tokens": 22920,
+      "output_tokens": 3818,
+      "wall_time_seconds": 25,
+      "tool_calls": 21,
+      "tool_breakdown": {
+        "analyze": 20,
+        "shell": 0,
+        "text_editor": 1
+      },
+      "tokens": {
+        "total": 26738,
+        "input": 22920,
+        "output": 3818
+      },
+      "score": {
+        "structural_accuracy": 2,
+        "cross_module_tracing": 3,
+        "approach_quality": 2,
+        "tool_efficiency": 2,
+        "total": 9
+      }
+    }
+  ],
+  "rubric": {
+    "dimensions": [
+      "structural_accuracy",
+      "cross_module_tracing",
+      "approach_quality",
+      "tool_efficiency"
+    ],
+    "scale": "0-3 per dimension, 0-12 total",
+    "thresholds": {
+      "tool_efficiency": {
+        "0": ">25 calls",
+        "1": "16-25",
+        "2": "8-15",
+        "3": "<8 calls"
+      }
+    }
+  },
+  "code_analyze_mcp": {
+    "version": "0.1.0",
+    "modes_available": [
+      "Overview",
+      "FileDetails",
+      "SymbolFocus"
+    ]
+  }
+}

--- a/benchmarks/v2/ground-truth.md
+++ b/benchmarks/v2/ground-truth.md
@@ -1,0 +1,101 @@
+# Ground Truth: bat Data Flow
+
+## Module Map (Structural Accuracy)
+
+The `bat` codebase has these key modules in `src/`:
+
+| Module | Role |
+|--------|------|
+| `lib.rs` | Re-exports public API types |
+| `controller.rs` | Orchestrates file processing pipeline |
+| `printer.rs` | Renders lines to output (trait + 2 impls) |
+| `decorations.rs` | Line decorations (numbers, git changes, grid) |
+| `output.rs` | Output destination (stdout, pager) |
+| `input.rs` | Input abstraction (files, stdin, readers) |
+| `config.rs` | Configuration struct aggregating all options |
+| `assets.rs` | Syntax/theme loading (syntect integration) |
+| `diff.rs` | Git diff computation |
+| `style.rs` | Style component flags |
+| `theme.rs` | Theme selection and color scheme detection |
+| `syntax_mapping.rs` | File-to-syntax mapping rules |
+| `line_range.rs` | Line range filtering |
+| `preprocessor.rs` | Tab expansion, ANSI stripping, nonprintable replacement |
+| `terminal.rs` | Terminal escape code generation |
+| `vscreen.rs` | Virtual screen / ANSI escape sequence parsing |
+| `wrapping.rs` | Line wrapping modes |
+| `paging.rs` | Paging mode enum |
+| `less.rs` | Less version detection |
+| `lessopen.rs` | LESSOPEN preprocessor support |
+| `pretty_printer.rs` | High-level builder API (library consumers) |
+| `bin/bat/main.rs` | CLI entry point |
+| `bin/bat/app.rs` | Argument parsing |
+| `bin/bat/config.rs` | Config file loading |
+
+**Scoring:** A complete answer identifies at least the core pipeline modules (controller, printer, decorations, output, input, config, assets, preprocessor). Partial credit for listing files without understanding roles.
+
+## Data Flow (Cross-Module Tracing)
+
+### Entry Point
+`bin/bat/main.rs::run_controller()` -> creates `Controller::new(&config, &assets)` -> calls `controller.run(inputs, None)`
+
+### Pipeline
+1. **main.rs** parses CLI args via `App` (clap), builds `Config` struct
+2. **Controller::run()** creates `OutputType` (stdout or pager) from `output.rs`, gets `OutputHandle`
+3. For each input, **Controller::run()** calls `Controller::print_input()`:
+   - Opens input via `InputReader` from `input.rs`
+   - Computes git diff via `diff::get_git_diff()` (if enabled)
+   - Creates printer: `InteractivePrinter::new()` or `SimplePrinter::new()`
+   - Calls `Controller::print_file()` with the printer
+4. **Controller::print_file()** calls:
+   - `printer.print_header()` -> writes file name, language info
+   - `Controller::print_file_ranges()` -> iterates lines, calls `printer.print_line()` for each
+   - `printer.print_footer()` -> writes closing grid
+5. **InteractivePrinter::print_line()** (the core rendering):
+   - Runs decorations (line numbers, git changes, grid border) via `Decoration` trait
+   - Applies syntax highlighting via `syntect` (from `assets.rs`)
+   - Preprocesses content: `expand_tabs()`, `replace_nonprintable()`, `strip_ansi()` from `preprocessor.rs`
+   - Converts to terminal escapes via `terminal::as_terminal_escaped()`
+   - Handles line wrapping via `wrapping.rs` logic
+   - Writes to `OutputHandle`
+
+### Key Types Crossing Module Boundaries
+- `Config` (config.rs -> controller, printer, pretty_printer)
+- `HighlightingAssets` (assets.rs -> controller, printer)
+- `Input` / `OpenedInput` / `InputReader` (input.rs -> controller, printer, assets)
+- `OutputType` / `OutputHandle` (output.rs -> controller, printer)
+- `LineChanges` (diff.rs -> controller, printer, decorations)
+- `Decoration` trait (decorations.rs -> printer)
+- `StyleComponents` (style.rs -> config, printer)
+- `AnsiStyle` / `EscapeSequence` (vscreen.rs -> printer)
+- `Printer` trait (printer.rs -> controller)
+
+**Scoring:** A complete answer traces the full pipeline from main -> Controller -> Printer -> Output with the key types. Must identify the Printer trait and its two implementations. Must identify the Decoration system.
+
+## HTML Output Approach (Approach Quality)
+
+### Recommended Approach: New Printer Implementation
+
+The cleanest approach is to implement a new `HtmlPrinter` that implements the `Printer` trait:
+
+1. **Add `HtmlPrinter` struct** in a new `html_printer.rs` (or in `printer.rs`)
+   - Implements `Printer` trait: `print_header`, `print_footer`, `print_snip`, `print_line`
+   - Generates HTML tags instead of terminal escape codes
+   - Skips `Decoration` system (or adapts it for HTML classes)
+
+2. **Add output format to Config**
+   - New enum variant in config or a new field: `output_format: OutputFormat`
+   - `OutputFormat::Terminal` (default) | `OutputFormat::Html`
+
+3. **Controller selects printer based on format**
+   - In `Controller::print_input()`, choose `HtmlPrinter` when format is HTML
+   - The `Printer` trait already abstracts this; no changes to `Controller::print_file()`
+
+4. **Minimal changes:**
+   - `printer.rs` or new `html_printer.rs`: new struct + trait impl
+   - `config.rs`: add output format field
+   - `controller.rs`: add printer selection branch
+   - `bin/bat/main.rs` or `clap_app.rs`: add CLI flag
+
+**Why this is elegant:** The `Printer` trait already exists as the abstraction point. `Controller::print_file()` takes `&mut dyn Printer`, so a new implementation slots in without changing the orchestration layer.
+
+**Scoring:** An answer that identifies the Printer trait as the extension point and proposes a new implementation scores 3. An answer that proposes modifying InteractivePrinter or adding HTML logic inline scores 1-2.

--- a/benchmarks/v2/prompt-control.md
+++ b/benchmarks/v2/prompt-control.md
@@ -1,0 +1,66 @@
+# Research Task: bat Codebase Analysis (Control - Manual Tools Only)
+
+You are a research agent analyzing the `sharkdp/bat` codebase. The repo is already cloned at `/tmp/bat_check`.
+
+## Task
+
+Map the complete data flow from user input to terminal output in `bat`. Your deliverable is a structured research report with three sections:
+
+1. **Module map:** List every module in `src/` with its role and key types
+2. **Data flow:** Trace the complete pipeline from CLI entry point to terminal output, identifying all module boundaries crossed and the key types passed between modules
+3. **Extension proposal:** Propose where you would add a new output format (e.g., HTML) with minimal changes, identifying the specific abstraction points and files to modify
+
+## Instructions
+
+Follow these steps exactly:
+
+**Step 1: Directory structure.** Use `rg --files src/ | head -50` and `wc -l src/*.rs src/**/*.rs` to understand the file layout and sizes.
+
+**Step 2: Module roles.** Use `cat` or `head` to read `src/lib.rs` for the module declarations and re-exports. Then read the first 30 lines of each key module to understand its role.
+
+**Step 3: Cross-module dependencies.** Use `rg '^use crate::' src/ --no-heading` to map all internal imports. Identify which modules depend on which.
+
+**Step 4: Entry point tracing.** Read `src/bin/bat/main.rs` to find the entry point. Use `rg` to trace the call chain: find where `Controller` is created, where `run()` is called, and what it delegates to.
+
+**Step 5: Printer system.** Use `rg 'trait Printer|impl Printer|struct.*Printer' src/` to find the printer abstraction. Read the trait definition and its implementations.
+
+**Step 6: Decoration system.** Use `rg 'trait Decoration|impl Decoration' src/` to find the decoration system. Understand how it connects to the printer.
+
+**Step 7: Output pipeline.** Use `rg 'OutputType|OutputHandle' src/ -l` to trace how output reaches the terminal.
+
+**Step 8: Synthesize.** Write your structured report with all three sections.
+
+## Output Format
+
+Write your report as structured JSON:
+
+```json
+{
+  "module_map": [
+    {"module": "controller.rs", "role": "...", "key_types": ["Controller"]}
+  ],
+  "data_flow": {
+    "entry_point": "description",
+    "pipeline_steps": [
+      {"step": 1, "module": "...", "action": "...", "types_passed": ["..."]}
+    ],
+    "key_boundary_crossings": [
+      {"from": "module_a", "to": "module_b", "types": ["Type1"], "description": "..."}
+    ]
+  },
+  "extension_proposal": {
+    "approach": "description",
+    "abstraction_point": "where to extend",
+    "files_to_modify": ["file1.rs"],
+    "rationale": "why this is minimal"
+  },
+  "tool_calls_used": 0
+}
+```
+
+## Constraints
+
+- You may only use: `rg`, `cat`, `head`, `tail`, `wc`, `grep`, `sed`, `awk`, and the text_editor view command
+- Do NOT use any structural analysis tools
+- Count your tool calls and report the total
+- Work in `/tmp/bat_check`

--- a/benchmarks/v2/prompt-treatment.md
+++ b/benchmarks/v2/prompt-treatment.md
@@ -1,0 +1,64 @@
+# Research Task: bat Codebase Analysis (Treatment - code-analyze-mcp)
+
+You are a research agent analyzing the `sharkdp/bat` codebase. The repo is already cloned at `/tmp/bat_check`.
+
+## Task
+
+Map the complete data flow from user input to terminal output in `bat`. Your deliverable is a structured research report with three sections:
+
+1. **Module map:** List every module in `src/` with its role and key types
+2. **Data flow:** Trace the complete pipeline from CLI entry point to terminal output, identifying all module boundaries crossed and the key types passed between modules
+3. **Extension proposal:** Propose where you would add a new output format (e.g., HTML) with minimal changes, identifying the specific abstraction points and files to modify
+
+## Instructions
+
+Follow these steps exactly:
+
+**Step 1: Directory overview.** Use the `developer__analyze` tool with path `/tmp/bat_check/src` and max_depth 3 to get the complete directory structure with file metrics (LOC, function counts, class counts).
+
+**Step 2: Module roles.** Use the `developer__analyze` tool on each key file (e.g., `/tmp/bat_check/src/controller.rs`, `/tmp/bat_check/src/printer.rs`) to get function lists, imports, and type definitions.
+
+**Step 3: Cross-module tracing.** Use the `developer__analyze` tool with the `focus` parameter set to `Printer` on path `/tmp/bat_check/src` to trace the call graph for the Printer type across the codebase. Then do the same for `Controller`.
+
+**Step 4: Decoration system.** Use the `developer__analyze` tool with `focus` set to `Decoration` on path `/tmp/bat_check/src` to trace the decoration call graph.
+
+**Step 5: Output pipeline.** Use the `developer__analyze` tool with `focus` set to `OutputHandle` on path `/tmp/bat_check/src` to trace how output reaches the terminal.
+
+**Step 6: Entry point.** Use the `developer__analyze` tool on `/tmp/bat_check/src/bin/bat/main.rs` to understand the CLI entry point and its dependencies.
+
+**Step 7: Synthesize.** Write your structured report with all three sections.
+
+## Output Format
+
+Write your report as structured JSON:
+
+```json
+{
+  "module_map": [
+    {"module": "controller.rs", "role": "...", "key_types": ["Controller"]}
+  ],
+  "data_flow": {
+    "entry_point": "description",
+    "pipeline_steps": [
+      {"step": 1, "module": "...", "action": "...", "types_passed": ["..."]}
+    ],
+    "key_boundary_crossings": [
+      {"from": "module_a", "to": "module_b", "types": ["Type1"], "description": "..."}
+    ]
+  },
+  "extension_proposal": {
+    "approach": "description",
+    "abstraction_point": "where to extend",
+    "files_to_modify": ["file1.rs"],
+    "rationale": "why this is minimal"
+  },
+  "tool_calls_used": 0
+}
+```
+
+## Constraints
+
+- You MUST use the `developer__analyze` tool for all structural queries (steps 1-6)
+- You may use `rg` or `cat` only to read specific file content when analyze output is insufficient
+- Count your tool calls and report the total
+- Work in `/tmp/bat_check`

--- a/benchmarks/v2/results.md
+++ b/benchmarks/v2/results.md
@@ -1,0 +1,141 @@
+# Benchmark v2 Results
+
+## Setup
+
+- **Target repo:** sharkdp/bat (10.8K LOC, 40 Rust files, multi-module)
+- **Task:** Map data flow from user input to terminal output; identify module boundaries and key types; propose HTML output extension point
+- **Model:** claude-haiku-4-5@20251001 (via gcp_vertex_ai)
+- **Temperature:** 0.5
+- **Conditions:**
+  - Control (A): `developer` extension only (no `developer__analyze`)
+  - Treatment (B): `developer` + `code-analyze-mcp` (`developer__analyze` forced)
+
+## Rubric
+
+| Dimension | 0 | 1 | 2 | 3 |
+|-----------|---|---|---|---|
+| Structural accuracy | Wrong module map | Partial | Correct but incomplete | Complete and correct |
+| Cross-module tracing | Missed dependencies | Found some | Found most | Found all with context |
+| Approach quality | Infeasible | Works but naive | Good with tradeoffs | Elegant, minimal, safe |
+| Tool efficiency | >25 calls | 16-25 | 8-15 | <8 calls |
+
+## Raw Scores
+
+### Control Run A1 (26 tool calls, 40s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 3 | Listed 20 modules with accurate roles. Identified all core pipeline modules including preprocessor, terminal, wrapping. Correctly described Printer trait with two implementations. |
+| Cross-module tracing | 3 | Traced full pipeline: main -> Controller -> Printer -> Output. Identified Printer trait, Decoration trait, all key types (Config, HighlightingAssets, OutputHandle, LineChanges). Named run_controller() entry point. 14-step pipeline with 10 boundary crossings. |
+| Approach quality | 3 | Identified Printer trait as extension point. Proposed HtmlPrinter implementing Printer trait. Correctly noted Controller::print_file() takes &mut dyn Printer. Minimal file list: printer.rs, config.rs, controller.rs, clap_app.rs. |
+| Tool efficiency | 0 | 26 tool calls (>25 threshold) |
+| **Total** | **9** | |
+
+### Control Run A2 (37 tool calls, 55s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 3 | Listed 20 modules with accurate roles. Identified all core modules including pager.rs. Correctly described Printer trait and both implementations. |
+| Cross-module tracing | 3 | Full pipeline traced: main -> Controller -> Printer -> Output. 14-step pipeline with 10 boundary crossings. Identified Printer trait, Decoration trait, all key types. Named run_controller() entry point. |
+| Approach quality | 3 | Identified Printer trait as extension point. Proposed HtmlPrinter implementing same trait methods. Correctly noted decorations remain unchanged. Minimal file list. |
+| Tool efficiency | 0 | 37 tool calls (>25 threshold) |
+| **Total** | **9** | |
+
+### Control Run A3 (31 tool calls, 76s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 3 | Listed 20 modules with accurate roles. Identified all core pipeline modules. Correctly described Printer trait and both implementations. |
+| Cross-module tracing | 3 | Full pipeline traced with 19 steps. Identified Printer trait, Decoration trait, all key types. Named run_controller() entry point. Detailed boundary crossings. |
+| Approach quality | 3 | Identified Printer trait as extension point. Proposed HtmlPrinter. Correctly noted existing abstractions enable minimal changes. |
+| Tool efficiency | 0 | 31 tool calls (>25 threshold) |
+| **Total** | **9** | |
+
+### Treatment Run B1 (18 tool calls, 25s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 2 | Listed 18 modules but missed some (wrapping.rs, lessopen.rs, macros.rs, nonprintable_notation.rs). Roles mostly accurate. Did not explicitly name the Printer trait (listed InteractivePrinter and SimplePrinter but not the trait itself in module map). |
+| Cross-module tracing | 2 | 10-step pipeline is compressed; misses some intermediate steps (e.g., print_file_ranges, line range filtering). Identified key boundary crossings but fewer details on types. Did not name run_controller() entry point. Missing diff.rs integration in pipeline. |
+| Approach quality | 2 | Proposed OutputFormatter trait instead of using existing Printer trait. This adds unnecessary abstraction; the Printer trait already serves this purpose. Workable but not minimal. |
+| Tool efficiency | 2 | 18 tool calls (16-25 range) |
+| **Total** | **8** | |
+
+### Treatment Run B2 (17 tool calls, 23s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 2 | Listed 16 modules. Missing wrapping.rs, lessopen.rs, macros.rs, nonprintable_notation.rs, terminal.rs, diff.rs. Did not explicitly name the Printer trait in module map (listed InteractivePrinter and SimplePrinter). |
+| Cross-module tracing | 3 | 17-step pipeline is detailed. Identified key boundary crossings including Printer -> decorations, Printer -> vscreen. Named key types. Traced full path from main to terminal output. |
+| Approach quality | 2 | Proposed new Formatter trait alongside Printer. While workable, this misses that the Printer trait already is the abstraction point. Adding a Formatter trait is unnecessary indirection. |
+| Tool efficiency | 2 | 17 tool calls (16-25 range) |
+| **Total** | **9** | |
+
+### Treatment Run B3 (19 tool calls, 25s)
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Structural accuracy | 2 | Listed 19 modules. Missing wrapping.rs, lessopen.rs, macros.rs, nonprintable_notation.rs, terminal.rs. Roles mostly accurate. Did not explicitly name the Printer trait. |
+| Cross-module tracing | 3 | 20-step pipeline is detailed. Identified all key boundary crossings. Named key types. Traced full path from main to terminal output including pager. |
+| Approach quality | 2 | Proposed Formatter trait abstraction. Same issue as B1/B2: misses that Printer trait already serves this purpose. Workable but adds unnecessary complexity. |
+| Tool efficiency | 2 | 19 tool calls (16-25 range) |
+| **Total** | **9** | |
+
+## Summary Statistics
+
+### Per-Dimension Means
+
+| Dimension | Control Mean (A) | Treatment Mean (B) | Difference |
+|-----------|-----------------|-------------------|------------|
+| Structural accuracy | 3.0 | 2.0 | -1.0 |
+| Cross-module tracing | 3.0 | 2.7 | -0.3 |
+| Approach quality | 3.0 | 2.0 | -1.0 |
+| Tool efficiency | 0.0 | 2.0 | +2.0 |
+| **Total** | **9.0** | **8.7** | **-0.3** |
+
+### Per-Condition Summary
+
+| Condition | Run 1 | Run 2 | Run 3 | Mean | Range |
+|-----------|-------|-------|-------|------|-------|
+| Control (A) | 9 | 9 | 9 | 9.0 | 0 |
+| Treatment (B) | 8 | 9 | 9 | 8.7 | 1 |
+
+## Metrics Comparison
+
+| Metric | Control (A) | Treatment (B) | Delta | Delta % |
+|--------|:-----------:|:-------------:|:-----:|:-------:|
+| Wall time mean (s) | 57.0 | 24.3 | -32.7 | -57% |
+| Wall time range (s) | 40-76 | 23-25 | | |
+| Tool calls mean | 31.3 | 21.3 | -10.0 | -32% |
+| Tool calls range | 26-37 | 21-22 | | |
+| Total tokens mean | 33463 | 26309 | -7154 | -21% |
+| Input tokens mean | 31087 | 22963 | -8124 | -26% |
+| Output tokens mean | 2376 | 3347 | +971 | +41% |
+| Quality score mean (0-12) | 9.0 | 8.7 | -0.3 | -3% |
+| Quality score range | 9-9 | 8-9 | | |
+
+### Tool Call Counts and Wall Time
+
+| Condition | Run 1 | Run 2 | Run 3 | Mean | Tool Breakdown |
+|-----------|-------|-------|-------|------|---|
+| Control (A) calls | 26 | 37 | 31 | 31.3 | shell: 24-35, text_editor: 2 |
+| Control (A) wall time (s) | 40 | 55 | 76 | 57.0 | |
+| Treatment (B) calls | 22 | 21 | 21 | 21.3 | analyze: 20-21, text_editor: 1 |
+| Treatment (B) wall time (s) | 25 | 23 | 25 | 24.3 | |
+
+## Analysis
+
+- Total quality score: Control 9.0, Treatment 8.7 (difference -0.3).
+- Wall time: Treatment 24.3s mean vs Control 57.0s mean (57% reduction).
+- Tool calls: Treatment 21.3 mean vs Control 31.3 mean (32% reduction).
+- Total tokens: Treatment 26309 mean vs Control 33463 mean (21% reduction).
+- Input tokens: Treatment 22963 mean vs Control 31087 mean (26% reduction).
+- Output tokens: Treatment 3347 mean vs Control 2376 mean (41% increase).
+- Structural accuracy: Control 3.0 mean, Treatment 2.0 mean (difference -1.0). Control identified 20 modules consistently; Treatment identified 16-19 modules, missing wrapping.rs, lessopen.rs, macros.rs, nonprintable_notation.rs, terminal.rs, diff.rs.
+- Cross-module tracing: Control 3.0 mean, Treatment 2.7 mean (difference -0.3). Control traced 14-19 step pipelines; Treatment traced 10-20 step pipelines.
+- Approach quality: Control 3.0 mean, Treatment 2.0 mean (difference -1.0). Control identified Printer trait as extension point; Treatment proposed new Formatter trait in all runs.
+- Tool efficiency: Control 0.0 mean (all runs >25 calls), Treatment 2.0 mean (all runs 16-25 calls).
+
+## Summary
+
+Raw data and session IDs are in conditions.json for independent verification.


### PR DESCRIPTION
## Summary

A/B benchmark comparing code-analyze-mcp vs manual tooling (rg/cat) for cross-module codebase research.

## Design

- **Target repo:** sharkdp/bat (10.8K LOC, 40 Rust files, multi-module) at commit cc5f782d
- **Task:** Map data flow from user input to terminal output; identify module boundaries; propose HTML output extension
- **Model:** claude-haiku-4-5@20251001 (gcp_vertex_ai), temperature 0.5
- **Conditions:** Control (developer only) vs Treatment (developer + code-analyze-mcp, forced usage)
- **Repetitions:** 3 per condition (6 total)

## Metrics Comparison

| Metric | Control (A) | Treatment (B) | Delta | Delta % |
|--------|:-----------:|:-------------:|:-----:|:-------:|
| Wall time mean (s) | 57.0 | 24.3 | -32.7 | -57% |
| Wall time range (s) | 40-76 | 23-25 | | |
| Tool calls mean | 31.3 | 21.3 | -10.0 | -32% |
| Tool calls range | 26-37 | 21-22 | | |
| Total tokens mean | 33463 | 26309 | -7154 | -21% |
| Input tokens mean | 31087 | 22963 | -8124 | -26% |
| Output tokens mean | 2376 | 3347 | +971 | +41% |
| Quality score mean (0-12) | 9.0 | 8.7 | -0.3 | -3% |
| Quality score range | 9-9 | 8-9 | | |

### Per-Dimension Quality

| Dimension | Control (A) | Treatment (B) | Delta |
|-----------|:-----------:|:-------------:|:-----:|
| Structural accuracy | 3.0 | 2.0 | -1.0 |
| Cross-module tracing | 3.0 | 2.7 | -0.3 |
| Approach quality | 3.0 | 2.0 | -1.0 |
| Tool efficiency | 0.0 | 2.0 | +2.0 |

## Files

- `benchmarks/README.md` - Conventions and how to reproduce
- `benchmarks/v1/` - Flawed v1 benchmark (preserved for reference)
- `benchmarks/v2/conditions.json` - Full reproducibility metadata (session IDs, tokens, wall times)
- `benchmarks/v2/ground-truth.md` - Expected answers for scoring
- `benchmarks/v2/prompt-control.md` - Exact control prompt used
- `benchmarks/v2/prompt-treatment.md` - Exact treatment prompt used
- `benchmarks/v2/results.md` - Raw scores, metrics comparison, analysis

Closes #64