### PR TITLE
feat(mcp): add outputSchema and structuredContent to tool responses

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -6,6 +6,8 @@ use crate::test_detection::is_test_file;
 use crate::traversal::{WalkEntry, walk_directory};
 use crate::types::{AnalysisMode, FileInfo, SemanticAnalysis};
 use rayon::prelude::*;
+use schemars::JsonSchema;
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -29,17 +31,22 @@ pub enum AnalyzeError {
 }
 
 /// Result of directory analysis containing both formatted output and file data.
-#[derive(Debug)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct AnalysisOutput {
+    #[schemars(description = "Formatted text representation of the analysis")]
     pub formatted: String,
+    #[schemars(description = "List of files analyzed in the directory")]
     pub files: Vec<FileInfo>,
 }
 
 /// Result of file-level semantic analysis.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct FileAnalysisOutput {
+    #[schemars(description = "Formatted text representation of the analysis")]
     pub formatted: String,
+    #[schemars(description = "Semantic analysis data including functions, classes, and imports")]
     pub semantic: SemanticAnalysis,
+    #[schemars(description = "Total line count of the analyzed file")]
     pub line_count: usize,
 }
 
@@ -211,8 +218,9 @@ pub fn analyze_file(
 }
 
 /// Result of focused symbol analysis.
-#[derive(Debug)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct FocusedAnalysisOutput {
+    #[schemars(description = "Formatted text representation of the call graph analysis")]
     pub formatted: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,12 @@ pub mod types;
 use cache::AnalysisCache;
 use logging::LogEvent;
 use rmcp::handler::server::tool::ToolRouter;
-use rmcp::handler::server::wrapper::Parameters;
+use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
-    Annotated, CallToolResult, CancelledNotificationParam, CompleteRequestParams, CompleteResult,
-    CompletionInfo, ErrorData, Implementation, InitializeResult, LoggingLevel,
-    LoggingMessageNotificationParam, Notification, NumberOrString, ProgressNotificationParam,
-    ProgressToken, ProtocolVersion, RawContent, ServerCapabilities, ServerNotification,
-    SetLevelRequestParams,
+    CancelledNotificationParam, CompleteRequestParams, CompleteResult, CompletionInfo, ErrorData,
+    Implementation, InitializeResult, LoggingLevel, LoggingMessageNotificationParam, Notification,
+    NumberOrString, ProgressNotificationParam, ProgressToken, ProtocolVersion, ServerCapabilities,
+    ServerNotification, SetLevelRequestParams,
 };
 use rmcp::service::{NotificationContext, RequestContext};
 use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -30,7 +29,7 @@ use tokio::sync::{Mutex as TokioMutex, mpsc};
 use tracing::{instrument, warn};
 use tracing_subscriber::filter::LevelFilter;
 use traversal::walk_directory;
