### PR TITLE
perf(output): return text-only MCP response, drop structured JSON

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@ use formatter::{format_structure_paginated, format_summary};
 use logging::LogEvent;
 use pagination::{DEFAULT_PAGE_SIZE, decode_cursor, paginate_slice};
 use rmcp::handler::server::tool::ToolRouter;
-use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CancelledNotificationParam, CompleteRequestParams, CompleteResult, CompletionInfo, ErrorData,
-    Implementation, InitializeResult, LoggingLevel, LoggingMessageNotificationParam, Notification,
-    NumberOrString, ProgressNotificationParam, ProgressToken, ProtocolVersion, ServerCapabilities,
-    ServerNotification, SetLevelRequestParams,
+    CallToolResult, CancelledNotificationParam, CompleteRequestParams, CompleteResult,
+    CompletionInfo, Content, ErrorData, Implementation, InitializeResult, LoggingLevel,
+    LoggingMessageNotificationParam, Notification, NumberOrString, ProgressNotificationParam,
+    ProgressToken, ProtocolVersion, ServerCapabilities, ServerNotification, SetLevelRequestParams,
 };
 use rmcp::service::{NotificationContext, RequestContext};
 use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -32,7 +32,7 @@ use tokio::sync::{Mutex as TokioMutex, mpsc};
 use tracing::{instrument, warn};
 use tracing_subscriber::filter::LevelFilter;
 use traversal::walk_directory;
