### PR TITLE
feat(benchmark): add v5 benchmark artifacts and tooling

### DIFF
--- a/docs/benchmarks/v5/methodology.md
+++ b/docs/benchmarks/v5/methodology.md
@@ -1,0 +1,189 @@
+# Methodology: V5 Benchmark (Tool Isolation & Efficiency)
+
+## Experiment Overview
+
+This document describes the design, execution, and analysis methodology for the v5 benchmark, which tests whether the `code-analyze-mcp` MCP server can match or exceed the `developer__analyze` baseline when combined with an explicit rg-blocking constraint.
+
+## Experiment Design
+
+| Aspect | Details |
+|--------|---------|
+| **Objective** | Validate code-analyze-mcp efficiency under tool isolation constraints; measure optimization delta (v5B vs v3B) and gap closure (v5B vs v3A) |
+| **Conditions** | A (control): developer__analyze baseline; B (treatment): code-analyze-mcp__analyze with rg-blocking constraint |
+| **Hypothesis** | Explicit tool isolation (prompt-enforced rg blocking + disabled native analyze) will improve Condition B efficiency without sacrificing quality |
+| **Sample Size** | n=5 per condition (10 total runs) |
+| **Randomization** | Blinded; run order shuffled with seed=124; scorers blind to condition labels |
+| **Primary Outcome** | Tool efficiency (≤5 calls = 3, 6-10 = 2, 11-20 = 1, >20 = 0); secondary: quality (structural_accuracy, cross_module_tracing, approach_quality) |
+| **Statistical Test** | Mann-Whitney U (non-parametric, small n); rank-biserial r for effect size |
+| **Decision Threshold** | p < 0.05 for significance; r ≥ 0.3 for meaningful effect |
+
+## Conditions
+
+| Condition | Tool Choice | Constraints | Native Analyze Extension | rg Constraint | Expected Behavior |
+|-----------|------------|-------------|--------------------------|---------------|-------------------|
+| **A: Control** | developer__analyze (goose built-in) | Standard prompt; tool available | Enabled | None (standard) | Baseline efficiency; leverages native extension |
+| **B: Treatment** | code-analyze-mcp__analyze | rg-blocking prompt; focused structural tool | Disabled in goose config | "Do NOT use rg or cat to understand code structure... Use code-analyze-mcp__analyze exclusively" | Forced reliance on MCP tool; should reveal efficiency gains from focused queries |
+
+## Tool Isolation
+
+**Critical Requirement:** Condition B must enforce tool isolation at two levels:
+
+1. **Prompt-level (documented here):** Condition B prompt explicitly blocks rg for structural analysis and native analyze extension.
+2. **System-level (during execution):** Goose configuration must have the native `developer__analyze` extension disabled for Condition B runs.
+
+Validation script (`validate.py`) will check:
+- **Condition A:** developer__analyze used; no code-analyze-mcp calls.
+- **Condition B:** code-analyze-mcp__analyze used; no developer__analyze calls; no rg structural patterns (rg + keywords like 'fn ', 'struct ', 'impl ', 'mod ', 'use ').
+
+## Scoring Rubric
+
+All dimensions use 0-3 scale. Total maximum: 12 points.
+
+### Structural Accuracy (0-3)
+
+- **3:** Correctly identifies all major modules (core, display, meta, icon, color, flags, theme, sort); responsibilities clearly mapped; key types (Block, Blocks, Meta) accurately described; call sequence aligns with codebase.
+- **2:** Identifies 5-6 major modules correctly; 1-2 responsibilities mischaracterized or generic; key types mostly correct; minor call sequence gaps.
+- **1:** Identifies 3-4 modules; significant gaps in responsibility mapping or type understanding; call sequence partially correct or out of order.
+- **0:** Identifies fewer than 3 modules; fundamentally incorrect structure or types; no meaningful sequence.
+
+### Cross-Module Tracing (0-3)
+
+- **3:** Traces Meta::from_path through sorting, icon resolution, color resolution, Block creation, and display_grid output; intermediate types (Vec<Meta>, Icons, Colors, Vec<Block>) named at each stage; call sites accurate.
+- **2:** Traces 4-5 stages with correct types; 1-2 intermediate steps unclear or generalized; overall flow correct.
+- **1:** Traces 2-3 stages; significant gaps in intermediate types or module boundaries; flow partially reconstructed.
+- **0:** No meaningful trace or fundamentally incorrect; cannot reconstruct flow.
+
+### Approach Quality (0-3)
+
+- **3:** Proposes checksum column with: correct files to modify (display.rs for rendering, meta.rs for type addition, likely block.rs for field); new type (Checksum struct or field); integration pattern matching existing color/icon handlers; 3+ identified risks (performance, display width, sorting implications).
+- **2:** Proposes reasonable solution with 2-3 files, new type present; integration sketch present; 2 risks identified.
+- **1:** Identifies some files and a type; integration vague; 1 risk or generic risks.
+- **0:** Superficial proposal, missing files, or no type definition; no realistic integration path.
+
+### Tool Efficiency (0-3)
+
+- **3:** ≤5 analysis tool calls; focused queries that systematically reduce uncertainty; minimal backtracking.
+- **2:** 6-10 analysis tool calls; mostly focused; some exploratory calls; reaches synthesis without excessive detours.
+- **1:** 11-20 analysis tool calls; notable redundancy or broad exploration; delayed synthesis; writer apparent hesitation.
+- **0:** >20 analysis tool calls; highly exploratory or repetitive; late synthesis or abandoned queries.
+
+## Cross-Version Comparisons
+
+### v5B vs v3B (Optimization Delta)
+
+Measures whether the rg-blocking constraint forces efficiency improvements:
+
+- **Quality (structural_accuracy, cross_module_tracing, approach_quality):** v5B should maintain or exceed v3B median.
+- **Efficiency:** v5B should reduce median tool calls and wall time vs v3B.
+- **Tokens:** v5B may use fewer tokens if forced focus improves clarity.
+
+Success criteria:
+- v5B quality ≥ v3B median (no regression).
+- v5B tool calls < v3B tool calls (constraint-driven efficiency).
+- v5B wall time ≤ v3B wall time (optimization realized).
+
+### v5B vs v3A (Gap Closure)
+
+Measures whether code-analyze-mcp can match the native analyze baseline:
+
+- **Quality:** v5B median quality ≥ v3A median (can code-analyze-mcp reach parity?).
+- **Efficiency:** v5B tool calls, tokens, wall time comparable to v3A (if quality matches, efficiency must be competitive).
+
+Success criteria:
+- v5B quality ≥ v3A quality (feature parity achieved).
+- v5B efficiency metrics close to v3A (within 10-20% or statistically equivalent).
+
+## Blinding Procedure
+
+1. **Run order:** Randomized with seed=124 to avoid order bias.
+2. **Labeling:** 10 runs labeled R01-R10 during scoring; condition mapping kept secret until final tally.
+3. **Scoring:** Each run scored independently on rubric before condition is revealed.
+4. **Mapping disclosure:** After all 10 runs scored, reveal condition mapping and separate A/B results.
+
+Mapping (R## → A/B condition):
+- Generated by seed=124 shuffle; stored in scores-template.json blinding.mapping after execution.
+
+## Statistical Analysis Plan
+
+### Mann-Whitney U Test
+
+Used to compare quality and efficiency between Condition A and B:
+
+1. **Null hypothesis:** No difference in quality (or efficiency) between conditions.
+2. **Alternative:** Conditions differ (two-tailed).
+3. **Calculation:** Rank all 10 observations combined; compute U = n1*n2 + n1(n1+1)/2 - R1 (R1 = sum of ranks for group 1).
+4. **Critical value:** α=0.05, two-tailed, n1=n2=5 → critical U = 2.
+5. **p-value:** Use exact distribution for small n (scipy.stats.mannwhitneyu if available).
+6. **Effect size:** Rank-biserial r = 1 - 2U/(n1*n2). |r| ≥ 0.3 = small effect, ≥ 0.5 = medium, ≥ 0.7 = large.
+
+### Dimensions Tested
+
+1. **Quality:** Pool structural_accuracy, cross_module_tracing, approach_quality; compare A vs B totals.
+2. **Efficiency:** Mann-Whitney on tool_calls (analyze_calls + shell_calls for structural work); tokens; wall time.
+3. **Tool efficiency score:** Direct comparison of tool_efficiency dimension (rubric-driven, already 0-3).
+
+### Interpretation
+
+- **Significant efficiency gain (p<0.05, r>0.5):** Condition B tools isolate is effective; recommend for production.
+- **No significant difference:** Conditions equivalent; choose based on cost/availability.
+- **Regression in B:** Investigate whether constraint is too strict; refine prompt.
+
+## Cross-Version Comparison Strategy
+
+Using v3 baselines (embedded in scores-template.json):
+
+1. **Extract v3 per-run scores** from v3/scores.json.
+2. **Compute v3 medians:** A=10 (range 9-10), B=10 (range 9-11).
+3. **After v5 runs complete, compute v5 medians:** A and B.
+4. **Calculate deltas:**
+   - v5B vs v3B quality delta = v5B_quality - v3B_quality (should be ≥0).
+   - v5B vs v3B efficiency delta = v5B_median_calls - v3B_median_calls (should be ≤0 if improvement).
+   - v5B vs v3A quality gap = v5B_quality - v3A_quality (should be ≥0 for parity).
+5. **Publish** in analysis.md with decision recommendation.
+
+## Decision Framework
+
+| Scenario | Quality (v5B vs baseline) | Efficiency (v5B vs v3B) | Recommendation |
+|----------|-------------------------|------------------------|-----------------|
+| v5B ≥ v3A quality AND v5B < v3B calls | Parity achieved + optimization | Approve; recommend v5B | Deploy code-analyze-mcp as recommended MCP tool |
+| v5B ≥ v3B quality AND v5B < v3B calls | Improvement over prior treatment | Strong approval | Deploy; updated treatment baseline |
+| v5B ≥ v3B quality AND v5B ≥ v3B calls | No efficiency gain | Conditional; weigh quality | Investigate constraint tightness; revise if needed |
+| v5B < v3A quality | Regression to baseline | Failure | Revise prompt/constraint; rerun v5 or stay with v3A |
+
+## v3 Baseline Reference
+
+Provided in scores-template.json under `v3_baselines`:
+
+- **Condition A:** Median quality 10, range [9-10], median tool calls 14
+- **Condition B:** Median quality 10, range [9-11], median tool calls 18
+
+(Full per-run scores and efficiency metrics in v3/scores.json)
+
+## Execution Checklist
+
+- [ ] Create docs/benchmarks/v5/prompts/task.md (copy from v3, identical task)
+- [ ] Create docs/benchmarks/v5/prompts/condition-a-control.md (copy from v3, identical control)
+- [ ] Create docs/benchmarks/v5/prompts/condition-b-treatment.md (fork v3, add rg-blocking text)
+- [ ] Create docs/benchmarks/v5/run-order.txt with randomized 10-run order (seed=124)
+- [ ] Create docs/benchmarks/v5/scores-template.json with rubric, v3 baselines, null placeholders
+- [ ] Disable native analyze extension in goose config for Condition B runs
+- [ ] Run 10 goose sessions following run-order.txt (alternating A/B)
+- [ ] Collect session metrics using scripts/collect.py (tokens, wall time, tool calls)
+- [ ] Score each run using scores-template.json rubric (blind to condition until mapped)
+- [ ] Validate tool isolation using scripts/validate.py for each run
+- [ ] Run scripts/analyze.py on completed scores.json to generate Mann-Whitney U, r, cross-version comparisons
+- [ ] Write docs/benchmarks/v5/analysis.md with findings, decision recommendation, cross-version insights
+- [ ] Commit all results to GitHub with PR for review
+
+## Output Artifacts
+
+- **docs/benchmarks/v5/prompts/task.md** – Experiment task (reused from v3)
+- **docs/benchmarks/v5/prompts/condition-a-control.md** – Control prompt (reused from v3)
+- **docs/benchmarks/v5/prompts/condition-b-treatment.md** – Treatment prompt (rg-blocking variant)
+- **docs/benchmarks/v5/run-order.txt** – Randomized run execution sequence
+- **docs/benchmarks/v5/scores-template.json** – Scoring template (filled during execution)
+- **docs/benchmarks/v5/results/runs/R##.json** – Individual session outputs (10 total)
+- **docs/benchmarks/v5/scripts/analyze.py** – Statistical analysis script
+- **docs/benchmarks/v5/scripts/validate.py** – Tool isolation validation script
+- **docs/benchmarks/v5/scripts/collect.py** – Metrics extraction script
+- **docs/benchmarks/v5/analysis.md** – Final results and interpretation

--- a/docs/benchmarks/v5/prompts/condition-a-control.md
+++ b/docs/benchmarks/v5/prompts/condition-a-control.md
@@ -1,0 +1,62 @@
+# Condition A: Control (developer__analyze)
+
+YOUR GOAL: Analyze the lsd codebase and write a structured JSON report to OUTPUT_PATH. Everything below serves that goal. Do not end without writing the file.
+
+## Repository
+
+The lsd codebase is at: TARGET_REPO_PATH
+
+## Required Tool Usage
+
+You MUST use the `developer__analyze` tool for structural analysis:
+
+1. **Directory overview:** `developer__analyze` on `src/` to get the file tree with function/class counts.
+2. **File details:** `developer__analyze` on key files (display.rs, core.rs, meta/mod.rs) for functions, imports, types.
+3. **Cross-module tracing:** `developer__analyze` with `focus` parameter on key functions (from_path, display_grid) for call chains.
+
+You may also use `developer__shell` for `rg` searches and `developer__text_editor` to read files, but `developer__analyze` must be your primary structural analysis tool.
+
+**Turn budget:** You have approximately 30 turns total. Use at most 10 analysis/research tool calls, then write the report. Do not keep exploring -- write the report with what you have.
+
+## Task
+
+Analyze the lsd codebase to answer:
+
+1. **Module map:** Top-level modules and responsibilities. How submodules (flags/, meta/, theme/) relate.
+2. **Data flow:** Trace a file entry from metadata collection (Meta::from_path) through sorting, icon resolution, color resolution, to display output. Key types passed between modules at each stage.
+3. **Cross-module dependencies:** Top 3 most-connected modules by cross-module imports. Why they are hubs.
+4. **Change proposal:** Where to add a file checksum display column (SHA-256). Files to modify, patterns to follow, new types needed, Block/display integration, risks.
+
+## Output Schema
+
+Write to OUTPUT_PATH using `developer__text_editor` write command:
+
+```json
+{
+  "run_id": "RUN_ID",
+  "condition": "A-control",
+  "module_map": [
+    {"module": "name", "responsibility": "...", "submodules": ["..."], "key_types": ["..."]}
+  ],
+  "data_flow": [
+    {"stage": "1. Metadata collection", "module": "meta/", "key_function": "...", "types_produced": ["..."]}
+  ],
+  "cross_module_hubs": [
+    {"module": "name", "inbound_deps": 0, "outbound_deps": 0, "reason": "..."}
+  ],
+  "change_proposal": {
+    "files_to_modify": ["path"],
+    "new_types": ["type description"],
+    "pattern_to_follow": "existing pattern description",
+    "integration_point": "how it connects to Block/display",
+    "risks": ["risk 1"]
+  },
+  "tool_usage": [
+    {"tool": "tool_name", "params": "brief description"}
+  ]
+}
+```
+
+## Reminder
+
+Your deliverable is the JSON report file at OUTPUT_PATH. You must write it before you finish. Use `developer__text_editor` write command to create the file. Do not end without writing the report.

--- a/docs/benchmarks/v5/prompts/condition-b-treatment.md
+++ b/docs/benchmarks/v5/prompts/condition-b-treatment.md
@@ -1,0 +1,64 @@
+# Condition B: Treatment (code-analyze-mcp)
+
+YOUR GOAL: Analyze the lsd codebase and write a structured JSON report to OUTPUT_PATH. Everything below serves that goal. Do not end without writing the file.
+
+## Repository
+
+The lsd codebase is at: TARGET_REPO_PATH
+
+## Required Tool Usage
+
+You MUST use the `code-analyze-mcp__analyze` tool for structural analysis:
+
+1. **Directory overview:** `code-analyze-mcp__analyze` on `src/` to get the file tree with function/class counts.
+2. **File details:** `code-analyze-mcp__analyze` on key files (display.rs, core.rs, meta/mod.rs) for functions, imports, types.
+3. **Cross-module tracing:** `code-analyze-mcp__analyze` with `focus` parameter on key functions (from_path, display_grid) for call chains.
+
+Do NOT use `rg` or `cat` to understand code structure, module layout, or function signatures. Use `code-analyze-mcp__analyze` exclusively for all structural analysis. You may use `developer__shell` only to write the output file.
+
+Do NOT use `developer__analyze`. It is not available to you.
+
+**Turn budget:** You have approximately 30 turns total. Use at most 10 analysis/research tool calls, then write the report. Do not keep exploring -- write the report with what you have.
+
+## Task
+
+Analyze the lsd codebase to answer:
+
+1. **Module map:** Top-level modules and responsibilities. How submodules (flags/, meta/, theme/) relate.
+2. **Data flow:** Trace a file entry from metadata collection (Meta::from_path) through sorting, icon resolution, color resolution, to display output. Key types passed between modules at each stage.
+3. **Cross-module dependencies:** Top 3 most-connected modules by cross-module imports. Why they are hubs.
+4. **Change proposal:** Where to add a file checksum display column (SHA-256). Files to modify, patterns to follow, new types needed, Block/display integration, risks.
+
+## Output Schema
+
+Write to OUTPUT_PATH using `developer__text_editor` write command:
+
+```json
+{
+  "run_id": "RUN_ID",
+  "condition": "B-treatment",
+  "module_map": [
+    {"module": "name", "responsibility": "...", "submodules": ["..."], "key_types": ["..."]}
+  ],
+  "data_flow": [
+    {"stage": "1. Metadata collection", "module": "meta/", "key_function": "...", "types_produced": ["..."]}
+  ],
+  "cross_module_hubs": [
+    {"module": "name", "inbound_deps": 0, "outbound_deps": 0, "reason": "..."}
+  ],
+  "change_proposal": {
+    "files_to_modify": ["path"],
+    "new_types": ["type description"],
+    "pattern_to_follow": "existing pattern description",
+    "integration_point": "how it connects to Block/display",
+    "risks": ["risk 1"]
+  },
+  "tool_usage": [
+    {"tool": "tool_name", "params": "brief description"}
+  ]
+}
+```
+
+## Reminder
+
+Your deliverable is the JSON report file at OUTPUT_PATH. You must write it before you finish. Use `developer__text_editor` write command to create the file. Do not end without writing the report.

--- a/docs/benchmarks/v5/prompts/task.md
+++ b/docs/benchmarks/v5/prompts/task.md
@@ -1,0 +1,58 @@
+# Benchmark Task: Cross-Module Research on lsd
+
+## Target Repository
+
+- **Repo:** lsd-rs/lsd (https://github.com/lsd-rs/lsd)
+- **Size:** ~13K LOC, 52 Rust source files
+- **Structure:** 4 module groups (flags/, meta/, theme/, root)
+- **Selection rationale:** Mid-size Rust CLI with clear module boundaries, rich cross-module
+  dependencies (display.rs imports from meta/, flags/, color, theme, icon), and a data pipeline
+  pattern (collect metadata -> sort -> resolve icons/colors -> render). The project is well-known
+  but unlikely to be in any session's prior context.
+
+## Task Description
+
+Analyze the lsd codebase to answer:
+
+1. **Module map:** What are the top-level modules and their responsibilities? How do the
+   submodules (flags/, meta/, theme/) relate to each other?
+
+2. **Data flow:** Trace the path of a file entry from initial metadata collection (`Meta::from_path`
+   or equivalent) through sorting, icon resolution, color resolution, and final display output.
+   Identify the key types passed between modules at each stage.
+
+3. **Cross-module dependencies:** Which modules have the most cross-module imports? Identify the
+   top 3 most-connected modules and explain why they are hubs.
+
+4. **Change proposal:** Propose where you would add a new display column showing file checksums
+   (e.g., SHA-256 of file content). Identify:
+   - Which files need modification
+   - Which existing patterns to follow
+   - What new types or structs are needed
+   - How the new column integrates with the existing Block/display system
+   - Potential risks or complications
+
+## Deliverable Format
+
+Produce a structured JSON report:
+
+```json
+{
+  "module_map": [
+    {"module": "name", "responsibility": "...", "submodules": ["..."], "key_types": ["..."]}
+  ],
+  "data_flow": [
+    {"stage": "1. Metadata collection", "module": "meta/", "key_function": "...", "types_produced": ["..."]}
+  ],
+  "cross_module_hubs": [
+    {"module": "name", "inbound_deps": 0, "outbound_deps": 0, "reason": "..."}
+  ],
+  "change_proposal": {
+    "files_to_modify": ["path"],
+    "new_types": ["type description"],
+    "pattern_to_follow": "description of existing pattern",
+    "integration_point": "how it connects to Block/display",
+    "risks": ["risk 1"]
+  }
+}
+```

--- a/docs/benchmarks/v5/run-order.txt
+++ b/docs/benchmarks/v5/run-order.txt
@@ -1,0 +1,10 @@
+1. Condition B, rep 5
+2. Condition B, rep 1
+3. Condition B, rep 2
+4. Condition A, rep 3
+5. Condition A, rep 4
+6. Condition B, rep 3
+7. Condition A, rep 2
+8. Condition A, rep 1
+9. Condition B, rep 4
+10. Condition A, rep 5

--- a/docs/benchmarks/v5/scores-template.json
+++ b/docs/benchmarks/v5/scores-template.json
@@ -1,0 +1,252 @@
+{
+  "experiment": "v5-benchmark",
+  "conditions": {
+    "A-control": "developer__analyze (goose built-in)",
+    "B-treatment": "code-analyze-mcp__analyze with rg-blocking constraint"
+  },
+  "model": "claude-haiku-4-5",
+  "temperature": 0.5,
+  "target_repo": "lsd-rs/lsd",
+  "tool_isolation_verified": false,
+  "blinding": {
+    "method": "Random shuffle with seed=124, condition labels stripped before scoring",
+    "mapping": {
+      "R01": null,
+      "R02": null,
+      "R03": null,
+      "R04": null,
+      "R05": null,
+      "R06": null,
+      "R07": null,
+      "R08": null,
+      "R09": null,
+      "R10": null
+    }
+  },
+  "rubric": {
+    "structural_accuracy": {
+      "3": "Correctly identifies all major modules, responsibilities, and data types; traces match codebase structure",
+      "2": "Identifies most modules and responsibilities; minor omissions or generalization errors",
+      "1": "Partial module identification; significant structural gaps or confusions",
+      "0": "Misses major components; fundamentally incorrect structure"
+    },
+    "cross_module_tracing": {
+      "3": "Complete cross-module trace with intermediate types; call chains are accurate and detailed",
+      "2": "Traces key call chains; minor gaps or simplifications in type flow",
+      "1": "Partial trace; missing intermediate steps or types",
+      "0": "No meaningful trace or entirely incorrect"
+    },
+    "approach_quality": {
+      "3": "Well-reasoned change proposal; identifies all affected files, new types, and integration points; realistic risks",
+      "2": "Reasonable proposal; most files and types identified; risks partially addressed",
+      "1": "Incomplete or partially reasoned proposal; missing files or risk analysis",
+      "0": "Superficial or incorrect proposal; major gaps"
+    },
+    "tool_efficiency": {
+      "3": "5 or fewer analysis tool calls; focused exploration, clear path to synthesis",
+      "2": "6-10 analysis tool calls; somewhat exploratory but reaches conclusions",
+      "1": "11-20 analysis tool calls; extensive exploration; delayed synthesis",
+      "0": "More than 20 analysis tool calls; inefficient, redundant, exploration-heavy"
+    }
+  },
+  "per_run_scores": {
+    "A1": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "A2": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "A3": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "A4": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "A5": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "B1": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "B2": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "B3": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "B4": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    },
+    "B5": {
+      "structural_accuracy": null,
+      "cross_module_tracing": null,
+      "approach_quality": null,
+      "tool_efficiency": null,
+      "total": null
+    }
+  },
+  "v3_baselines": {
+    "A_condition": {
+      "per_run": {
+        "A1": 10,
+        "A2": 9,
+        "A3": 10,
+        "A4": 10,
+        "A5": 9
+      },
+      "median": 10,
+      "range": [9, 10],
+      "efficiency_median_calls": 14
+    },
+    "B_condition": {
+      "per_run": {
+        "B1": 10,
+        "B2": 11,
+        "B3": 9,
+        "B4": 9,
+        "B5": 10
+      },
+      "median": 10,
+      "range": [9, 11],
+      "efficiency_median_calls": 18
+    }
+  },
+  "cross_version_comparisons": {
+    "v5B_vs_v3B": {
+      "quality_delta": null,
+      "efficiency_delta_tokens": null,
+      "efficiency_delta_wall_time": null,
+      "efficiency_delta_calls": null,
+      "optimization_achieved": null,
+      "notes": "Measure whether v5B (with rg-blocking constraint) maintains v3B quality while reducing tool calls"
+    },
+    "v5B_vs_v3A": {
+      "quality_gap": null,
+      "efficiency_gap_tokens": null,
+      "efficiency_gap_calls": null,
+      "gap_closed": null,
+      "notes": "Measure whether v5B (code-analyze-mcp-focused) can match v3A (native analyze) baseline"
+    }
+  },
+  "efficiency": {
+    "per_run": {
+      "A1": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "A2": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "A3": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "A4": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "A5": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "B1": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "B2": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "B3": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "B4": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      },
+      "B5": {
+        "tokens": null,
+        "wall_seconds": null,
+        "analyze_calls": null,
+        "shell_calls": null,
+        "editor_calls": null,
+        "total_calls": null
+      }
+    },
+    "statistics": null
+  }
+}

