### PR TITLE
feat(pagination): add cursor-based pagination for large result sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ name = "code-analyze-mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "criterion",
  "ignore",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1"
 ignore = "0.4"
 lru = "0.16"
 serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
 serde_json = "1"
 schemars = { version = "1", features = ["derive"] }
 thiserror = "2.0.18"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -41,6 +41,11 @@ pub struct AnalysisOutput {
     #[serde(skip)]
     #[schemars(skip)]
     pub entries: Vec<WalkEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "Opaque cursor token for the next page of results (absent when no more results)"
+    )]
+    pub next_cursor: Option<String>,
 }
 
 /// Result of file-level semantic analysis.
@@ -52,6 +57,11 @@ pub struct FileAnalysisOutput {
     pub semantic: SemanticAnalysis,
     #[schemars(description = "Total line count of the analyzed file")]
     pub line_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "Opaque cursor token for the next page of results (absent when no more results)"
+    )]
+    pub next_cursor: Option<String>,
 }
 
 /// Analyze a directory structure with progress tracking.
@@ -151,6 +161,7 @@ pub fn analyze_directory_with_progress(
         formatted,
         files: analysis_results,
         entries,
+        next_cursor: None,
     })
 }
 
@@ -219,6 +230,7 @@ pub fn analyze_file(
         formatted,
         semantic,
         line_count,
+        next_cursor: None,
     })
 }
 
@@ -227,6 +239,11 @@ pub fn analyze_file(
 pub struct FocusedAnalysisOutput {
     #[schemars(description = "Formatted text representation of the call graph analysis")]
     pub formatted: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        description = "Opaque cursor token for the next page of results (absent when no more results)"
+    )]
+    pub next_cursor: Option<String>,
 }
 
 /// Analyze a symbol's call graph across a directory with progress tracking.
@@ -250,7 +267,10 @@ pub fn analyze_focused_with_progress(
         let formatted =
             "Single-file focus not supported. Please provide a directory path for cross-file call graph analysis.\n"
                 .to_string();
-        return Ok(FocusedAnalysisOutput { formatted });
+        return Ok(FocusedAnalysisOutput {
+            formatted,
+            next_cursor: None,
+        });
     }
 
     // Walk the directory
@@ -315,7 +335,10 @@ pub fn analyze_focused_with_progress(
     // Format output
     let formatted = format_focused(&graph, focus, follow_depth)?;
 
-    Ok(FocusedAnalysisOutput { formatted })
+    Ok(FocusedAnalysisOutput {
+        formatted,
+        next_cursor: None,
+    })
 }
 
 /// Analyze a symbol's call graph across a directory.

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -543,3 +543,61 @@ pub fn format_summary(
 
     output
 }