-use types::{AnalysisMode, AnalysisResponse, AnalyzeParams};
+use types::{AnalysisMode, AnalyzeParams};
 
 #[derive(Clone)]
 pub struct CodeAnalyzer {
@@ -97,7 +97,7 @@ impl CodeAnalyzer {
         &self,
         params: Parameters<AnalyzeParams>,
         context: RequestContext<RoleServer>,
-    ) -> Result<Json<AnalysisResponse>, ErrorData> {
+    ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let ct = context.ct.clone();
 
@@ -383,8 +383,8 @@ impl CodeAnalyzer {
             0
         };
 
-        // Convert ModeResult to AnalysisResponse with pagination
-        let response = match mode_result {
+        // Convert ModeResult to text-only content with pagination
+        let (formatted_text, next_cursor) = match mode_result {
             types::ModeResult::Overview(mut output) => {
                 // Apply summary/output size limiting logic
                 let line_count = output.formatted.lines().count();
@@ -417,12 +417,10 @@ impl CodeAnalyzer {
                         params.max_depth,
                     );
                 }
-                output.files = paginated.items;
-                output.next_cursor = paginated.next_cursor;
 
-                AnalysisResponse::Overview(output)
+                (output.formatted, paginated.next_cursor)
             }
-            types::ModeResult::FileDetails(mut output) => {
+            types::ModeResult::FileDetails(output) => {
                 // Apply output size limiting
                 let line_count = output.formatted.lines().count();
                 if line_count > 1000 && params.force != Some(true) {
@@ -447,10 +445,8 @@ impl CodeAnalyzer {
                     .map_err(|e| {
                         ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
                     })?;
-                output.semantic.functions = paginated.items;
-                output.next_cursor = paginated.next_cursor;
 
-                AnalysisResponse::FileDetails(output)
+                (output.formatted, paginated.next_cursor)
             }
             types::ModeResult::SymbolFocus(output) => {
                 // Apply output size limiting
@@ -472,11 +468,18 @@ impl CodeAnalyzer {
                     ));
                 }
                 // SymbolFocus: no semantic data to paginate
-                AnalysisResponse::SymbolFocus(output)
+                (output.formatted, output.next_cursor)
             }
         };
 
-        Ok(Json(response))
+        // Build final text output with pagination cursor if present
+        let mut final_text = formatted_text;
+        if let Some(cursor) = next_cursor {
+            final_text.push('\n');
+            final_text.push_str(&format!("NEXT_CURSOR: {}", cursor));
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(final_text)]))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,22 +13,6 @@ pub enum ModeResult {
     SymbolFocus(FocusedAnalysisOutput),
 }
 
-/// Response envelope for analysis results, tagged by mode.
-/// Wraps the three analysis output types with a mode discriminator.
-#[derive(Debug, Serialize, JsonSchema)]
-#[serde(tag = "mode")]
-pub enum AnalysisResponse {
-    #[serde(rename = "overview")]
-    #[schemars(description = "Directory overview analysis")]
-    Overview(AnalysisOutput),
-    #[serde(rename = "file_details")]
-    #[schemars(description = "File-level semantic analysis")]
-    FileDetails(FileAnalysisOutput),
-    #[serde(rename = "symbol_focus")]
-    #[schemars(description = "Symbol call graph analysis")]
-    SymbolFocus(FocusedAnalysisOutput),
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeParams {
     #[schemars(description = "Path to the file or directory to analyze")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use code_analyze_mcp::analyze::{
 use code_analyze_mcp::cache::{AnalysisCache, CacheKey};
 use code_analyze_mcp::completion::{path_completions, symbol_completions};
 use code_analyze_mcp::traversal::walk_directory;
-use code_analyze_mcp::types::{AnalysisMode, AnalysisResponse};
+use code_analyze_mcp::types::AnalysisMode;
 use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1695,7 +1695,7 @@ fn test_format_structure_partitions_test_files() {
 // AnalysisResponse serialization tests
 
 #[test]
-fn test_analysis_response_overview_serialization() {
+fn test_analysis_output_overview_fields() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();
 
@@ -1705,32 +1705,16 @@ fn test_analysis_response_overview_serialization() {
     // Act: Analyze directory to get AnalysisOutput
     let analysis_output = analyze_directory(root, None).unwrap();
 
-    // Convert to AnalysisResponse
-    let response = AnalysisResponse::Overview(analysis_output);
+    // Assert: AnalysisOutput has formatted text
+    assert!(!analysis_output.formatted.is_empty());
+    assert!(analysis_output.formatted.contains("SUMMARY:"));
 
-    // Serialize to JSON
-    let json_value = serde_json::to_value(&response).unwrap();
-
-    // Assert: JSON has mode tag
-    assert_eq!(
-        json_value.get("mode").and_then(|v| v.as_str()),
-        Some("overview")
-    );
-
-    // Assert: JSON contains files array
-    assert!(json_value.get("files").is_some());
-    let files = json_value.get("files").unwrap();
-    assert!(files.is_array());
-
-    // Assert: JSON contains formatted field
-    assert!(json_value.get("formatted").is_some());
-    let formatted = json_value.get("formatted").unwrap();
-    assert!(formatted.is_string());
-    assert!(formatted.as_str().unwrap().contains("SUMMARY:"));
+    // Assert: AnalysisOutput has files array
+    assert!(!analysis_output.files.is_empty());
 }
 
 #[test]
-fn test_analysis_response_file_details_serialization() {
+fn test_analysis_output_file_details_fields() {
     let temp_dir = TempDir::new().unwrap();
     let file_path = temp_dir.path().join("test.rs");
 
@@ -1752,32 +1736,15 @@ struct Point {
     // Act: Analyze file to get FileAnalysisOutput
     let analysis_output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
 
-    // Convert to AnalysisResponse
-    let response = AnalysisResponse::FileDetails(analysis_output);
+    // Assert: FileAnalysisOutput has formatted text
+    assert!(!analysis_output.formatted.is_empty());
+    assert!(analysis_output.formatted.contains("FILE:"));
 
-    // Serialize to JSON
-    let json_value = serde_json::to_value(&response).unwrap();
+    // Assert: FileAnalysisOutput has semantic data with functions
+    assert!(!analysis_output.semantic.functions.is_empty());
 
-    // Assert: JSON has mode tag
-    assert_eq!(
-        json_value.get("mode").and_then(|v| v.as_str()),
-        Some("file_details")
-    );
-
-    // Assert: JSON contains semantic field with functions
-    assert!(json_value.get("semantic").is_some());
-    let semantic = json_value.get("semantic").unwrap();
-    assert!(semantic.get("functions").is_some());
-
-    // Assert: JSON contains formatted field
-    assert!(json_value.get("formatted").is_some());
-    let formatted = json_value.get("formatted").unwrap();
-    assert!(formatted.is_string());
-    assert!(formatted.as_str().unwrap().contains("FILE:"));
-
-    // Assert: JSON contains line_count field
-    assert!(json_value.get("line_count").is_some());
-    assert!(json_value.get("line_count").unwrap().is_number());
+    // Assert: FileAnalysisOutput has line_count
+    assert!(analysis_output.line_count > 0);
 }
 
 // Pagination integration tests


### PR DESCRIPTION
## Summary

Switch MCP tool return type from `Json<AnalysisResponse>` (sends full JSON as `structured_content` + `content`) to `CallToolResult::success(Content::text())` (sends only formatted text as `content`).

This eliminates dual serialization where the full JSON struct was serialized, transmitted, and ignored by LLMs that only read the `formatted` text field. Expected savings: **-40% output size**.

## Root Cause

Benchmark v3 (#69, PR #76) showed code-analyze-mcp costs 29% more tokens than `developer__analyze` for identical quality. The primary root cause is `Json<T>` in rmcp 0.17, which calls `CallToolResult::structured(value)` -- placing the full serialized struct in both `structured_content` (JSON) and `content` (JSON-as-text). The `formatted` field is buried inside this blob.

**Evidence:** Overview mode returns 416 chars as text vs 1594 chars as JSON (+283%). Both contain the same information.

## Changes

- **`src/types.rs`**: Remove `AnalysisResponse` enum (no longer needed for MCP wire format). `ModeResult` retained for internal dispatch.
- **`src/lib.rs`**: Change `analyze` tool return type from `Result<Json<AnalysisResponse>, ErrorData>` to `Result<CallToolResult, ErrorData>`. Extract formatted text from each `ModeResult` variant and return via `CallToolResult::success(vec![Content::text(text)])`. Pagination cursors appended as `NEXT_CURSOR: {cursor}` line when present.
- **`tests/integration_tests.rs`**: Update two serialization tests to verify internal types directly (`AnalysisOutput`, `FileAnalysisOutput`) instead of removed `AnalysisResponse` wrapper.

## What stays the same

- Internal types (`AnalysisOutput`, `FileAnalysisOutput`, `FocusedAnalysisOutput`, `SemanticAnalysis`) unchanged for programmatic access and testing
- `AnalyzeParams` (tool parameters) unchanged -- no breaking changes to tool interface
- All 58 existing tests pass

## Validation

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo deny check advisories licenses`: clean
- `cargo test`: 58 passed, 0 failed
- Security scan: 0 findings

## Next Steps

Benchmark re-run (v3 methodology, n=5, same task/model/prompt against lsd-rs/lsd) to measure actual token reduction against:
- Current: median 31,005 tokens, 80s wall time
- Target: < 24,000 tokens, < 65s wall time

Closes #78
Refs #77