### PR TITLE
feat(logging): add structured tracing events at pipeline decision points

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -8,6 +8,7 @@ use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
@@ -59,6 +60,9 @@ pub fn analyze_directory_with_progress(
 
     // Detect language from file extension
     let file_entries: Vec<&WalkEntry> = entries.iter().filter(|e| !e.is_dir).collect();
+
+    let start = Instant::now();
+    tracing::debug!(file_count = file_entries.len(), root = %root.display(), "analysis start");
 
     // Parallel analysis of files
     let analysis_results: Vec<FileInfo> = file_entries
@@ -119,6 +123,12 @@ pub fn analyze_directory_with_progress(
         return Err(AnalyzeError::Cancelled);
     }
 
+    tracing::debug!(
+        file_count = file_entries.len(),
+        duration_ms = start.elapsed().as_millis() as u64,
+        "analysis complete"
+    );
+
     // Format output
     let formatted = format_structure(&entries, &analysis_results, max_depth);
 
@@ -159,6 +169,7 @@ pub fn analyze_file(
     path: &str,
     ast_recursion_limit: Option<usize>,
 ) -> Result<FileAnalysisOutput, AnalyzeError> {
+    let start = Instant::now();
     let source = std::fs::read_to_string(path)
         .map_err(|e| AnalyzeError::Parser(crate::parser::ParserError::ParseError(e.to_string())))?;
 
@@ -182,6 +193,8 @@ pub fn analyze_file(
 
     // Format output
     let formatted = format_file_details(path, &semantic, line_count);
+
+    tracing::debug!(path = %path, language = %ext, functions = semantic.functions.len(), classes = semantic.classes.len(), imports = semantic.imports.len(), duration_ms = start.elapsed().as_millis() as u64, "file analysis complete");
 
     Ok(FileAnalysisOutput {
         formatted,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -76,6 +76,17 @@ impl CallGraph {
             }
         }
 
+        let total_edges = graph.callees.values().map(|v| v.len()).sum::<usize>()
+            + graph.callers.values().map(|v| v.len()).sum::<usize>();
+        let file_count = results.len();
+
+        tracing::debug!(
+            definitions = graph.definitions.len(),
+            edges = total_edges,
+            files = file_count,
+            "graph built"
+        );
+
         Ok(graph)
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,7 +3,7 @@ use rmcp::RoleServer;
 use rmcp::model::{
     LoggingLevel, LoggingMessageNotificationParam, Notification, ServerNotification,
 };
-use serde_json::json;
+use serde_json::{Map, Value};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Mutex as TokioMutex;
 use tracing::span::Attributes;
@@ -58,9 +58,9 @@ where
         }
         drop(filter_level);
 
-        // Extract message from the event using a visitor.
-        let mut message = String::new();
-        let mut visitor = MessageVisitor(&mut message);
+        // Extract fields from the event using a visitor that collects into a Map.
+        let mut fields = Map::new();
+        let mut visitor = MessageVisitor(&mut fields);
         event.record(&mut visitor);
 
         let mcp_level = level_to_mcp(&level);
@@ -68,7 +68,7 @@ where
         // Spawn async task to send notification without blocking on_event.
         let peer = self.peer.clone();
         let logger = target.to_string();
-        let msg = message.clone();
+        let data = Value::Object(fields);
 
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
@@ -78,7 +78,7 @@ where
                         Notification::new(LoggingMessageNotificationParam {
                             level: mcp_level,
                             logger: Some(logger),
-                            data: json!(msg),
+                            data,
                         }),
                     );
                     if let Err(e) = peer.send_notification(notification).await {
@@ -106,23 +106,33 @@ where
     fn on_new_span(&self, _attrs: &Attributes<'_>, _id: &tracing::span::Id, _ctx: Context<'_, S>) {}
 }
 
-/// Visitor to extract message from tracing event.
-struct MessageVisitor<'a>(&'a mut String);
+/// Visitor to extract fields from tracing event into a JSON Map.
+struct MessageVisitor<'a>(&'a mut Map<String, Value>);
 
 impl<'a> tracing::field::Visit for MessageVisitor<'a> {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "message" {
-            self.0.push_str(&format!("{:?}", value));
-        } else {
-            self.0.push_str(&format!("{}={:?}", field.name(), value));
-        }
+        self.0.insert(
+            field.name().to_string(),
+            Value::String(format!("{:?}", value)),
+        );
     }
 
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == "message" {
-            self.0.push_str(value);
-        } else {
-            self.0.push_str(&format!("{}={}", field.name(), value));
-        }
+        self.0
+            .insert(field.name().to_string(), Value::String(value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.0
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.0.insert(field.name().to_string(), Value::Bool(value));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -63,6 +63,8 @@ impl ElementExtractor {
             }
         }
 
+        tracing::debug!(language = %language, functions = function_count, classes = class_count, "parse complete");
+
         Ok((function_count, class_count))
     }
 }
@@ -456,6 +458,8 @@ impl SemanticExtractor {
                 }
             }
         }
+
+        tracing::debug!(language = %language, functions = functions.len(), classes = classes.len(), imports = imports.len(), references = references.len(), calls = calls.len(), "extraction complete");
 
         Ok(SemanticAnalysis {
             functions,

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -1,5 +1,6 @@
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 use thiserror::Error;
 use tracing::instrument;
 
@@ -25,6 +26,7 @@ pub fn walk_directory(
     root: &Path,
     max_depth: Option<u32>,
 ) -> Result<Vec<WalkEntry>, TraversalError> {
+    let start = Instant::now();
     let mut builder = WalkBuilder::new(root);
     builder.hidden(true).standard_filters(true);
 
@@ -65,6 +67,17 @@ pub fn walk_directory(
             }
         }
     }
+
+    let dir_count = entries.iter().filter(|e| e.is_dir).count();
+    let file_count = entries.iter().filter(|e| !e.is_dir).count();
+
+    tracing::debug!(
+        entries = entries.len(),
+        dirs = dir_count,
+        files = file_count,
+        duration_ms = start.elapsed().as_millis() as u64,
+        "walk complete"
+    );
 
     Ok(entries)
 }


### PR DESCRIPTION
## Summary

Add 7 structured `tracing::debug!` events at key analysis pipeline decision points and fix `McpLoggingLayer` to emit structured JSON objects in the MCP `data` field.

## Changes

### McpLoggingLayer fix (src/logging.rs)
- Refactored `MessageVisitor` to collect tracing fields into a `serde_json::Map<String, Value>` instead of concatenating into a flat string
- `data` field now emits structured JSON objects (e.g., `{"file_count": 42, "duration_ms": 15}`) per MCP spec

### 7 new tracing::debug! events
| Location | Event | Fields |
|----------|-------|--------|
| `walk_directory` | walk complete | entries, dirs, files, duration_ms |
| `analyze_directory_with_progress` | analysis start | file_count, root |
| `analyze_directory_with_progress` | analysis complete | file_count, duration_ms |
| `analyze_file` | file analysis complete | path, language, functions, classes, imports, duration_ms |
| `ElementExtractor::extract_with_depth` | parse complete | language, functions, classes |
| `SemanticExtractor::extract` | extraction complete | language, functions, classes, imports, references, calls |
| `CallGraph::build_from_results` | graph built | definitions, edges, files |

## Performance
- All events use `tracing::debug!` (zero-cost at INFO level)
- No events in hot paths (par_iter loops, tree-sitter node traversal)
- Duration measured with `std::time::Instant` at function boundaries only
- No new dependencies

## Testing
- All 44 existing tests pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean

Closes #68