### PR TITLE
feat(output): enhance output quality across analysis modes

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -5,6 +5,7 @@ use crate::parser::{ElementExtractor, SemanticExtractor};
 use crate::traversal::{WalkEntry, walk_directory};
 use crate::types::{AnalysisMode, FileInfo, SemanticAnalysis};
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -61,7 +62,7 @@ pub fn analyze_directory_with_progress(
     let file_entries: Vec<&WalkEntry> = entries.iter().filter(|e| !e.is_dir).collect();
 
     // Parallel analysis of files
-    let analysis_results: Vec<FileInfo> = file_entries
+    let results: Vec<(FileInfo, String, Option<SemanticAnalysis>)> = file_entries
         .par_iter()
         .filter_map(|entry| {
             // Check cancellation per file
@@ -88,31 +89,49 @@ pub fn analyze_directory_with_progress(
             let line_count = source.lines().count();
 
             // Detect language and extract counts
-            let (language, function_count, class_count) = if let Some(ext_str) = ext {
+            let (language, function_count, class_count, semantic) = if let Some(ext_str) = ext {
                 if let Some(lang) = language_from_extension(ext_str) {
                     let lang_str = lang.to_string();
                     match ElementExtractor::extract_with_depth(&source, &lang_str) {
-                        Ok((func_count, class_count)) => (lang_str, func_count, class_count),
-                        Err(_) => (lang_str, 0, 0),
+                        Ok((func_count, class_count)) => {
+                            // Also extract semantic data for module summary
+                            let semantic =
+                                SemanticExtractor::extract(&source, &lang_str, None).ok();
+                            (lang_str, func_count, class_count, semantic)
+                        }
+                        Err(_) => (lang_str, 0, 0, None),
                     }
                 } else {
-                    ("unknown".to_string(), 0, 0)
+                    ("unknown".to_string(), 0, 0, None)
                 }
             } else {
-                ("unknown".to_string(), 0, 0)
+                ("unknown".to_string(), 0, 0, None)
             };
 
             progress.fetch_add(1, Ordering::Relaxed);
 
-            Some(FileInfo {
-                path: path_str,
+            let file_info = FileInfo {
+                path: path_str.clone(),
                 line_count,
                 function_count,
                 class_count,
                 language,
-            })
+            };
+
+            Some((file_info, path_str, semantic))
         })
         .collect();
+
+    // Separate results into analysis_results and semantic_map
+    let mut analysis_results = Vec::new();
+    let mut semantic_map = HashMap::new();
+
+    for (file_info, path_str, semantic) in results {
+        analysis_results.push(file_info);
+        if let Some(sem) = semantic {
+            semantic_map.insert(path_str, sem);
+        }
+    }
 
     // Check if cancelled after parallel processing
     if ct.is_cancelled() {
@@ -120,7 +139,7 @@ pub fn analyze_directory_with_progress(
     }
 
     // Format output
-    let formatted = format_structure(&entries, &analysis_results, max_depth);
+    let formatted = format_structure(&entries, &analysis_results, max_depth, &semantic_map);
 
     Ok(AnalysisOutput {
         formatted,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -17,6 +17,7 @@ pub fn format_structure(
     entries: &[WalkEntry],
     analysis_results: &[FileInfo],
     max_depth: Option<u32>,
+    semantic_map: &HashMap<String, SemanticAnalysis>,
 ) -> String {
     let mut output = String::new();
 
@@ -104,11 +105,27 @@ pub fn format_structure(
                     info_parts.push(format!("{}C", analysis.class_count));
                 }
 
-                if info_parts.is_empty() {
-                    output.push_str(&format!("{}{}\n", indent, name));
+                let path_str = entry.path.display().to_string();
+                let mut line = if info_parts.is_empty() {
+                    format!("{}{}", indent, name)
                 } else {
-                    output.push_str(&format!("{}{} [{}]\n", indent, name, info_parts.join(", ")));
+                    format!("{}{} [{}]", indent, name, info_parts.join(", "))
+                };
+
+                // Append module summary if semantic data is available
+                if let Some(semantic) = semantic_map.get(&path_str) {
+                    // Find the largest class (first one if multiple)
+                    if let Some(class) = semantic.classes.first() {
+                        let import_count = semantic.imports.len();
+                        line.push_str(&format!(" | {}, {} deps", class.name, import_count));
+                    } else if !semantic.imports.is_empty() {
+                        // No classes but has imports
+                        let import_count = semantic.imports.len();
+                        line.push_str(&format!(" | {} deps", import_count));
+                    }
                 }
+
+                output.push_str(&format!("{}\n", line));
             }
             // Skip files not in analysis_map (binary/unreadable files)
         } else {
@@ -185,22 +202,19 @@ pub fn format_file_details(path: &str, analysis: &SemanticAnalysis, line_count: 
         }
     }
 
-    // I: section with imports grouped by module
+    // I: section with full import paths
     if !analysis.imports.is_empty() {
         output.push_str("I:\n");
-        let mut module_map: HashMap<String, usize> = HashMap::new();
+        let mut import_paths: Vec<String> = Vec::new();
         for import in &analysis.imports {
-            module_map
-                .entry(import.module.clone())
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
+            for item in &import.items {
+                import_paths.push(format!("{}::{}", import.module, item));
+            }
         }
-
-        let mut modules: Vec<_> = module_map.keys().collect();
-        modules.sort();
-        for module in modules {
-            let count = module_map[module];
-            output.push_str(&format!("  {} ({})\n", module, count));
+        import_paths.sort();
+        import_paths.dedup();
+        for path in import_paths {
+            output.push_str(&format!("  {}\n", path));
         }
     }
 
@@ -233,11 +247,18 @@ pub fn format_focused(
     // DEPTH section
     output.push_str(&format!("DEPTH: {}\n", follow_depth));
 
-    // DEFINED section - show where the symbol is defined
+    // DEFINED section - show where the symbol is defined with kind
     if let Some(definitions) = graph.definitions.get(symbol) {
         output.push_str("DEFINED:\n");
-        for (path, line) in definitions {
-            output.push_str(&format!("  {}:{}\n", path.display(), line));
+        for (path, line, kind) in definitions {
+            let kind_str = match kind {
+                crate::types::DefinitionKind::Function => "function",
+                crate::types::DefinitionKind::Struct => "struct",
+                crate::types::DefinitionKind::Trait => "trait",
+                crate::types::DefinitionKind::Enum => "enum",
+                crate::types::DefinitionKind::Method => "method",
+            };
+            output.push_str(&format!("  {}:{} ({})\n", path.display(), line, kind_str));
         }
     } else {
         output.push_str("DEFINED: (not found)\n");
@@ -260,13 +281,14 @@ pub fn format_focused(
         }
     }
 
-    // CALLEES section - what this symbol calls
+    // CALLEES section - what this symbol calls (capped at 25)
     let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
     output.push_str("CALLEES:\n");
     if outgoing_chains.is_empty() {
         output.push_str("  (none)\n");
     } else {
-        for chain in &outgoing_chains {
+        let display_count = outgoing_chains.len().min(25);
+        for chain in &outgoing_chains[..display_count] {
             let chain_str = chain
                 .chain
                 .iter()
@@ -274,6 +296,10 @@ pub fn format_focused(
                 .collect::<Vec<_>>()
                 .join(" -> ");
             output.push_str(&format!("  {}\n", chain_str));
+        }
+        if outgoing_chains.len() > 25 {
+            let remaining = outgoing_chains.len() - 25;
+            output.push_str(&format!("  ... and {} more\n", remaining));
         }
     }
 
@@ -297,7 +323,7 @@ pub fn format_focused(
         }
     }
     if let Some(definitions) = graph.definitions.get(symbol) {
-        for (path, _) in definitions {
+        for (path, _, _) in definitions {
             files.insert(path.clone());
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-use crate::types::SemanticAnalysis;
+use crate::types::{DefinitionKind, SemanticAnalysis};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use thiserror::Error;
@@ -19,7 +19,7 @@ pub struct CallChain {
 pub struct CallGraph {
     pub callers: HashMap<String, Vec<(PathBuf, usize, String)>>,
     pub callees: HashMap<String, Vec<(PathBuf, usize, String)>>,
-    pub definitions: HashMap<String, Vec<(PathBuf, usize)>>,
+    pub definitions: HashMap<String, Vec<(PathBuf, usize, DefinitionKind)>>,
 }
 
 impl CallGraph {
@@ -43,14 +43,14 @@ impl CallGraph {
                     .definitions
                     .entry(func.name.clone())
                     .or_default()
-                    .push((path.clone(), func.line));
+                    .push((path.clone(), func.line, DefinitionKind::Function));
             }
             for class in &analysis.classes {
                 graph
                     .definitions
                     .entry(class.name.clone())
                     .or_default()
-                    .push((path.clone(), class.line));
+                    .push((path.clone(), class.line, class.kind.clone()));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,7 @@ impl CodeAnalyzer {
                             end_line: c.end_line,
                             methods: c.methods.clone(),
                             fields: c.fields.clone(),
+                            kind: c.kind.clone(),
                         })
                         .collect();
                     let references = output.semantic.references.clone();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use crate::languages::get_language_info;
 use crate::types::{
-    CallInfo, ClassInfo, FunctionInfo, ImportInfo, ReferenceInfo, ReferenceType, SemanticAnalysis,
+    CallInfo, ClassInfo, DefinitionKind, FunctionInfo, ImportInfo, ReferenceInfo, ReferenceType,
+    SemanticAnalysis,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -193,6 +194,22 @@ fn extract_imports_from_node(
     }
 }
 
+/// Detect the definition kind from a tree-sitter node.
+fn detect_definition_kind(node: &Node) -> DefinitionKind {
+    match node.kind() {
+        "struct_item" => DefinitionKind::Struct,
+        "trait_item" => DefinitionKind::Trait,
+        "enum_item" => DefinitionKind::Enum,
+        _ => {
+            tracing::warn!(
+                node_kind = node.kind(),
+                "unknown class-like node kind, defaulting to Struct"
+            );
+            DefinitionKind::Struct
+        }
+    }
+}
+
 pub struct SemanticExtractor;
 
 impl SemanticExtractor {
@@ -288,12 +305,14 @@ impl SemanticExtractor {
                         if let Some(name_node) = node.child_by_field_name("name") {
                             let name =
                                 source[name_node.start_byte()..name_node.end_byte()].to_string();
+                            let kind = detect_definition_kind(&node);
                             classes.push(ClassInfo {
                                 name,
                                 line: node.start_position().row + 1,
                                 end_line: node.end_position().row + 1,
                                 methods: Vec::new(),
                                 fields: Vec::new(),
+                                kind,
                             });
                         }
                     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,12 +70,29 @@ pub struct FunctionInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DefinitionKind {
+    #[schemars(description = "Function definition")]
+    Function,
+    #[schemars(description = "Struct definition")]
+    Struct,
+    #[schemars(description = "Trait definition")]
+    Trait,
+    #[schemars(description = "Enum definition")]
+    Enum,
+    #[schemars(description = "Method definition")]
+    Method,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClassInfo {
     pub name: String,
     pub line: usize,
     pub end_line: usize,
     pub methods: Vec<FunctionInfo>,
     pub fields: Vec<String>,
+    #[schemars(description = "Kind of definition (struct, trait, enum)")]
+    pub kind: DefinitionKind,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1208,3 +1208,226 @@ fn test_cancellation_noop_after_completion() {
     let output = result.unwrap();
     assert_eq!(output.files.len(), 1);
 }
+
+// Tests for enhanced output quality (issue #66, Phase 1)
+
+/// Helper struct to encapsulate test setup and context
+struct TestContext {
+    _temp_dir: TempDir,
+    dir_output: code_analyze_mcp::analyze::AnalysisOutput,
+    semantic_results: Vec<(
+        std::path::PathBuf,
+        code_analyze_mcp::types::SemanticAnalysis,
+    )>,
+}
+
+/// Setup helper: creates TempDir, writes Rust source, analyzes directory and files
+fn setup_rust_test(source: &str) -> TestContext {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("lib.rs");
+    fs::write(&file_path, source).unwrap();
+
+    let dir_output = analyze_directory(temp_dir.path(), None).unwrap();
+    let mut semantic_results = Vec::new();
+    for file in &dir_output.files {
+        let file_output = analyze_file(&file.path, None).unwrap();
+        semantic_results.push((std::path::PathBuf::from(&file.path), file_output.semantic));
+    }
+
+    TestContext {
+        _temp_dir: temp_dir,
+        dir_output,
+        semantic_results,
+    }
+}
+
+#[test]
+fn test_format_file_details_full_import_paths() {
+    // Arrange: Create a Rust file with multiple imports
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.rs");
+
+    let rust_code = r#"
+use std::collections::HashMap;
+use std::io::Write;
+use serde::Serialize;
+
+fn main() {
+    let map = HashMap::new();
+}
+"#;
+    fs::write(&file_path, rust_code).unwrap();
+
+    // Act: Analyze the file
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Assert: Verify full import paths are shown (module::item format)
+    assert!(output.formatted.contains("I:"));
+    assert!(output.formatted.contains("std::collections::HashMap"));
+    assert!(output.formatted.contains("std::io::Write"));
+    assert!(output.formatted.contains("serde::Serialize"));
+    // Verify old format (module with count) is NOT present
+    assert!(!output.formatted.contains("std::collections ("));
+}
+
+#[test]
+fn test_format_file_details_no_imports() {
+    // Arrange: Create a Rust file with no imports
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.rs");
+
+    let rust_code = r#"
+fn main() {
+    println!("Hello");
+}
+"#;
+    fs::write(&file_path, rust_code).unwrap();
+
+    // Act: Analyze the file
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Assert: Verify I: section is omitted when no imports
+    assert!(!output.formatted.contains("I:"));
+}
+
+#[test]
+fn test_format_focused_definition_kind_struct() {
+    // Arrange
+    let rust_code = r#"
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn distance(p: Point) -> f64 {
+    0.0
+}
+"#;
+    let ctx = setup_rust_test(rust_code);
+
+    // Act
+    let graph =
+        code_analyze_mcp::graph::CallGraph::build_from_results(ctx.semantic_results).unwrap();
+    let formatted = code_analyze_mcp::formatter::format_focused(&graph, "Point", 1).unwrap();
+
+    // Assert
+    assert!(formatted.contains("DEFINED:"));
+    assert!(formatted.contains("(struct)"));
+}
+
+#[test]
+fn test_format_focused_definition_kind_trait() {
+    // Arrange
+    let rust_code = r#"
+trait Drawable {
+    fn draw(&self);
+}
+
+fn render(obj: &dyn Drawable) {
+    obj.draw();
+}
+"#;
+    let ctx = setup_rust_test(rust_code);
+
+    // Act
+    let graph =
+        code_analyze_mcp::graph::CallGraph::build_from_results(ctx.semantic_results).unwrap();
+    let formatted = code_analyze_mcp::formatter::format_focused(&graph, "Drawable", 1).unwrap();
+
+    // Assert
+    assert!(formatted.contains("DEFINED:"));
+    assert!(formatted.contains("(trait)"));
+}
+
+#[test]
+fn test_format_focused_definition_kind_enum() {
+    // Arrange
+    let rust_code = r#"
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+fn describe(c: Color) -> &'static str {
+    "color"
+}
+"#;
+    let ctx = setup_rust_test(rust_code);
+
+    // Act
+    let graph =
+        code_analyze_mcp::graph::CallGraph::build_from_results(ctx.semantic_results).unwrap();
+    let formatted = code_analyze_mcp::formatter::format_focused(&graph, "Color", 1).unwrap();
+
+    // Assert
+    assert!(formatted.contains("DEFINED:"));
+    assert!(formatted.contains("(enum)"));
+}
+
+#[test]
+fn test_format_focused_chain_limiting() {
+    // Arrange
+    let rust_code = r#"
+fn hub() {
+    a(); b(); c(); d(); e(); f(); g(); h(); i(); j();
+    k(); l(); m(); n(); o(); p(); q(); r(); s(); t();
+    u(); v(); w(); x(); y(); z();
+    a1(); b1(); c1(); d1(); e1(); f1(); g1(); h1(); i1(); j1();
+    k1(); l1(); m1(); n1(); o1(); p1(); q1(); r1(); s1(); t1();
+    u1(); v1(); w1(); x1(); y1(); z1();
+}
+
+fn a() {} fn b() {} fn c() {} fn d() {} fn e() {}
+fn f() {} fn g() {} fn h() {} fn i() {} fn j() {}
+fn k() {} fn l() {} fn m() {} fn n() {} fn o() {}
+fn p() {} fn q() {} fn r() {} fn s() {} fn t() {}
+fn u() {} fn v() {} fn w() {} fn x() {} fn y() {}
+fn z() {} fn a1() {} fn b1() {} fn c1() {} fn d1() {}
+fn e1() {} fn f1() {} fn g1() {} fn h1() {} fn i1() {}
+fn j1() {} fn k1() {} fn l1() {} fn m1() {} fn n1() {}
+fn o1() {} fn p1() {} fn q1() {} fn r1() {} fn s1() {}
+fn t1() {} fn u1() {} fn v1() {} fn w1() {} fn x1() {}
+fn y1() {} fn z1() {}
+"#;
+    let ctx = setup_rust_test(rust_code);
+
+    // Act
+    let graph =
+        code_analyze_mcp::graph::CallGraph::build_from_results(ctx.semantic_results).unwrap();
+    let formatted = code_analyze_mcp::formatter::format_focused(&graph, "hub", 1).unwrap();
+
+    // Assert
+    assert!(formatted.contains("CALLEES:"));
+    let callees_section = formatted.split("CALLEES:").nth(1).unwrap_or("");
+    let callees_lines = callees_section
+        .split('\n')
+        .take_while(|l| !l.starts_with("STATISTICS:"))
+        .count();
+    assert!(callees_lines <= 27);
+    assert!(formatted.contains("... and"));
+}
+
+#[test]
+fn test_format_structure_with_classes_and_imports() {
+    // Arrange
+    let rust_code = r#"
+use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
+
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn create_user() -> User {
+    User { name: "Alice".to_string(), age: 30 }
+}
+"#;
+    let ctx = setup_rust_test(rust_code);
+
+    // Act & Assert
+    assert!(ctx.dir_output.formatted.contains("lib.rs"));
+    assert!(ctx.dir_output.formatted.contains("1C"));
+    assert!(ctx.dir_output.formatted.contains("1F"));
+}


### PR DESCRIPTION
## Summary

Enhances output quality across all three analysis modes, addressing Phase 1 of issue #66.

### Changes

**FileDetails mode:**
- Full import paths (`module::item`) instead of module counts in the `I:` section

**SymbolFocus mode:**
- Definition kind (`struct`, `trait`, `enum`, `function`) shown in the `DEFINED:` section
- Outgoing call chains capped at 25 with `... and N more` truncation message

**Overview mode:**
- Module summary appended per file line: dominant class name and dependency count (e.g. `| User, 3 deps`)
- Requires collecting `SemanticAnalysis` data in the analysis pipeline and passing to `format_structure`

**Infrastructure:**
- `DefinitionKind` enum added to `types.rs` (Function, Struct, Trait, Enum, Method)
- `ClassInfo.kind` field carries definition kind from parser through to formatter
- `CallGraph.definitions` tuple extended to `(PathBuf, usize, DefinitionKind)`
- `tracing::warn!` for unknown class-like node kinds in `detect_definition_kind`
- `TestContext` helper and `setup_rust_test()` function reduce test boilerplate

### Testing

- 7 new integration tests covering all formatter changes
- All tests use inline Rust source in TempDir (project pattern)
- 59 tests pass across all targets, 0 failures
- `cargo clippy`, `cargo fmt`, `cargo deny` all clean

### Deviations from issue #66

- Trait impl and `dyn` dispatch detection deferred to Phase 2 (as planned)
- Test-to-code ratio is 1.70x (budget 1.5x); the chain-limiting test inherently requires ~52 lines of fixture data to exercise the 25-chain cap

Closes #66