-use types::{AnalysisMode, AnalyzeParams};
+use types::{AnalysisMode, AnalysisResponse, AnalyzeParams};
 
 #[derive(Clone)]
 pub struct CodeAnalyzer {
@@ -95,7 +94,7 @@ impl CodeAnalyzer {
         &self,
         params: Parameters<AnalyzeParams>,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<Json<AnalysisResponse>, ErrorData> {
         let params = params.0;
         let ct = context.ct.clone();
 
@@ -360,36 +359,74 @@ impl CodeAnalyzer {
             }
         };
 
-        // Extract formatted_output from ModeResult
-        let formatted_output = match mode_result {
-            types::ModeResult::Overview(output) => output.formatted,
-            types::ModeResult::FileDetails(output) => output.formatted,
-            types::ModeResult::SymbolFocus(output) => output.formatted,
+        // Convert ModeResult to AnalysisResponse
+        let response = match mode_result {
+            types::ModeResult::Overview(output) => {
+                // Apply output size limiting
+                let line_count = output.formatted.lines().count();
+                if line_count > 1000 && params.force != Some(true) {
+                    let estimated_tokens = line_count * 40;
+                    let message = format!(
+                        "Output exceeds 1000 lines ({} lines, ~{} tokens). Use one of:\n\
+                         - force=true to return full output\n\
+                         - Narrow your scope (smaller directory, specific file)\n\
+                         - Use symbol_focus mode for targeted analysis\n\
+                         - Reduce max_depth parameter",
+                        line_count, estimated_tokens
+                    );
+                    return Err(ErrorData::new(
+                        rmcp::model::ErrorCode::INVALID_REQUEST,
+                        message,
+                        None,
+                    ));
+                }
+                AnalysisResponse::Overview(output)
+            }
+            types::ModeResult::FileDetails(output) => {
+                // Apply output size limiting
+                let line_count = output.formatted.lines().count();
+                if line_count > 1000 && params.force != Some(true) {
+                    let estimated_tokens = line_count * 40;
+                    let message = format!(
+                        "Output exceeds 1000 lines ({} lines, ~{} tokens). Use one of:\n\
+                         - force=true to return full output\n\
+                         - Narrow your scope (smaller directory, specific file)\n\
+                         - Use symbol_focus mode for targeted analysis\n\
+                         - Reduce max_depth parameter",
+                        line_count, estimated_tokens
+                    );
+                    return Err(ErrorData::new(
+                        rmcp::model::ErrorCode::INVALID_REQUEST,
+                        message,
+                        None,
+                    ));
+                }
+                AnalysisResponse::FileDetails(output)
+            }
+            types::ModeResult::SymbolFocus(output) => {
+                // Apply output size limiting
+                let line_count = output.formatted.lines().count();
+                if line_count > 1000 && params.force != Some(true) {
+                    let estimated_tokens = line_count * 40;
+                    let message = format!(
+                        "Output exceeds 1000 lines ({} lines, ~{} tokens). Use one of:\n\
+                         - force=true to return full output\n\
+                         - Narrow your scope (smaller directory, specific file)\n\
+                         - Use symbol_focus mode for targeted analysis\n\
+                         - Reduce max_depth parameter",
+                        line_count, estimated_tokens
+                    );
+                    return Err(ErrorData::new(
+                        rmcp::model::ErrorCode::INVALID_REQUEST,
+                        message,
+                        None,
+                    ));
+                }
+                AnalysisResponse::SymbolFocus(output)
+            }
         };
 
-        // Apply output size limiting
-        let line_count = formatted_output.lines().count();
-        if line_count > 1000 && params.force != Some(true) {
-            let estimated_tokens = line_count * 40;
-            let message = format!(
-                "Output exceeds 1000 lines ({} lines, ~{} tokens). Use one of:\n\
-                 - force=true to return full output\n\
-                 - Narrow your scope (smaller directory, specific file)\n\
-                 - Use symbol_focus mode for targeted analysis\n\
-                 - Reduce max_depth parameter",
-                line_count, estimated_tokens
-            );
-            return Err(ErrorData::new(
-                rmcp::model::ErrorCode::INVALID_REQUEST,
-                message,
-                None,
-            ));
-        }
-
-        Ok(CallToolResult::success(vec![Annotated {
-            raw: RawContent::text(formatted_output),
-            annotations: None,
-        }]))
+        Ok(Json(response))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,22 @@ pub enum ModeResult {
     SymbolFocus(FocusedAnalysisOutput),
 }
 
+/// Response envelope for analysis results, tagged by mode.
+/// Wraps the three analysis output types with a mode discriminator.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(tag = "mode")]
+pub enum AnalysisResponse {
+    #[serde(rename = "overview")]
+    #[schemars(description = "Directory overview analysis")]
+    Overview(AnalysisOutput),
+    #[serde(rename = "file_details")]
+    #[schemars(description = "File-level semantic analysis")]
+    FileDetails(FileAnalysisOutput),
+    #[serde(rename = "symbol_focus")]
+    #[schemars(description = "Symbol call graph analysis")]
+    SymbolFocus(FocusedAnalysisOutput),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeParams {
     #[schemars(description = "Path to the file or directory to analyze")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use code_analyze_mcp::analyze::{
 use code_analyze_mcp::cache::{AnalysisCache, CacheKey};
 use code_analyze_mcp::completion::{path_completions, symbol_completions};
 use code_analyze_mcp::traversal::walk_directory;
-use code_analyze_mcp::types::AnalysisMode;
+use code_analyze_mcp::types::{AnalysisMode, AnalysisResponse};
 use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1623,4 +1623,92 @@ fn test_format_structure_partitions_test_files() {
         output.formatted.contains("main.rs"),
         "Production file should be listed in PATH section"
     );
+}
+
+// AnalysisResponse serialization tests
+
+#[test]
+fn test_analysis_response_overview_serialization() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Arrange: Create a simple Rust file
+    fs::write(root.join("lib.rs"), "fn hello() {}\nfn world() {}").unwrap();
+
+    // Act: Analyze directory to get AnalysisOutput
+    let analysis_output = analyze_directory(root, None).unwrap();
+
+    // Convert to AnalysisResponse
+    let response = AnalysisResponse::Overview(analysis_output);
+
+    // Serialize to JSON
+    let json_value = serde_json::to_value(&response).unwrap();
+
+    // Assert: JSON has mode tag
+    assert_eq!(
+        json_value.get("mode").and_then(|v| v.as_str()),
+        Some("overview")
+    );
+
+    // Assert: JSON contains files array
+    assert!(json_value.get("files").is_some());
+    let files = json_value.get("files").unwrap();
+    assert!(files.is_array());
+
+    // Assert: JSON contains formatted field
+    assert!(json_value.get("formatted").is_some());
+    let formatted = json_value.get("formatted").unwrap();
+    assert!(formatted.is_string());
+    assert!(formatted.as_str().unwrap().contains("SUMMARY:"));
+}
+
+#[test]
+fn test_analysis_response_file_details_serialization() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.rs");
+
+    // Arrange: Create a Rust file with semantic content
+    let rust_code = r#"
+use std::collections::HashMap;
+
+fn calculate(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+"#;
+    fs::write(&file_path, rust_code).unwrap();
+
+    // Act: Analyze file to get FileAnalysisOutput
+    let analysis_output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Convert to AnalysisResponse
+    let response = AnalysisResponse::FileDetails(analysis_output);
+
+    // Serialize to JSON
+    let json_value = serde_json::to_value(&response).unwrap();
+
+    // Assert: JSON has mode tag
+    assert_eq!(
+        json_value.get("mode").and_then(|v| v.as_str()),
+        Some("file_details")
+    );
+
+    // Assert: JSON contains semantic field with functions
+    assert!(json_value.get("semantic").is_some());
+    let semantic = json_value.get("semantic").unwrap();
+    assert!(semantic.get("functions").is_some());
+
+    // Assert: JSON contains formatted field
+    assert!(json_value.get("formatted").is_some());
+    let formatted = json_value.get("formatted").unwrap();
+    assert!(formatted.is_string());
+    assert!(formatted.as_str().unwrap().contains("FILE:"));
+
+    // Assert: JSON contains line_count field
+    assert!(json_value.get("line_count").is_some());
+    assert!(json_value.get("line_count").unwrap().is_number());
 }


### PR DESCRIPTION
## Summary

Add `outputSchema` to the analyze tool definition and `structuredContent` to `CallToolResult` responses, leveraging rmcp 0.17's `Json<T>` wrapper for automatic schema generation and structured content population.

Closes #91

## Changes

- **src/analyze.rs**: Add `Serialize` + `JsonSchema` derives to `AnalysisOutput`, `FileAnalysisOutput`, and `FocusedAnalysisOutput` with `#[schemars(description = "...")]` on all fields
- **src/types.rs**: Define `AnalysisResponse` enum with three variants (`Overview`, `FileDetails`, `SymbolFocus`) using `#[serde(tag = "mode")]` for clean JSON discriminator
- **src/lib.rs**: Change `analyze()` return type from `Result<CallToolResult, ErrorData>` to `Result<Json<AnalysisResponse>, ErrorData>`; rmcp auto-generates `outputSchema` from `AnalysisResponse`'s `JsonSchema` impl and populates `structured_content` via `CallToolResult::structured()`
- **tests/integration_tests.rs**: Add serialization tests for Overview and FileDetails modes verifying JSON structure

## How It Works

rmcp 0.17's `Json<T>` wrapper (`rmcp::handler::server::wrapper::Json`):
1. Auto-generates `outputSchema` from `T`'s `JsonSchema` implementation
2. Serializes `T` to `serde_json::Value` and calls `CallToolResult::structured(value)`
3. `structured()` sets both `content` (text fallback) and `structured_content` (JSON)

## Testing

- `cargo test`: 54 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean

## Acceptance Criteria

- [x] outputSchema defined for the analyze tool (auto-generated from `AnalysisResponse`'s `JsonSchema`)
- [x] structuredContent included in tool responses alongside text content
- [x] Schema matches the actual response structure (same type used for both)
- [x] Backward compatible: text content still present for clients that do not support structuredContent
- [x] Integration tests verify structured responses
- [x] All tests pass
- [x] No clippy warnings
- [x] Code formatted
- [x] Commit GPG signed and DCO signed-off