--- a/docs/benchmarks/v5/scripts/analyze.py
+++ b/docs/benchmarks/v5/scripts/analyze.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+analyze.py: Statistical analysis for v5 benchmark scores.
+
+Reads a filled scores.json, computes per-condition medians and ranges for quality
+and efficiency, runs Mann-Whitney U test, computes rank-biserial r, and generates
+cross-version comparisons (v5B vs v3B, v5B vs v3A).
+
+Usage:
+    python3 analyze.py --scores-file docs/benchmarks/v5/scores.json
+
+Output: Markdown tables printed to stdout (can be pasted into analysis.md)
+"""
+
+import argparse
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import List, Dict, Tuple, Optional
+
+
+def mannwhitneyu_exact(group1: List[float], group2: List[float]) -> Tuple[float, float, float]:
+    """
+    Compute Mann-Whitney U statistic and approximate p-value.
+    Falls back to manual calculation if scipy unavailable.
+    
+    Returns: (U, z_approx, p_approx)
+    """
+    try:
+        from scipy import stats
+        result = stats.mannwhitneyu(group1, group2, alternative='two-sided')
+        U = result.statistic
+        p_value = result.pvalue
+        # z-score approximation: z = (U - mu) / sigma where mu=n1*n2/2, sigma=sqrt(n1*n2*(n1+n2+1)/12)
+        n1, n2 = len(group1), len(group2)
+        mu = n1 * n2 / 2
+        sigma = math.sqrt(n1 * n2 * (n1 + n2 + 1) / 12)
+        z = (U - mu) / sigma if sigma > 0 else 0
+        return U, z, p_value
+    except ImportError:
+        # Manual calculation
+        n1, n2 = len(group1), len(group2)
+        combined = [(x, 1) for x in group1] + [(x, 2) for x in group2]
+        combined.sort()
+        
+        # Assign ranks
+        ranks = {}
+        current_rank = 1
+        i = 0
+        while i < len(combined):
+            # Handle ties
+            j = i
+            while j < len(combined) and combined[j][0] == combined[i][0]:
+                j += 1
+            avg_rank = (current_rank + j - i + 1) / 2 if j > i + 1 else current_rank
+            for k in range(i, j):
+                ranks[k] = avg_rank
+            current_rank = j + 1
+            i = j
+        
+        R1 = sum(ranks[i] for i in range(len(group1)))
+        U = n1 * n2 + n1 * (n1 + 1) / 2 - R1
+        
+        # z-score
+        mu = n1 * n2 / 2
+        sigma = math.sqrt(n1 * n2 * (n1 + n2 + 1) / 12)
+        z = (U - mu) / sigma if sigma > 0 else 0
+        
+        # p-value approximation (normal approximation, not exact)
+        p_value = 0.0  # Placeholder; scipy recommended
+        
+        return U, z, p_value
+
+
+def rank_biserial_r(U: float, n1: int, n2: int) -> float:
+    """Compute rank-biserial correlation: r = 1 - 2U/(n1*n2)"""
+    return 1 - (2 * U) / (n1 * n2) if (n1 * n2) > 0 else 0
+
+
+def load_scores(filepath: Path) -> Dict:
+    """Load and validate scores.json"""
+    with open(filepath) as f:
+        data = json.load(f)
+    return data
+
+
+def extract_condition_scores(scores_data: Dict, dimension: str) -> Tuple[List[int], List[int]]:
+    """
+    Extract scores for dimension (e.g., 'structural_accuracy', 'tool_efficiency')
+    from per_run_scores, grouped by condition A and B.
+    
+    Returns: (condition_A_scores, condition_B_scores)
+    """
+    a_scores = []
+    b_scores = []
+    
+    for run_id, run_data in scores_data['per_run_scores'].items():
+        if run_data[dimension] is not None:
+            if run_id.startswith('A'):
+                a_scores.append(run_data[dimension])
+            elif run_id.startswith('B'):
+                b_scores.append(run_data[dimension])
+    
+    return a_scores, b_scores
+
+
+def extract_efficiency_metric(scores_data: Dict, metric: str) -> Tuple[List[float], List[float]]:
+    """
+    Extract efficiency metric (tokens, wall_seconds, total_calls, etc.)
+    from per_run efficiency data, grouped by condition.
+    
+    Returns: (condition_A_values, condition_B_values)
+    """
+    a_vals = []
+    b_vals = []
+    
+    for run_id, run_data in scores_data['efficiency']['per_run'].items():
+        if run_data[metric] is not None:
+            if run_id.startswith('A'):
+                a_vals.append(run_data[metric])
+            elif run_id.startswith('B'):
+                b_vals.append(run_data[metric])
+    
+    return a_vals, b_vals
+
+
+def compute_stats(values: List[float]) -> Dict:
+    """Compute basic statistics"""
+    if not values:
+        return {'median': None, 'min': None, 'max': None, 'mean': None}
+    return {
+        'median': statistics.median(values),
+        'min': min(values),
+        'max': max(values),
+        'mean': statistics.mean(values)
+    }
+
+
+def print_quality_table(scores_data: Dict):
+    """Print quality scores analysis table"""
+    print("\n## Quality Analysis\n")
+    
+    dimensions = ['structural_accuracy', 'cross_module_tracing', 'approach_quality']
+    
+    print("| Dimension | A Median | A Range | B Median | B Range | U | z | r | Significant |")
+    print("|-----------|----------|---------|----------|---------|---|---|---|-------------|")
+    
+    for dim in dimensions:
+        a_scores, b_scores = extract_condition_scores(scores_data, dim)
+        
+        if not a_scores or not b_scores:
+            continue
+        
+        a_stats = compute_stats(a_scores)
+        b_stats = compute_stats(b_scores)
+        
+        U, z, p = mannwhitneyu_exact(a_scores, b_scores)
+        r = rank_biserial_r(U, len(a_scores), len(b_scores))
+        significant = p < 0.05 if p > 0 else "N/A"
+        
+        print(f"| {dim} | {a_stats['median']} | [{a_stats['min']}, {a_stats['max']}] | "
+              f"{b_stats['median']} | [{b_stats['min']}, {b_stats['max']}] | {U:.1f} | {z:.2f} | {r:.2f} | {significant} |")
+
+
+def print_efficiency_table(scores_data: Dict):
+    """Print efficiency analysis table"""
+    print("\n## Efficiency Analysis\n")
+    
+    metrics = [
+        ('tokens', 'Tokens'),
+        ('wall_seconds', 'Wall Time (s)'),
+        ('total_calls', 'Total Tool Calls'),
+        ('analyze_calls', 'Analyze Calls'),
+        ('shell_calls', 'Shell Calls'),
+        ('editor_calls', 'Editor Calls')
+    ]
+    
+    print("| Metric | A Median | A Range | B Median | B Range | U | z | r | Significant |")
+    print("|--------|----------|---------|----------|---------|---|---|---|-------------|")
+    
+    for metric_key, metric_label in metrics:
+        a_vals, b_vals = extract_efficiency_metric(scores_data, metric_key)
+        
+        if not a_vals or not b_vals:
+            continue
+        
+        a_stats = compute_stats(a_vals)
+        b_stats = compute_stats(b_vals)
+        
+        U, z, p = mannwhitneyu_exact(a_vals, b_vals)
+        r = rank_biserial_r(U, len(a_vals), len(b_vals))
+        significant = p < 0.05 if p > 0 else "N/A"
+        
+        print(f"| {metric_label} | {a_stats['median']:.0f} | [{a_stats['min']:.0f}, {a_stats['max']:.0f}] | "
+              f"{b_stats['median']:.0f} | [{b_stats['min']:.0f}, {b_stats['max']:.0f}] | {U:.1f} | {z:.2f} | {r:.2f} | {significant} |")
+
+
+def print_tool_efficiency_summary(scores_data: Dict):
+    """Print tool_efficiency dimension summary"""
+    print("\n## Tool Efficiency (Rubric Score)\n")
+    
+    a_scores, b_scores = extract_condition_scores(scores_data, 'tool_efficiency')
+    
+    if not a_scores or not b_scores:
+        print("(Insufficient data)")
+        return
+    
+    a_stats = compute_stats(a_scores)
+    b_stats = compute_stats(b_scores)
+    
+    U, z, p = mannwhitneyu_exact(a_scores, b_scores)
+    r = rank_biserial_r(U, len(a_scores), len(b_scores))
+    significant = "Yes" if p < 0.05 else "No"
+    
+    print(f"**Condition A (developer__analyze):**")
+    print(f"- Median: {a_stats['median']} (range: {a_stats['min']}-{a_stats['max']})")
+    print(f"- Mean: {a_stats['mean']:.2f}")
+    print()
+    print(f"**Condition B (code-analyze-mcp with rg-blocking):**")
+    print(f"- Median: {b_stats['median']} (range: {b_stats['min']}-{b_stats['max']})")
+    print(f"- Mean: {b_stats['mean']:.2f}")
+    print()
+    print(f"**Statistical Test (Mann-Whitney U):**")
+    print(f"- U: {U:.1f}")
+    print(f"- z: {z:.2f}")
+    print(f"- rank-biserial r: {r:.2f}")
+    print(f"- p-value: {p:.4f}")
+    print(f"- Significant (p<0.05): {significant}")
+
+
+def print_cross_version_comparison(scores_data: Dict):
+    """Print cross-version comparison table"""
+    print("\n## Cross-Version Comparisons\n")
+    
+    v3_baselines = scores_data.get('v3_baselines', {})
+    
+    # v5B vs v3B
+    print("### v5B vs v3B (Optimization Delta)\n")
+    
+    v5b_quality, _ = extract_condition_scores(scores_data, 'tool_efficiency')
+    v5b_eff, _ = extract_efficiency_metric(scores_data, 'total_calls')
+    
+    v3b_median_quality = v3_baselines.get('B_condition', {}).get('median')
+    v3b_median_calls = v3_baselines.get('B_condition', {}).get('efficiency_median_calls')
+    
+    if v5b_quality and v3b_median_quality:
+        v5b_med_quality = statistics.median(v5b_quality)
+        print(f"| Metric | v3B | v5B | Delta |")
+        print("|--------|-----|-----|-------|")
+        print(f"| Quality (tool_efficiency) | {v3b_median_quality} | {v5b_med_quality} | {v5b_med_quality - v3b_median_quality:+.1f} |")
+    
+    if v5b_eff and v3b_median_calls:
+        v5b_med_calls = statistics.median(v5b_eff)
+        print(f"| Total Calls | {v3b_median_calls} | {v5b_med_calls:.0f} | {v5b_med_calls - v3b_median_calls:+.0f} |")
+    
+    # v5B vs v3A
+    print("\n### v5B vs v3A (Gap Closure)\n")
+    
+    v3a_median_quality = v3_baselines.get('A_condition', {}).get('median')
+    v3a_median_calls = v3_baselines.get('A_condition', {}).get('efficiency_median_calls')
+    
+    if v5b_quality and v3a_median_quality:
+        print(f"| Metric | v3A | v5B | Gap |")
+        print("|--------|-----|-----|-----|")
+        print(f"| Quality | {v3a_median_quality} | {v5b_med_quality} | {v5b_med_quality - v3a_median_quality:+.1f} |")
+    
+    if v5b_eff and v3a_median_calls:
+        print(f"| Total Calls | {v3a_median_calls} | {v5b_med_calls:.0f} | {v5b_med_calls - v3a_median_calls:+.0f} |")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze v5 benchmark scores: Mann-Whitney U, rank-biserial r, cross-version comparisons'
+    )
+    parser.add_argument(
+        '--scores-file',
+        type=Path,
+        default=Path('scores.json'),
+        help='Path to filled scores.json (default: scores.json in cwd)'
+    )
+    
+    args = parser.parse_args()
+    
+    if not args.scores_file.exists():
+        print(f"Error: {args.scores_file} not found", file=__import__('sys').stderr)
+        exit(1)
+    
+    scores = load_scores(args.scores_file)
+    
+    print(f"# Analysis: {scores.get('experiment', 'v5-benchmark')}\n")
+    print(f"**Model:** {scores.get('model')}")
+    print(f"**Runs:** 10 (5 per condition)")
+    
+    print_quality_table(scores)
+    print_efficiency_table(scores)
+    print_tool_efficiency_summary(scores)
+    print_cross_version_comparison(scores)
+    
+    print("\n---\n")
+    print("*Note: Mann-Whitney U test requires scipy for exact p-values. If scipy unavailable, p-value is approximate.*")
+    print("*rank-biserial r: |r| >= 0.3 (small), >= 0.5 (medium), >= 0.7 (large effect).*")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/benchmarks/v5/scripts/collect.py
+++ b/docs/benchmarks/v5/scripts/collect.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+collect.py: Extract session metrics from goose sessions database.
+
+Queries a goose session by name, extracts:
+- total_tokens, input_tokens, output_tokens from sessions table
+- wall time (last message timestamp - first message timestamp)
+- tool call counts by tool name from messages.content_json
+
+Usage:
+    python3 collect.py --session-name R01
+    python3 collect.py --session-name R01 --db-path ~/.local/share/goose/sessions/sessions.db
+
+Output: JSON to stdout (can be pasted into scores-template.json efficiency section)
+"""
+
+import argparse
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+
+def get_db_connection(db_path: Path) -> sqlite3.Connection:
+    """Connect to goose sessions database"""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def get_session_info(conn: sqlite3.Connection, session_name: str) -> Optional[Dict]:
+    """Fetch session info from sessions table"""
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, total_tokens, input_tokens, output_tokens FROM sessions WHERE name = ?",
+        (session_name,)
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None
+
+
+def get_session_messages(conn: sqlite3.Connection, session_id: str) -> list:
+    """Fetch all messages for a session with timestamps"""
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT created_timestamp, role, content_json FROM messages WHERE session_id = ? ORDER BY created_timestamp",
+        (session_id,)
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
+def extract_tool_calls(messages: list) -> Dict[str, int]:
+    """
+    Extract tool calls from message content and count by tool name.
+    
+    Looks for tool_use blocks in assistant messages.
+    """
+    counts = {}
+    
+    for msg in messages:
+        if msg['role'] != 'assistant':
+            continue
+        
+        try:
+            content = json.loads(msg['content_json'])
+        except (json.JSONDecodeError, TypeError):
+            continue
+        
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    tool_name = block.get('name', 'unknown')
+                    counts[tool_name] = counts.get(tool_name, 0) + 1
+    
+    return counts
+
+
+def calculate_wall_time(messages: list) -> Optional[int]:
+    """Calculate wall time in seconds from first to last message"""
+    if not messages:
+        return None
+    
+    try:
+        first_ts = messages[0]['created_timestamp']
+        last_ts = messages[-1]['created_timestamp']
+        
+        # Timestamps may be ISO format strings or Unix timestamps
+        if isinstance(first_ts, str):
+            first_dt = datetime.fromisoformat(first_ts.replace('Z', '+00:00'))
+            last_dt = datetime.fromisoformat(last_ts.replace('Z', '+00:00'))
+        else:
+            first_dt = datetime.fromtimestamp(first_ts)
+            last_dt = datetime.fromtimestamp(last_ts)
+        
+        delta = last_dt - first_dt
+        return int(delta.total_seconds())
+    except (ValueError, TypeError):
+        return None
+
+
+def categorize_tool_calls(tool_counts: Dict[str, int]) -> Dict[str, int]:
+    """
+    Categorize tools into analyze_calls, shell_calls, editor_calls.
+    
+    Returns dict with keys: analyze_calls, shell_calls, editor_calls, total_calls
+    """
+    analyze_calls = 0
+    shell_calls = 0
+    editor_calls = 0
+    
+    for tool_name, count in tool_counts.items():
+        if 'analyze' in tool_name.lower():
+            analyze_calls += count
+        elif 'shell' in tool_name.lower():
+            shell_calls += count
+        elif 'editor' in tool_name.lower() or 'text_editor' in tool_name.lower():
+            editor_calls += count
+    
+    total = analyze_calls + shell_calls + editor_calls
+    
+    return {
+        'analyze_calls': analyze_calls,
+        'shell_calls': shell_calls,
+        'editor_calls': editor_calls,
+        'total_calls': total
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Extract session metrics from goose DB for v5 benchmark'
+    )
+    parser.add_argument(
+        '--session-name',
+        required=True,
+        help='Session name (e.g., R01, R02)'
+    )
+    parser.add_argument(
+        '--db-path',
+        type=Path,
+        default=Path.home() / '.local' / 'share' / 'goose' / 'sessions' / 'sessions.db',
+        help='Path to goose sessions database'
+    )
+    
+    args = parser.parse_args()
+    
+    if not args.db_path.exists():
+        print(json.dumps({"error": f"Database not found at {args.db_path}"}))
+        exit(1)
+    
+    conn = get_db_connection(args.db_path)
+    
+    session_info = get_session_info(conn, args.session_name)
+    if not session_info:
+        print(json.dumps({"error": f"Session '{args.session_name}' not found"}))
+        exit(1)
+    
+    session_id = session_info['id']
+    messages = get_session_messages(conn, session_id)
+    
+    if not messages:
+        print(json.dumps({"error": f"No messages found for session '{args.session_name}'"}))
+        exit(1)
+    
+    # Extract metrics
+    tool_counts = extract_tool_calls(messages)
+    tool_categories = categorize_tool_calls(tool_counts)
+    wall_time = calculate_wall_time(messages)
+    
+    result = {
+        'session_name': args.session_name,
+        'tokens': session_info['total_tokens'],
+        'input_tokens': session_info['input_tokens'],
+        'output_tokens': session_info['output_tokens'],
+        'wall_seconds': wall_time,
+        'tool_calls_detail': tool_counts,
+        'analyze_calls': tool_categories['analyze_calls'],
+        'shell_calls': tool_categories['shell_calls'],
+        'editor_calls': tool_categories['editor_calls'],
+        'total_calls': tool_categories['total_calls']
+    }
+    
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/benchmarks/v5/scripts/validate.py
+++ b/docs/benchmarks/v5/scripts/validate.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+validate.py: Tool isolation validation for v5 benchmark runs.
+
+Queries goose sessions DB, extracts tool call information, and validates
+tool isolation constraints:
+
+- Condition A: developer__analyze used; no code-analyze-mcp calls
+- Condition B: code-analyze-mcp__analyze used; no developer__analyze calls;
+               no rg structural analysis patterns
+
+Usage:
+    python3 validate.py --session-name R01 --condition A
+    python3 validate.py --session-name R01 --condition B --db-path ~/.local/share/goose/sessions/sessions.db
+
+Output: PASS/FAIL with details to stdout
+"""
+
+import argparse
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import List, Dict, Tuple, Optional
+
+
+def get_db_connection(db_path: Path) -> sqlite3.Connection:
+    """Connect to goose sessions database"""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def get_session_id(conn: sqlite3.Connection, session_name: str) -> Optional[str]:
+    """Fetch session ID by name"""
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM sessions WHERE name = ?", (session_name,))
+    row = cursor.fetchone()
+    return row['id'] if row else None
+
+
+def get_session_messages(conn: sqlite3.Connection, session_id: str) -> List[Dict]:
+    """Fetch all messages for a session"""
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT role, content_json FROM messages WHERE session_id = ? ORDER BY created_timestamp",
+        (session_id,)
+    )
+    messages = []
+    for row in cursor.fetchall():
+        try:
+            content = json.loads(row['content_json'])
+            messages.append({
+                'role': row['role'],
+                'content': content
+            })
+        except json.JSONDecodeError:
+            continue
+    return messages
+
+
+def extract_tool_calls(messages: List[Dict]) -> List[Dict]:
+    """
+    Extract tool calls from message content.
+    
+    Messages with role 'assistant' contain tool_use blocks:
+    {
+        "content": [
+            {"type": "tool_use", "name": "tool_name", "input": {...}},
+            ...
+        ]
+    }
+    
+    Returns list of dicts: [{"tool": "name", "input": {...}}, ...]
+    """
+    tools = []
+    
+    for msg in messages:
+        if msg['role'] != 'assistant':
+            continue
+        
+        content = msg.get('content', [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    tools.append({
+                        'tool': block.get('name', 'unknown'),
+                        'input': block.get('input', {})
+                    })
+    
+    return tools
+
+
+def count_tool_calls(tools: List[Dict]) -> Dict[str, int]:
+    """Count tool calls by name"""
+    counts = {}
+    for tool in tools:
+        name = tool['tool']
+        counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def has_rg_structural_patterns(tools: List[Dict]) -> bool:
+    """
+    Check for rg structural analysis patterns in shell calls.
+    
+    Looks for rg commands with patterns like 'fn ', 'struct ', 'impl ', 'mod ', 'use '
+    which indicate structural code search rather than generic file search.
+    """
+    structural_keywords = [r'\bfn\s', r'\bstruct\s', r'\bimpl\s', r'\bmod\s', r'\buse\s']
+    
+    for tool in tools:
+        if 'developer__shell' in tool['tool'] or 'shell' in tool['tool'].lower():
+            # Check the command
+            cmd = tool.get('input', {}).get('command', '')
+            if isinstance(cmd, str) and 'rg' in cmd:
+                for pattern in structural_keywords:
+                    if re.search(pattern, cmd):
+                        return True
+    
+    return False
+
+
+def validate_condition_a(tools_by_name: Dict[str, int], tools_list: List[Dict]) -> Tuple[bool, List[str]]:
+    """
+    Validate Condition A:
+    - developer__analyze must be used
+    - code-analyze-mcp__analyze must NOT be used
+    """
+    issues = []
+    
+    # Check for developer__analyze
+    has_analyze = any('analyze' in name and 'code-analyze-mcp' not in name for name in tools_by_name)
+    if not has_analyze:
+        issues.append("ERROR: developer__analyze not used (required for Condition A)")
+    
+    # Check for code-analyze-mcp
+    has_mcp = any('code-analyze-mcp' in name for name in tools_by_name)
+    if has_mcp:
+        issues.append(f"ERROR: code-analyze-mcp tool used (forbidden for Condition A): {[n for n in tools_by_name if 'code-analyze-mcp' in n]}")
+    
+    passed = len(issues) == 0
+    return passed, issues
+
+
+def validate_condition_b(tools_by_name: Dict[str, int], tools_list: List[Dict]) -> Tuple[bool, List[str]]:
+    """
+    Validate Condition B:
+    - code-analyze-mcp__analyze must be used
+    - developer__analyze must NOT be used
+    - rg structural patterns must NOT be present
+    """
+    issues = []
+    
+    # Check for code-analyze-mcp
+    has_mcp = any('code-analyze-mcp' in name for name in tools_by_name)
+    if not has_mcp:
+        issues.append("ERROR: code-analyze-mcp__analyze not used (required for Condition B)")
+    
+    # Check for developer__analyze
+    has_analyze = any('developer__analyze' in name for name in tools_by_name)
+    if has_analyze:
+        issues.append("ERROR: developer__analyze used (forbidden for Condition B; native extension should be disabled)")
+    
+    # Check for rg structural patterns
+    if has_rg_structural_patterns(tools_list):
+        issues.append("WARNING: rg with structural patterns detected (should use code-analyze-mcp for structural analysis)")
+    
+    passed = len(issues) == 0
+    return passed, issues
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Validate tool isolation for a v5 benchmark run'
+    )
+    parser.add_argument(
+        '--session-name',
+        required=True,
+        help='Session name (e.g., R01, R02)'
+    )
+    parser.add_argument(
+        '--condition',
+        required=True,
+        choices=['A', 'B'],
+        help='Expected condition (A or B)'
+    )
+    parser.add_argument(
+        '--db-path',
+        type=Path,
+        default=Path.home() / '.local' / 'share' / 'goose' / 'sessions' / 'sessions.db',
+        help='Path to goose sessions database'
+    )
+    
+    args = parser.parse_args()
+    
+    if not args.db_path.exists():
+        print(f"FAIL: Database not found at {args.db_path}")
+        exit(1)
+    
+    conn = get_db_connection(args.db_path)
+    session_id = get_session_id(conn, args.session_name)
+    
+    if not session_id:
+        print(f"FAIL: Session '{args.session_name}' not found in database")
+        exit(1)
+    
+    messages = get_session_messages(conn, session_id)
+    if not messages:
+        print(f"FAIL: No messages found for session '{args.session_name}'")
+        exit(1)
+    
+    tools = extract_tool_calls(messages)
+    tools_by_name = count_tool_calls(tools)
+    
+    print(f"Session: {args.session_name}")
+    print(f"Condition: {args.condition}")
+    print(f"\nTool usage:")
+    for name, count in sorted(tools_by_name.items()):
+        print(f"  {name}: {count} call(s)")
+    
+    if args.condition == 'A':
+        passed, issues = validate_condition_a(tools_by_name, tools)
+    else:  # B
+        passed, issues = validate_condition_b(tools_by_name, tools)
+    
+    print(f"\nValidation: {'PASS' if passed else 'FAIL'}")
+    
+    if issues:
+        for issue in issues:
+            print(f"  {issue}")
+    
+    exit(0 if passed else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Preparatory artifacts for v5 benchmark (issue #124) comparing code-analyze-mcp (post-optimization, 16 commits since v3) vs developer__analyze on cross-module research tasks. No code changes to code-analyze-mcp. Measurement infrastructure only.

## Changes

### Prompts (`docs/benchmarks/v5/prompts/`)
- **task.md** -- verbatim copy from v3 (identical task for direct comparability)
- **condition-a-control.md** -- verbatim copy from v3 (developer__analyze baseline)
- **condition-b-treatment.md** -- forked from v3 with rg-blocking constraint: *"Do NOT use rg or cat to understand code structure, module layout, or function signatures. Use code-analyze-mcp__analyze exclusively for all structural analysis."*

### Experiment Design
- **run-order.txt** -- randomized 10-run order (seed=124, 5 Condition A + 5 Condition B)
- **scores-template.json** -- scoring template with updated rubric (tool efficiency: 3=<=5 calls, 2=6-10, 1=11-20, 0=>20), v3 baselines embedded, cross-version comparison fields
- **methodology.md** -- full experiment design: conditions table, updated rubric (all 4 dimensions), blinding procedure (seed=124), Mann-Whitney U statistical plan, cross-version comparison strategy (v5B vs v3B optimization delta, v5B vs v3A gap closure), decision framework

### Analysis Scripts (`docs/benchmarks/v5/scripts/`)
- **analyze.py** -- reads filled scores.json, computes Mann-Whitney U + rank-biserial r + cross-version comparisons, outputs markdown tables (scipy optional, graceful fallback)
- **validate.py** -- queries goose sessions DB, validates tool isolation per run (no developer__analyze in B runs, no rg structural patterns in B runs)
- **collect.py** -- extracts session metrics (tokens, wall time, tool calls by type) from goose sessions DB

## Key Design Decisions

1. **v3 comparability preserved**: task.md and Condition A prompt are byte-identical to v3
2. **Tool isolation at two levels**: prompt-level rg-blocking + system-level (methodology documents disabling native analyze extension for Condition B runs)
3. **Tightened tool efficiency rubric**: addresses v3 ceiling effect (all runs scored 3/3 with old threshold of <8 calls)
4. **Scripts are stdlib-first**: sqlite3, json, argparse from Python stdlib; scipy is the only optional dependency (for exact p-values)

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| Condition B disables native analyze extension | Documented in methodology |
| Condition B prompt blocks rg for structural analysis | Exact text from issue |
| Updated rubric with tightened tool efficiency thresholds | 3=<=5, 2=6-10, 1=11-20, 0=>20 |
| Blinded scoring with documented procedure | Seed=124, mapping in scores-template |
| Mann-Whitney U test with effect size | analyze.py implements both |
| Cross-version comparison: v5B vs v3B and v5B vs v3A | In analyze.py and scores-template |
| All artifacts in docs/benchmarks/v5/ | 9 files, all under v5/ |

## Not Included (execution phase, same PR or follow-up)

- Actual benchmark run results (requires 10 separate goose sessions)
- Filled scores and analysis.md (post-execution)

Closes #124 (preparatory phase)

## Testing

- task.md and condition-a-control.md verified byte-identical to v3 via `diff`
- scores-template.json validated as parseable JSON
- All 3 Python scripts pass `py_compile`
- No v3 files modified; no Rust source changes