### PR TITLE
fix(main): await RunningService to keep MCP server alive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let analyzer = CodeAnalyzer::new(peer, log_level_filter, event_rx);
     let (stdin, stdout) = stdio();
 
-    serve_server(analyzer, (stdin, stdout)).await?;
+    let service = serve_server(analyzer, (stdin, stdout)).await?;
+    service.waiting().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

One-line fix: await the `RunningService` returned by `serve_server()` so the MCP server stays alive after the handshake.

## Root Cause

`serve_server()` returns a `RunningService` that processes MCP requests in a background tokio task. The old code discarded it immediately with `;`, causing the `RunningService` to be dropped and the background task cancelled. The server completed the MCP handshake (initialize/initialized) then exited cleanly (exit code 0, no errors) before it could respond to any tool calls.

## Evidence

1. Goose logs showed `WARN: Failed to list tools, extension: "code-analyze-mcp", error: "Transport closed"` on every delegate spawn
2. Python MCP handshake test confirmed: server alive after `initialize` response, dead after `initialized` notification (returncode=0, no stderr)
3. After the fix, a goose delegate with `"extensions": ["code-analyze-mcp"]` gets `code-analyze-mcp__analyze` and uses it successfully

## Changes

```diff
-    serve_server(analyzer, (stdin, stdout)).await?;
+    let service = serve_server(analyzer, (stdin, stdout)).await?;
+    service.waiting().await?;
```

## Testing

- `cargo test`: 47 passed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- Manual: delegate with `["code-analyze-mcp"]` extension receives and uses `code-analyze-mcp__analyze`

Closes #74