### PR TITLE
perf(formatter): compact R: section and add overview summary line

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -44,6 +44,25 @@ pub fn format_structure(
     }
     let total_files = analysis_results.len();
 
+    // Leading summary line with totals
+    let primary_lang = lang_counts
+        .iter()
+        .max_by_key(|&(_, count)| count)
+        .map(|(name, count)| {
+            let percentage = if total_files > 0 {
+                (*count * 100) / total_files
+            } else {
+                0
+            };
+            format!("{} {}%", name, percentage)
+        })
+        .unwrap_or_else(|| "unknown 0%".to_string());
+
+    output.push_str(&format!(
+        "{} files, {}L, {}F, {}C ({})\n",
+        total_files, total_loc, total_functions, total_classes, primary_lang
+    ));
+
     // SUMMARY block
     output.push_str("SUMMARY:\n");
     let depth_label = match max_depth {
@@ -277,17 +296,6 @@ pub fn format_file_details(
         }
     }
 
-    // R: section with references and line numbers
-    if !analysis.references.is_empty() {
-        output.push_str("R:\n");
-        for reference in &analysis.references {
-            output.push_str(&format!(
-                "  {} (line {}, Usage)\n",
-                reference.symbol, reference.line
-            ));
-        }
-    }
-
     output
 }
 
@@ -431,6 +439,25 @@ pub fn format_summary(
         *lang_counts.entry(analysis.language.clone()).or_insert(0) += 1;
     }
     let total_files = analysis_results.len();
+
+    // Leading summary line with totals
+    let primary_lang = lang_counts
+        .iter()
+        .max_by_key(|&(_, count)| count)
+        .map(|(name, count)| {
+            let percentage = if total_files > 0 {
+                (*count * 100) / total_files
+            } else {
+                0
+            };
+            format!("{} {}%", name, percentage)
+        })
+        .unwrap_or_else(|| "unknown 0%".to_string());
+
+    output.push_str(&format!(
+        "{} files, {}L, {}F, {}C ({})\n",
+        total_files, total_loc, total_functions, total_classes, primary_lang
+    ));
 
     // SUMMARY block
     output.push_str("SUMMARY:\n");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -99,6 +99,13 @@ fn world() {
     let output = analyze_directory(root, None).unwrap();
 
     // Check that output contains expected sections with new format
+    // Verify leading summary line is present
+    assert!(
+        output.formatted.contains("1 files, ")
+            && output.formatted.contains("L, ")
+            && output.formatted.contains("F, ")
+            && output.formatted.contains("C (")
+    );
     assert!(output.formatted.contains("SUMMARY:"));
     assert!(output.formatted.contains("Shown:"));
     assert!(output.formatted.contains("PATH [LOC, FUNCTIONS, CLASSES]"));
@@ -114,6 +121,8 @@ fn test_analyze_directory_empty_directory() {
     let output = analyze_directory(root, None).unwrap();
 
     // Should still have SUMMARY and PATH sections with new format
+    // Verify leading summary line is present for empty directory
+    assert!(output.formatted.contains("0 files, 0L, 0F, 0C ("));
     assert!(output.formatted.contains("SUMMARY:"));
     assert!(output.formatted.contains("Shown: 0 files"));
     assert!(output.formatted.contains("PATH [LOC, FUNCTIONS, CLASSES]"));


### PR DESCRIPTION
## Summary

Combines #80 (compact R: section) and #81 (overview summary line) into a single PR. Part of the output verbosity epic (#77).

### Changes

**1. Remove R: (references) section from file_details output**

The R: section was low-value in single-file scope: all references share the same location, and symbol names are already visible in the I: (imports) and F: (function signatures) sections. PR #84 previously validated this finding when complex optimizations produced byte-identical output because file_details analyzes one file at a time.

**2. Add leading summary statistics line to overview output**

Both `format_structure()` and `format_summary()` now prepend a leading summary line before the SUMMARY: block:

```
52 files, 13223L, 672F, 171C (rust 100%)

SUMMARY:
Shown: 52 files (50 prod, 2 test), 13223L, 672F, 171C
...
```

This gives LLMs instant metrics without scanning the file list.

### Files changed

- `src/formatter.rs` -- R: section removal + summary line addition
- `tests/integration_tests.rs` -- Updated assertions for new format

### Testing

- All 58 tests pass
- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo deny check advisories licenses`: clean
- No public API changes (SemanticAnalysis.references field still populated)

Closes #108