### PR TITLE
feat(formatter): implement summary-first responses for large codebases

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -37,6 +37,10 @@ pub struct AnalysisOutput {
     pub formatted: String,
     #[schemars(description = "List of files analyzed in the directory")]
     pub files: Vec<FileInfo>,
+    /// Walk entries used internally for summary generation; not serialized.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub entries: Vec<WalkEntry>,
 }
 
 /// Result of file-level semantic analysis.
@@ -146,6 +150,7 @@ pub fn analyze_directory_with_progress(
     Ok(AnalysisOutput {
         formatted,
         files: analysis_results,
+        entries,
     })
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -405,3 +405,141 @@ pub fn format_focused(
 
     Ok(output)
 }
+
+/// Format a compact summary for large directory analysis results.
+/// Used when output would exceed the size threshold or when explicitly requested.
+#[instrument(skip_all)]
+pub fn format_summary(
+    entries: &[WalkEntry],
+    analysis_results: &[FileInfo],
+    max_depth: Option<u32>,
+) -> String {
+    let mut output = String::new();
+
+    // Partition files into production and test
+    let (prod_files, test_files): (Vec<_>, Vec<_>) =
+        analysis_results.iter().partition(|a| !a.is_test);
+
+    // Calculate totals
+    let total_loc: usize = analysis_results.iter().map(|a| a.line_count).sum();
+    let total_functions: usize = analysis_results.iter().map(|a| a.function_count).sum();
+    let total_classes: usize = analysis_results.iter().map(|a| a.class_count).sum();
+
+    // Count files by language
+    let mut lang_counts: HashMap<String, usize> = HashMap::new();
+    for analysis in analysis_results {
+        *lang_counts.entry(analysis.language.clone()).or_insert(0) += 1;
+    }
+    let total_files = analysis_results.len();
+
+    // SUMMARY block
+    output.push_str("SUMMARY:\n");
+    let depth_label = match max_depth {
+        Some(n) if n > 0 => format!(" (max_depth={})", n),
+        _ => String::new(),
+    };
+    output.push_str(&format!(
+        "{} files ({} prod, {} test), {}L, {}F, {}C{}\n",
+        total_files,
+        prod_files.len(),
+        test_files.len(),
+        total_loc,
+        total_functions,
+        total_classes,
+        depth_label
+    ));
+
+    if !lang_counts.is_empty() {
+        output.push_str("Languages: ");
+        let mut langs: Vec<_> = lang_counts.iter().collect();
+        langs.sort_by_key(|&(name, _)| name);
+        let lang_strs: Vec<String> = langs
+            .iter()
+            .map(|(name, count)| {
+                let percentage = if total_files > 0 {
+                    (**count * 100) / total_files
+                } else {
+                    0
+                };
+                format!("{} ({}%)", name, percentage)
+            })
+            .collect();
+        output.push_str(&lang_strs.join(", "));
+        output.push('\n');
+    }
+
+    output.push('\n');
+
+    // STRUCTURE (depth 1) block
+    output.push_str("STRUCTURE (depth 1):\n");
+
+    // Build a map of path -> analysis for quick lookup
+    let analysis_map: HashMap<String, &FileInfo> = analysis_results
+        .iter()
+        .map(|a| (a.path.clone(), a))
+        .collect();
+
+    // Collect depth-1 entries (directories and files at depth 1)
+    let mut depth1_entries: Vec<&WalkEntry> = entries.iter().filter(|e| e.depth == 1).collect();
+    depth1_entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    for entry in depth1_entries {
+        let name = entry
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?");
+
+        if entry.is_dir {
+            // For directories, aggregate stats from all files under this directory
+            let dir_path_str = entry.path.display().to_string();
+            let files_in_dir: Vec<&FileInfo> = analysis_results
+                .iter()
+                .filter(|f| f.path.starts_with(&dir_path_str))
+                .collect();
+
+            if !files_in_dir.is_empty() {
+                let dir_file_count = files_in_dir.len();
+                let dir_loc: usize = files_in_dir.iter().map(|f| f.line_count).sum();
+                let dir_functions: usize = files_in_dir.iter().map(|f| f.function_count).sum();
+                let dir_classes: usize = files_in_dir.iter().map(|f| f.class_count).sum();
+
+                output.push_str(&format!(
+                    "  {}/ [{} files, {}L, {}F, {}C]\n",
+                    name, dir_file_count, dir_loc, dir_functions, dir_classes
+                ));
+            } else {
+                output.push_str(&format!("  {}/\n", name));
+            }
+        } else {
+            // For files, show individual stats
+            if let Some(analysis) = analysis_map.get(&entry.path.display().to_string()) {
+                let mut info_parts = Vec::new();
+
+                if analysis.line_count > 0 {
+                    info_parts.push(format!("{}L", analysis.line_count));
+                }
+                if analysis.function_count > 0 {
+                    info_parts.push(format!("{}F", analysis.function_count));
+                }
+                if analysis.class_count > 0 {
+                    info_parts.push(format!("{}C", analysis.class_count));
+                }
+
+                if info_parts.is_empty() {
+                    output.push_str(&format!("  {}\n", name));
+                } else {
+                    output.push_str(&format!("  {} [{}]\n", name, info_parts.join(", ")));
+                }
+            }
+        }
+    }
+
+    output.push('\n');
+
+    // SUGGESTION block
+    output.push_str("SUGGESTION:\n");
+    output.push_str("Use a narrower path for details (e.g., analyze src/core/)\n");
+
+    output
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod traversal;
 pub mod types;
 
 use cache::AnalysisCache;
+use formatter::format_summary;
 use logging::LogEvent;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
@@ -181,6 +182,7 @@ impl CodeAnalyzer {
                         let output = analyze::AnalysisOutput {
                             formatted: "Analysis cancelled".to_string(),
                             files: vec![],
+                            entries: vec![],
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -188,6 +190,7 @@ impl CodeAnalyzer {
                         let output = analyze::AnalysisOutput {
                             formatted: format!("Error analyzing directory: {}", e),
                             files: vec![],
+                            entries: vec![],
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -195,6 +198,7 @@ impl CodeAnalyzer {
                         let output = analyze::AnalysisOutput {
                             formatted: format!("Task join error: {}", e),
                             files: vec![],
+                            entries: vec![],
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -361,25 +365,33 @@ impl CodeAnalyzer {
 
         // Convert ModeResult to AnalysisResponse
         let response = match mode_result {
-            types::ModeResult::Overview(output) => {
-                // Apply output size limiting
+            types::ModeResult::Overview(mut output) => {
+                // Apply summary/output size limiting logic
                 let line_count = output.formatted.lines().count();
-                if line_count > 1000 && params.force != Some(true) {
-                    let estimated_tokens = line_count * 40;
-                    let message = format!(
-                        "Output exceeds 1000 lines ({} lines, ~{} tokens). Use one of:\n\
-                         - force=true to return full output\n\
-                         - Narrow your scope (smaller directory, specific file)\n\
-                         - Use symbol_focus mode for targeted analysis\n\
-                         - Reduce max_depth parameter",
-                        line_count, estimated_tokens
-                    );
-                    return Err(ErrorData::new(
-                        rmcp::model::ErrorCode::INVALID_REQUEST,
-                        message,
-                        None,
-                    ));
+
+                // Determine if we should use summary
+                let use_summary = if params.force == Some(true) {
+                    // force=true: return full output
+                    false
+                } else if params.summary == Some(true) {
+                    // summary=true: always generate summary
+                    true
+                } else if params.summary == Some(false) {
+                    // summary=false: return full output regardless of size
+                    false
+                } else if line_count > 1000 {
+                    // summary=None and large output: auto-detect and generate summary
+                    true
+                } else {
+                    // summary=None and small output: return full output
+                    false
+                };
+
+                if use_summary {
+                    output.formatted =
+                        format_summary(&output.entries, &output.files, params.max_depth);
                 }
+
                 AnalysisResponse::Overview(output)
             }
             types::ModeResult::FileDetails(output) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,6 +54,11 @@ pub struct AnalyzeParams {
 
     #[schemars(description = "Bypass output size limiting (default: false)")]
     pub force: Option<bool>,
+
+    #[schemars(
+        description = "Generate compact summary instead of full output. true=force summary, false=force full, unset=auto-detect on large output"
+    )]
+    pub summary: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1299,6 +1299,64 @@ async fn test_channel_closed_exits_consumer() {
     assert!(buffer.is_empty());
 }
 
+#[test]
+fn test_summary_auto_detect_large_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Create src/ subdirectory with 1100 .rs files
+    fs::create_dir(root.join("src")).unwrap();
+    for i in 0..1100 {
+        fs::write(root.join(format!("src/file_{:04}.rs", i)), "fn func() {}").unwrap();
+    }
+
+    // Analyze directory
+    let output = analyze_directory(root, None).unwrap();
+
+    // Generate summary
+    let summary = code_analyze_mcp::formatter::format_summary(&output.entries, &output.files, None);
+
+    // Assert summary contains expected sections
+    assert!(summary.contains("SUMMARY:"));
+    assert!(summary.contains("STRUCTURE (depth 1):"));
+    assert!(summary.contains("SUGGESTION:"));
+    assert!(summary.contains("1100 files"));
+    assert!(summary.contains("Languages:"));
+
+    // Assert summary is shorter than full output
+    let summary_lines = summary.lines().count();
+    let full_lines = output.formatted.lines().count();
+    assert!(
+        summary_lines < full_lines,
+        "Summary ({} lines) should be shorter than full output ({} lines)",
+        summary_lines,
+        full_lines
+    );
+}
+
+#[test]
+fn test_summary_explicit_on_small_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Create src/ subdirectory with 2 files
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+    fs::write(root.join("src/lib.rs"), "fn lib_fn() {}").unwrap();
+
+    // Analyze directory
+    let output = analyze_directory(root, None).unwrap();
+
+    // Generate summary
+    let summary = code_analyze_mcp::formatter::format_summary(&output.entries, &output.files, None);
+
+    // Assert summary contains expected sections
+    assert!(summary.contains("SUMMARY:"));
+    assert!(summary.contains("STRUCTURE (depth 1):"));
+    assert!(summary.contains("SUGGESTION:"));
+    assert!(summary.contains("2 files"));
+}
+
 // Reference extraction tests for Python, Java, and TypeScript
 
 #[test]


### PR DESCRIPTION
## Summary

Replace the hard error on large output (>1000 lines) with a compact summary response for Overview mode. Add `summary: Option<bool>` parameter to `AnalyzeParams` for explicit control.

## Changes

- **`src/types.rs`**: Add `summary: Option<bool>` to `AnalyzeParams` (`true`=force summary, `false`=force full, unset=auto-detect)
- **`src/analyze.rs`**: Add `entries: Vec<WalkEntry>` to `AnalysisOutput` (skipped in serialization, used for summary generation)
- **`src/formatter.rs`**: Add `format_summary()` function generating SUMMARY, STRUCTURE (depth 1), and SUGGESTION blocks
- **`src/lib.rs`**: Replace error-on-large-output with summary generation for Overview mode; FileDetails/SymbolFocus retain error behavior
- **`tests/integration_tests.rs`**: Add 2 integration tests (auto-detect large directory, explicit summary on small directory)

## Behavior

| `force` | `summary` | Output >1000 lines | Result |
|---------|-----------|-------------------|--------|
| `true` | any | any | Full output |
| `false`/unset | `true` | any | Summary |
| `false`/unset | `false` | any | Full output |
| `false`/unset | unset | yes | Summary (auto-detect) |
| `false`/unset | unset | no | Full output |

## Testing

- 56 tests pass (`cargo test`)
- Clippy clean (`cargo clippy -- -D warnings`)
- Formatted (`cargo fmt --check`)
- Deny clean (`cargo deny check advisories licenses`)
- Gitleaks clean

Closes #90