### PR TITLE
feat(languages): add inheritance extraction for class hierarchies

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -240,7 +240,16 @@ pub fn format_file_details(
     if !analysis.classes.is_empty() {
         output.push_str("C:\n");
         for class in &analysis.classes {
-            output.push_str(&format!("  {}:{}\n", class.name, class.line));
+            if class.inherits.is_empty() {
+                output.push_str(&format!("  {}:{}\n", class.name, class.line));
+            } else {
+                output.push_str(&format!(
+                    "  {}:{} ({})\n",
+                    class.name,
+                    class.line,
+                    class.inherits.join(", ")
+                ));
+            }
         }
     }
 

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -51,3 +51,51 @@ pub fn find_method_for_receiver(
         }
     })
 }
+
+/// Extract inheritance information from a Go type node.
+pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
+    let mut inherits = Vec::new();
+
+    // Get the type field from type_spec
+    if let Some(type_field) = node.child_by_field_name("type") {
+        match type_field.kind() {
+            "struct_type" => {
+                // For struct embedding, walk children for field_declaration_list
+                for i in 0..type_field.named_child_count() {
+                    if let Some(field_list) = type_field.named_child(i as u32)
+                        && field_list.kind() == "field_declaration_list"
+                    {
+                        // Walk field_declaration_list for field_declaration without name
+                        for j in 0..field_list.named_child_count() {
+                            if let Some(field) = field_list.named_child(j as u32)
+                                && field.kind() == "field_declaration"
+                                && field.child_by_field_name("name").is_none()
+                            {
+                                // Embedded type has no name field
+                                if let Some(type_node) = field.child_by_field_name("type") {
+                                    let text =
+                                        &source[type_node.start_byte()..type_node.end_byte()];
+                                    inherits.push(text.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            "interface_type" => {
+                // For interface embedding, walk children for type_elem
+                for i in 0..type_field.named_child_count() {
+                    if let Some(elem) = type_field.named_child(i as u32)
+                        && elem.kind() == "type_elem"
+                    {
+                        let text = &source[elem.start_byte()..elem.end_byte()];
+                        inherits.push(text.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    inherits
+}

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -25,3 +25,40 @@ pub const REFERENCE_QUERY: &str = r#"
 pub const IMPORT_QUERY: &str = r#"
 (import_declaration) @import_path
 "#;
+
+use tree_sitter::Node;
+
+/// Extract inheritance information from a Java class node.
+pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
+    let mut inherits = Vec::new();
+
+    // Extract superclass (extends)
+    if let Some(superclass) = node.child_by_field_name("superclass") {
+        for i in 0..superclass.named_child_count() {
+            if let Some(child) = superclass.named_child(i as u32)
+                && child.kind() == "type_identifier"
+            {
+                let text = &source[child.start_byte()..child.end_byte()];
+                inherits.push(format!("extends {}", text));
+            }
+        }
+    }
+
+    // Extract interfaces (implements)
+    if let Some(interfaces) = node.child_by_field_name("interfaces") {
+        for i in 0..interfaces.named_child_count() {
+            if let Some(type_list) = interfaces.named_child(i as u32) {
+                for j in 0..type_list.named_child_count() {
+                    if let Some(type_node) = type_list.named_child(j as u32)
+                        && type_node.kind() == "type_identifier"
+                    {
+                        let text = &source[type_node.start_byte()..type_node.end_byte()];
+                        inherits.push(format!("implements {}", text));
+                    }
+                }
+            }
+        }
+    }
+
+    inherits
+}

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -15,6 +15,9 @@ pub type FindMethodForReceiverHandler = fn(&Node, &str, Option<usize>) -> Option
 /// Handler to find receiver type for a method.
 pub type FindReceiverTypeHandler = fn(&Node, &str) -> Option<String>;
 
+/// Handler to extract inheritance information from a class node.
+pub type ExtractInheritanceHandler = fn(&Node, &str) -> Vec<String>;
+
 /// Information about a supported language for code analysis.
 pub struct LanguageInfo {
     pub name: &'static str,
@@ -27,6 +30,7 @@ pub struct LanguageInfo {
     pub extract_function_name: Option<ExtractFunctionNameHandler>,
     pub find_method_for_receiver: Option<FindMethodForReceiverHandler>,
     pub find_receiver_type: Option<FindReceiverTypeHandler>,
+    pub extract_inheritance: Option<ExtractInheritanceHandler>,
 }
 
 /// Get language information by language name.
@@ -43,6 +47,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: Some(rust::extract_function_name),
             find_method_for_receiver: Some(rust::find_method_for_receiver),
             find_receiver_type: Some(rust::find_receiver_type),
+            extract_inheritance: Some(rust::extract_inheritance),
         }),
         "python" => Some(LanguageInfo {
             name: "python",
@@ -55,6 +60,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: None,
             find_method_for_receiver: None,
             find_receiver_type: None,
+            extract_inheritance: Some(python::extract_inheritance),
         }),
         "typescript" => Some(LanguageInfo {
             name: "typescript",
@@ -67,6 +73,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: None,
             find_method_for_receiver: None,
             find_receiver_type: None,
+            extract_inheritance: Some(typescript::extract_inheritance),
         }),
         "tsx" => Some(LanguageInfo {
             name: "tsx",
@@ -79,6 +86,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: None,
             find_method_for_receiver: None,
             find_receiver_type: None,
+            extract_inheritance: Some(typescript::extract_inheritance),
         }),
         "go" => Some(LanguageInfo {
             name: "go",
@@ -91,6 +99,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: None,
             find_method_for_receiver: Some(go::find_method_for_receiver),
             find_receiver_type: None,
+            extract_inheritance: Some(go::extract_inheritance),
         }),
         "java" => Some(LanguageInfo {
             name: "java",
@@ -103,6 +112,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             extract_function_name: None,
             find_method_for_receiver: None,
             find_receiver_type: None,
+            extract_inheritance: Some(java::extract_inheritance),
         }),
         _ => None,
     }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -27,3 +27,25 @@ pub const IMPORT_QUERY: &str = r#"
 (import_statement) @import_path
 (import_from_statement) @import_path
 "#;
+
+use tree_sitter::Node;
+
+/// Extract inheritance information from a Python class node.
+pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
+    let mut inherits = Vec::new();
+
+    // Get superclasses field from class_definition
+    if let Some(superclasses) = node.child_by_field_name("superclasses") {
+        // superclasses contains an argument_list
+        for i in 0..superclasses.named_child_count() {
+            if let Some(child) = superclasses.named_child(i as u32)
+                && matches!(child.kind(), "identifier" | "attribute")
+            {
+                let text = &source[child.start_byte()..child.end_byte()];
+                inherits.push(text.to_string());
+            }
+        }
+    }
+
+    inherits
+}

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -88,3 +88,10 @@ pub fn find_receiver_type(node: &Node, source: &str) -> Option<String> {
         }
     })
 }
+
+/// Extract inheritance information from a Rust class node.
+/// Rust class nodes (struct_item, enum_item, trait_item) have no syntactic inheritance.
+/// Inheritance is via impl blocks, not on the type declaration itself.
+pub fn extract_inheritance(_node: &Node, _source: &str) -> Vec<String> {
+    Vec::new()
+}

--- a/src/languages/typescript.rs
+++ b/src/languages/typescript.rs
@@ -26,3 +26,42 @@ pub const REFERENCE_QUERY: &str = r#"
 pub const IMPORT_QUERY: &str = r#"
 (import_statement) @import_path
 "#;
+
+use tree_sitter::Node;
+
+/// Extract inheritance information from a TypeScript class node.
+pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
+    let mut inherits = Vec::new();
+
+    // Walk children to find class_heritage node
+    for i in 0..node.named_child_count() {
+        if let Some(child) = node.named_child(i as u32)
+            && child.kind() == "class_heritage"
+        {
+            // Walk class_heritage children for extends_clause and implements_clause
+            for j in 0..child.named_child_count() {
+                if let Some(clause) = child.named_child(j as u32) {
+                    if clause.kind() == "extends_clause" {
+                        // Extract extends type
+                        if let Some(value) = clause.child_by_field_name("value") {
+                            let text = &source[value.start_byte()..value.end_byte()];
+                            inherits.push(format!("extends {}", text));
+                        }
+                    } else if clause.kind() == "implements_clause" {
+                        // Extract implements types
+                        for k in 0..clause.named_child_count() {
+                            if let Some(type_node) = clause.named_child(k as u32)
+                                && type_node.kind() == "type_identifier"
+                            {
+                                let text = &source[type_node.start_byte()..type_node.end_byte()];
+                                inherits.push(format!("implements {}", text));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    inherits
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -411,12 +411,18 @@ impl SemanticExtractor {
                         if let Some(name_node) = node.child_by_field_name("name") {
                             let name =
                                 source[name_node.start_byte()..name_node.end_byte()].to_string();
+                            let inherits = if let Some(handler) = lang_info.extract_inheritance {
+                                handler(&node, source)
+                            } else {
+                                Vec::new()
+                            };
                             classes.push(ClassInfo {
                                 name,
                                 line: node.start_position().row + 1,
                                 end_line: node.end_position().row + 1,
                                 methods: Vec::new(),
                                 fields: Vec::new(),
+                                inherits,
                             });
                         }
                     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -130,6 +130,8 @@ pub struct ClassInfo {
     pub end_line: usize,
     pub methods: Vec<FunctionInfo>,
     pub fields: Vec<String>,
+    #[schemars(description = "Inherited types (parent classes, interfaces, trait bounds)")]
+    pub inherits: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1792,3 +1792,246 @@ fn test_single_page_no_cursor() {
     assert!(result.next_cursor.is_none());
     assert_eq!(result.total, 50);
 }
+
+// Inheritance extraction tests
+
+#[test]
+fn test_java_inheritance_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("Test.java");
+
+    let java_code = r#"
+public class Animal {
+    public void speak() {}
+}
+
+public class Dog extends Animal implements Comparable {
+    public int compareTo(Object o) {
+        return 0;
+    }
+}
+"#;
+
+    fs::write(&file_path, java_code).unwrap();
+
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Verify classes extracted
+    assert_eq!(output.semantic.classes.len(), 2);
+
+    // Find Dog class and verify inheritance
+    let dog_class = output
+        .semantic
+        .classes
+        .iter()
+        .find(|c| c.name == "Dog")
+        .expect("Dog class should be extracted");
+
+    assert!(
+        !dog_class.inherits.is_empty(),
+        "Dog should have inheritance info"
+    );
+    assert!(
+        dog_class
+            .inherits
+            .iter()
+            .any(|i| i.contains("extends Animal")),
+        "Dog should extend Animal"
+    );
+    assert!(
+        dog_class
+            .inherits
+            .iter()
+            .any(|i| i.contains("implements Comparable")),
+        "Dog should implement Comparable"
+    );
+}
+
+#[test]
+fn test_typescript_inheritance_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.ts");
+
+    let ts_code = r#"
+class Animal {
+    name: string;
+}
+
+interface Movable {
+    move(): void;
+}
+
+class Dog extends Animal implements Movable {
+    move(): void {}
+}
+"#;
+
+    fs::write(&file_path, ts_code).unwrap();
+
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Find Dog class and verify inheritance
+    let dog_class = output
+        .semantic
+        .classes
+        .iter()
+        .find(|c| c.name == "Dog")
+        .expect("Dog class should be extracted");
+
+    assert!(
+        !dog_class.inherits.is_empty(),
+        "Dog should have inheritance info"
+    );
+    assert!(
+        dog_class
+            .inherits
+            .iter()
+            .any(|i| i.contains("extends Animal")),
+        "Dog should extend Animal"
+    );
+    assert!(
+        dog_class
+            .inherits
+            .iter()
+            .any(|i| i.contains("implements Movable")),
+        "Dog should implement Movable"
+    );
+}
+
+#[test]
+fn test_python_inheritance_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.py");
+
+    let python_code = r#"
+class Animal:
+    pass
+
+class Dog(Animal):
+    pass
+"#;
+
+    fs::write(&file_path, python_code).unwrap();
+
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Find Dog class and verify inheritance
+    let dog_class = output
+        .semantic
+        .classes
+        .iter()
+        .find(|c| c.name == "Dog")
+        .expect("Dog class should be extracted");
+
+    assert!(
+        !dog_class.inherits.is_empty(),
+        "Dog should have inheritance info"
+    );
+    assert!(
+        dog_class.inherits.iter().any(|i| i.contains("Animal")),
+        "Dog should inherit from Animal"
+    );
+}
+
+#[test]
+fn test_go_inheritance_extraction() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.go");
+
+    let go_code = r#"
+package main
+
+type Reader interface {
+    Read() error
+}
+
+type Writer interface {
+    Write() error
+}
+
+type ReadWriter struct {
+    Reader
+    Writer
+}
+
+type MyInterface interface {
+    Reader
+    Writer
+}
+"#;
+
+    fs::write(&file_path, go_code).unwrap();
+
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Find ReadWriter struct and verify embedded types
+    let rw_struct = output
+        .semantic
+        .classes
+        .iter()
+        .find(|c| c.name == "ReadWriter")
+        .expect("ReadWriter struct should be extracted");
+
+    assert!(
+        !rw_struct.inherits.is_empty(),
+        "ReadWriter should have embedded types"
+    );
+    assert!(
+        rw_struct.inherits.iter().any(|i| i.contains("Reader")),
+        "ReadWriter should embed Reader"
+    );
+    assert!(
+        rw_struct.inherits.iter().any(|i| i.contains("Writer")),
+        "ReadWriter should embed Writer"
+    );
+
+    // Find MyInterface and verify embedded interfaces
+    let my_iface = output
+        .semantic
+        .classes
+        .iter()
+        .find(|c| c.name == "MyInterface")
+        .expect("MyInterface should be extracted");
+
+    assert!(
+        !my_iface.inherits.is_empty(),
+        "MyInterface should have embedded interfaces"
+    );
+}
+
+#[test]
+fn test_rust_no_syntactic_inheritance() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.rs");
+
+    let rust_code = r#"
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+trait Drawable {
+    fn draw(&self);
+}
+
+impl Drawable for Point {
+    fn draw(&self) {}
+}
+"#;
+
+    fs::write(&file_path, rust_code).unwrap();
+
+    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
+
+    // Verify classes extracted
+    assert_eq!(output.semantic.classes.len(), 2);
+
+    // Verify all Rust classes have empty inherits (no syntactic inheritance)
+    for class in &output.semantic.classes {
+        assert!(
+            class.inherits.is_empty(),
+            "Rust {} should have empty inherits (inheritance is via impl blocks)",
+            class.name
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add language-specific inheritance extraction for class hierarchies across 5 languages: Rust, Python, Go, Java, and TypeScript.

Closes #94

## Changes

- Add `inherits: Vec<String>` field to `ClassInfo` struct with schemars annotation
- Add `ExtractInheritanceHandler` type alias and `extract_inheritance` field to `LanguageInfo`
- Implement `extract_inheritance` handlers for each language:
  - **Java**: extracts `extends` (superclass) and `implements` (interfaces) via `child_by_field_name`
  - **TypeScript**: walks `class_heritage` children for `extends_clause` and `implements_clause`
  - **Python**: extracts base classes from `superclasses` field (`argument_list` children)
  - **Go**: extracts embedded types from struct `field_declaration` (no name) and interface `type_elem`
  - **Rust**: returns empty Vec (no syntactic inheritance on struct/enum/trait declarations)
- Update parser to call handler when building `ClassInfo`, populating `inherits` field
- Update formatter to render inheritance in C: section as `ClassName:line (extends X, implements Y)`
- Add 5 integration tests covering all languages (happy path + edge case)

## Testing

- 63 tests pass (58 existing + 5 new)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: advisory only (unmatched license allowances)
- Security scan: no findings

## Grammar Verification

All tree-sitter grammar fields verified against installed versions in `node-types.json`:
- `tree-sitter-java` 0.23.5: `superclass`, `interfaces` fields on `class_declaration`
- `tree-sitter-typescript` 0.23.2: `class_heritage` child with `extends_clause`/`implements_clause`
- `tree-sitter-python` 0.25.0: `superclasses` field on `class_definition`
- `tree-sitter-go` 0.25.0: `field_declaration` without name (embedding), `type_elem` (interface)
- `tree-sitter-rust` 0.24.0: no inheritance fields on struct/enum/trait nodes