+
+/// Format a paginated subset of files for Overview mode.
+#[instrument(skip_all)]
+pub fn format_structure_paginated(
+    paginated_files: &[FileInfo],
+    total_files: usize,
+    max_depth: Option<u32>,
+) -> String {
+    let mut output = String::new();
+
+    let depth_label = match max_depth {
+        Some(n) if n > 0 => format!(" (max_depth={})", n),
+        _ => String::new(),
+    };
+    output.push_str(&format!(
+        "PAGINATED: showing {} of {} files{}\n\n",
+        paginated_files.len(),
+        total_files,
+        depth_label
+    ));
+
+    let prod_files: Vec<&FileInfo> = paginated_files.iter().filter(|f| !f.is_test).collect();
+    let test_files: Vec<&FileInfo> = paginated_files.iter().filter(|f| f.is_test).collect();
+
+    if !prod_files.is_empty() {
+        output.push_str("FILES [LOC, FUNCTIONS, CLASSES]\n");
+        for file in &prod_files {
+            output.push_str(&format_file_entry(file));
+        }
+    }
+
+    if !test_files.is_empty() {
+        output.push_str("\nTEST FILES [LOC, FUNCTIONS, CLASSES]\n");
+        for file in &test_files {
+            output.push_str(&format_file_entry(file));
+        }
+    }
+
+    output
+}
+
+fn format_file_entry(file: &FileInfo) -> String {
+    let mut parts = Vec::new();
+    if file.line_count > 0 {
+        parts.push(format!("{}L", file.line_count));
+    }
+    if file.function_count > 0 {
+        parts.push(format!("{}F", file.function_count));
+    }
+    if file.class_count > 0 {
+        parts.push(format!("{}C", file.class_count));
+    }
+    if parts.is_empty() {
+        format!("{}\n", file.path)
+    } else {
+        format!("{} [{}]\n", file.path, parts.join(", "))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,16 @@ pub mod graph;
 pub mod lang;
 pub mod languages;
 pub mod logging;
+pub mod pagination;
 pub mod parser;
 pub mod test_detection;
 pub mod traversal;
 pub mod types;
 
 use cache::AnalysisCache;
-use formatter::format_summary;
+use formatter::{format_structure_paginated, format_summary};
 use logging::LogEvent;
+use pagination::{DEFAULT_PAGE_SIZE, decode_cursor, paginate_slice};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
@@ -183,6 +185,7 @@ impl CodeAnalyzer {
                             formatted: "Analysis cancelled".to_string(),
                             files: vec![],
                             entries: vec![],
+                            next_cursor: None,
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -191,6 +194,7 @@ impl CodeAnalyzer {
                             formatted: format!("Error analyzing directory: {}", e),
                             files: vec![],
                             entries: vec![],
+                            next_cursor: None,
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -199,6 +203,7 @@ impl CodeAnalyzer {
                             formatted: format!("Task join error: {}", e),
                             files: vec![],
                             entries: vec![],
+                            next_cursor: None,
                         };
                         types::ModeResult::Overview(output)
                     }
@@ -251,6 +256,7 @@ impl CodeAnalyzer {
                                 calls: vec![],
                             },
                             line_count: 0,
+                            next_cursor: None,
                         };
                         types::ModeResult::FileDetails(output)
                     }
@@ -344,18 +350,21 @@ impl CodeAnalyzer {
                     Ok(Err(analyze::AnalyzeError::Cancelled)) => {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: "Analysis cancelled".to_string(),
+                            next_cursor: None,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
                     Ok(Err(e)) => {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Error analyzing symbol focus: {}", e),
+                            next_cursor: None,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
                     Err(e) => {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Task join error: {}", e),
+                            next_cursor: None,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
@@ -363,7 +372,18 @@ impl CodeAnalyzer {
             }
         };
 
-        // Convert ModeResult to AnalysisResponse
+        // Decode pagination cursor if provided
+        let page_size = params.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let offset = if let Some(ref cursor_str) = params.cursor {
+            let cursor_data = decode_cursor(cursor_str).map_err(|e| {
+                ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, e.to_string(), None)
+            })?;
+            cursor_data.offset
+        } else {
+            0
+        };
+
+        // Convert ModeResult to AnalysisResponse with pagination
         let response = match mode_result {
             types::ModeResult::Overview(mut output) => {
                 // Apply summary/output size limiting logic
@@ -371,20 +391,13 @@ impl CodeAnalyzer {
 
                 // Determine if we should use summary
                 let use_summary = if params.force == Some(true) {
-                    // force=true: return full output
                     false
                 } else if params.summary == Some(true) {
-                    // summary=true: always generate summary
                     true
                 } else if params.summary == Some(false) {
-                    // summary=false: return full output regardless of size
                     false
-                } else if line_count > 1000 {
-                    // summary=None and large output: auto-detect and generate summary
-                    true
                 } else {
-                    // summary=None and small output: return full output
-                    false
+                    line_count > 1000
                 };
 
                 if use_summary {
@@ -392,9 +405,24 @@ impl CodeAnalyzer {
                         format_summary(&output.entries, &output.files, params.max_depth);
                 }
 
+                // Apply pagination to files
+                let paginated = paginate_slice(&output.files, offset, page_size).map_err(|e| {
+                    ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
+                })?;
+
+                if paginated.next_cursor.is_some() || offset > 0 {
+                    output.formatted = format_structure_paginated(
+                        &paginated.items,
+                        paginated.total,
+                        params.max_depth,
+                    );
+                }
+                output.files = paginated.items;
+                output.next_cursor = paginated.next_cursor;
+
                 AnalysisResponse::Overview(output)
             }
-            types::ModeResult::FileDetails(output) => {
+            types::ModeResult::FileDetails(mut output) => {
                 // Apply output size limiting
                 let line_count = output.formatted.lines().count();
                 if line_count > 1000 && params.force != Some(true) {
@@ -413,6 +441,15 @@ impl CodeAnalyzer {
                         None,
                     ));
                 }
+
+                // Paginate functions (typically the largest collection)
+                let paginated = paginate_slice(&output.semantic.functions, offset, page_size)
+                    .map_err(|e| {
+                        ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
+                    })?;
+                output.semantic.functions = paginated.items;
+                output.next_cursor = paginated.next_cursor;
+
                 AnalysisResponse::FileDetails(output)
             }
             types::ModeResult::SymbolFocus(output) => {
@@ -434,6 +471,7 @@ impl CodeAnalyzer {
                         None,
                     ));
                 }
+                // SymbolFocus: no semantic data to paginate
                 AnalysisResponse::SymbolFocus(output)
             }
         };

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -1,0 +1,153 @@
+use base64::engine::general_purpose::STANDARD;
+use base64::{DecodeError, engine::Engine};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub const DEFAULT_PAGE_SIZE: usize = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorData {
+    pub mode: String,
+    pub offset: usize,
+}
+
+#[derive(Debug, Error)]
+pub enum PaginationError {
+    #[error("Invalid cursor: {0}")]
+    InvalidCursor(String),
+}
+
+impl From<DecodeError> for PaginationError {
+    fn from(err: DecodeError) -> Self {
+        PaginationError::InvalidCursor(format!("Base64 decode error: {}", err))
+    }
+}
+
+impl From<serde_json::Error> for PaginationError {
+    fn from(err: serde_json::Error) -> Self {
+        PaginationError::InvalidCursor(format!("JSON parse error: {}", err))
+    }
+}
+
+pub fn encode_cursor(data: &CursorData) -> Result<String, PaginationError> {
+    let json = serde_json::to_string(data)?;
+    Ok(STANDARD.encode(json))
+}
+
+pub fn decode_cursor(cursor: &str) -> Result<CursorData, PaginationError> {
+    let decoded = STANDARD.decode(cursor)?;
+    let json_str = String::from_utf8(decoded)
+        .map_err(|e| PaginationError::InvalidCursor(format!("UTF-8 decode error: {}", e)))?;
+    Ok(serde_json::from_str(&json_str)?)
+}
+
+#[derive(Debug, Clone)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+    pub total: usize,
+}
+
+pub fn paginate_slice<T: Clone>(
+    items: &[T],
+    offset: usize,
+    page_size: usize,
+) -> Result<PaginationResult<T>, PaginationError> {
+    let total = items.len();
+
+    if offset >= total {
+        return Ok(PaginationResult {
+            items: vec![],
+            next_cursor: None,
+            total,
+        });
+    }
+
+    let end = std::cmp::min(offset + page_size, total);
+    let page_items = items[offset..end].to_vec();
+
+    let next_cursor = if end < total {
+        let cursor_data = CursorData {
+            mode: "default".to_string(),
+            offset: end,
+        };
+        Some(encode_cursor(&cursor_data)?)
+    } else {
+        None
+    };
+
+    Ok(PaginationResult {
+        items: page_items,
+        next_cursor,
+        total,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cursor_encode_decode_roundtrip() {
+        let original = CursorData {
+            mode: "overview".to_string(),
+            offset: 42,
+        };
+
+        let encoded = encode_cursor(&original).expect("encode failed");
+        let decoded = decode_cursor(&encoded).expect("decode failed");
+
+        assert_eq!(decoded.mode, original.mode);
+        assert_eq!(decoded.offset, original.offset);
+    }
+
+    #[test]
+    fn test_paginate_slice_middle_page() {
+        let items: Vec<i32> = (0..250).collect();
+        let result = paginate_slice(&items, 100, 100).expect("paginate failed");
+
+        assert_eq!(result.items.len(), 100);
+        assert_eq!(result.items[0], 100);
+        assert_eq!(result.items[99], 199);
+        assert!(result.next_cursor.is_some());
+        assert_eq!(result.total, 250);
+    }
+
+    #[test]
+    fn test_paginate_slice_empty_and_beyond() {
+        let empty: Vec<i32> = vec![];
+        let result = paginate_slice(&empty, 0, 100).expect("paginate failed");
+        assert_eq!(result.items.len(), 0);
+        assert!(result.next_cursor.is_none());
+        assert_eq!(result.total, 0);
+
+        let items: Vec<i32> = (0..50).collect();
+        let result = paginate_slice(&items, 100, 100).expect("paginate failed");
+        assert_eq!(result.items.len(), 0);
+        assert!(result.next_cursor.is_none());
+        assert_eq!(result.total, 50);
+    }
+
+    #[test]
+    fn test_paginate_slice_exact_boundary() {
+        let items: Vec<i32> = (0..200).collect();
+        let result = paginate_slice(&items, 100, 100).expect("paginate failed");
+
+        assert_eq!(result.items.len(), 100);
+        assert_eq!(result.items[0], 100);
+        assert!(result.next_cursor.is_none());
+        assert_eq!(result.total, 200);
+    }
+
+    #[test]
+    fn test_invalid_cursor_error() {
+        let result = decode_cursor("not-valid-base64!!!");
+        assert!(result.is_err());
+        match result {
+            Err(PaginationError::InvalidCursor(msg)) => {
+                assert!(msg.contains("Base64") || msg.contains("decode"));
+            }
+            _ => panic!("Expected InvalidCursor error"),
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,14 @@ pub struct AnalyzeParams {
         description = "Generate compact summary instead of full output. true=force summary, false=force full, unset=auto-detect on large output"
     )]
     pub summary: Option<bool>,
+
+    #[schemars(
+        description = "Opaque cursor token for pagination (from previous response's next_cursor)"
+    )]
+    pub cursor: Option<String>,
+
+    #[schemars(description = "Number of items per page (default: 100)")]
+    pub page_size: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1770,3 +1770,49 @@ struct Point {
     assert!(json_value.get("line_count").is_some());
     assert!(json_value.get("line_count").unwrap().is_number());
 }
+
+// Pagination integration tests
+
+#[test]
+fn test_overview_pagination_multi_page() {
+    use code_analyze_mcp::pagination::{decode_cursor, paginate_slice};
+
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    for i in 0..150 {
+        fs::write(root.join(format!("file_{:03}.rs", i)), "fn f() {}").unwrap();
+    }
+
+    let output = analyze_directory(root, None).unwrap();
+    assert_eq!(output.files.len(), 150);
+
+    let result = paginate_slice(&output.files, 0, 100).expect("paginate failed");
+    assert_eq!(result.items.len(), 100);
+    assert!(result.next_cursor.is_some());
+    assert_eq!(result.total, 150);
+
+    let cursor = result.next_cursor.unwrap();
+    let cursor_data = decode_cursor(&cursor).expect("decode failed");
+    let result2 = paginate_slice(&output.files, cursor_data.offset, 100).expect("paginate failed");
+    assert_eq!(result2.items.len(), 50);
+    assert!(result2.next_cursor.is_none());
+}
+
+#[test]
+fn test_single_page_no_cursor() {
+    use code_analyze_mcp::pagination::paginate_slice;
+
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    for i in 0..50 {
+        fs::write(root.join(format!("file_{:03}.rs", i)), "fn f() {}").unwrap();
+    }
+
+    let output = analyze_directory(root, None).unwrap();
+    let result = paginate_slice(&output.files, 0, 100).expect("paginate failed");
+    assert_eq!(result.items.len(), 50);
+    assert!(result.next_cursor.is_none());
+    assert_eq!(result.total, 50);
+}


### PR DESCRIPTION
## Summary

Add opaque cursor-based pagination using base64-encoded JSON tokens for large result sets. Implements MCP-style `nextCursor` pattern.

## Changes

- **New module** `src/pagination.rs`: `CursorData` struct, `encode_cursor`/`decode_cursor` (base64 JSON), generic `paginate_slice<T>`, `DEFAULT_PAGE_SIZE=100`, `PaginationError` type
- **`AnalyzeParams`**: added optional `cursor` and `page_size` fields
- **Output structs**: added `next_cursor: Option<String>` with `skip_serializing_if` to `AnalysisOutput`, `FileAnalysisOutput`, `FocusedAnalysisOutput`
- **Overview mode**: paginates `files` vec, re-formats with `format_structure_paginated`
- **FileDetails mode**: paginates `functions` vec
- **SymbolFocus mode**: passes through (no semantic data to paginate)
- **Backward compatible**: no cursor = first page; `next_cursor` omitted from JSON when absent

## Testing

- 5 unit tests in `src/pagination.rs` (encode/decode roundtrip, paginate_slice edge cases, invalid cursor)
- 2 integration tests (multi-page overview with 150 files, single-page with 50 files)
- All 58 tests pass, clippy clean, fmt clean, deny clean

## Dependencies

- Added `base64 = "0.22"` (already a transitive dependency via rmcp)

Closes #92