### PR TITLE
feat(formatter): partition CALLERS into production and test summary

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -460,8 +460,20 @@ pub fn format_focused(
 
     // CALLERS section - who calls this symbol
     let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
+
+    // Partition incoming_chains into production and test callers
+    let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
+        incoming_chains.into_iter().partition(|chain| {
+            chain
+                .chain
+                .first()
+                .is_none_or(|(name, path, _)| !is_test_file(path) && !name.starts_with("test_"))
+        });
+
     output.push_str("CALLERS:\n");
-    let incoming_refs: Vec<_> = incoming_chains
+
+    // Render production callers
+    let prod_refs: Vec<_> = prod_chains
         .iter()
         .filter_map(|chain| {
             if chain.chain.len() >= 2 {
@@ -474,10 +486,38 @@ pub fn format_focused(
         })
         .collect();
 
-    if incoming_refs.is_empty() {
+    if prod_refs.is_empty() {
         output.push_str("  (none)\n");
     } else {
-        output.push_str(&format_chains_as_tree(&incoming_refs, "<-", symbol));
+        output.push_str(&format_chains_as_tree(&prod_refs, "<-", symbol));
+    }
+
+    // Render test callers summary if any
+    if !test_chains.is_empty() {
+        let mut test_files: Vec<_> = test_chains
+            .iter()
+            .filter_map(|chain| {
+                chain
+                    .chain
+                    .first()
+                    .map(|(_, path, _)| path.to_string_lossy().into_owned())
+            })
+            .collect();
+        test_files.sort();
+        test_files.dedup();
+
+        // Strip base path for display
+        let display_files: Vec<_> = test_files
+            .iter()
+            .map(|f| strip_base_path_buf(Path::new(f), base_path))
+            .collect();
+
+        let file_list = display_files.join(", ");
+        output.push_str(&format!(
+            "CALLERS (test): {} test functions (in {})\n",
+            test_chains.len(),
+            file_list
+        ));
     }
 
     // CALLEES section - what this symbol calls
@@ -504,7 +544,7 @@ pub fn format_focused(
 
     // STATISTICS section
     output.push_str("STATISTICS:\n");
-    let incoming_count = incoming_refs
+    let incoming_count = prod_refs
         .iter()
         .map(|(p, _)| p)
         .collect::<std::collections::HashSet<_>>()
@@ -517,9 +557,9 @@ pub fn format_focused(
     output.push_str(&format!("  Incoming calls: {}\n", incoming_count));
     output.push_str(&format!("  Outgoing calls: {}\n", outgoing_count));
 
-    // FILES section - collect unique files from chains
+    // FILES section - collect unique files from production chains
     let mut files = HashSet::new();
-    for chain in &incoming_chains {
+    for chain in &prod_chains {
         for (_, path, _) in &chain.chain {
             files.insert(path.clone());
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2366,3 +2366,173 @@ pub fn isolated() {
     let has_none = lines.iter().any(|l| l.trim() == "(none)");
     assert!(has_none, "Empty chains should render (none)");
 }
+
+#[test]
+fn test_callers_mixed_prod_and_test() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Arrange: Create a crate with mixed production and test callers
+    fs::create_dir(root.join("src")).unwrap();
+    fs::create_dir(root.join("tests")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn target() {}
+
+pub fn prod_caller_a() {
+    target();
+}
+
+pub fn prod_caller_b() {
+    target();
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("tests/test_module.rs"),
+        r#"
+use code_analyze_mcp::*;
+
+#[test]
+fn test_target() {
+    target();
+}
+"#,
+    )
+    .unwrap();
+
+    // Act: Format focused output
+    let output = analyze_focused(root, "target", 1, None, None).unwrap();
+
+    // Assert: Production callers in CALLERS section, test summary in CALLERS (test)
+    let lines: Vec<&str> = output.formatted.lines().collect();
+
+    // Find CALLERS section
+    let callers_idx = lines
+        .iter()
+        .position(|l| l.contains("CALLERS:"))
+        .expect("Should have CALLERS section");
+
+    // Verify production callers are shown
+    let callers_content = &lines[callers_idx + 1..];
+    let has_prod_caller = callers_content
+        .iter()
+        .take_while(|l| {
+            !l.starts_with("STATISTICS:") && !l.starts_with("CALLERS (test):") && !l.is_empty()
+        })
+        .any(|l| l.contains("prod_caller_a") || l.contains("prod_caller_b"));
+    assert!(
+        has_prod_caller,
+        "Should have production callers in CALLERS section"
+    );
+
+    // Verify test callers summary line exists
+    let has_test_summary = output.formatted.contains("CALLERS (test):");
+    assert!(has_test_summary, "Should have CALLERS (test): summary line");
+
+    // Verify test summary contains file reference
+    let has_test_file_ref = output.formatted.contains("test_module.rs");
+    assert!(has_test_file_ref, "Test summary should reference test file");
+}
+
+#[test]
+fn test_callers_all_test() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Arrange: Create a crate with only test callers
+    fs::create_dir(root.join("src")).unwrap();
+    fs::create_dir(root.join("tests")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn target() {}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("tests/test_all.rs"),
+        r#"
+use code_analyze_mcp::*;
+
+#[test]
+fn test_target_a() {
+    target();
+}
+
+#[test]
+fn test_target_b() {
+    target();
+}
+"#,
+    )
+    .unwrap();
+
+    // Act: Format focused output
+    let output = analyze_focused(root, "target", 1, None, None).unwrap();
+
+    // Assert: CALLERS shows (none), CALLERS (test) shows test summary
+    let lines: Vec<&str> = output.formatted.lines().collect();
+
+    let callers_idx = lines
+        .iter()
+        .position(|l| l.contains("CALLERS:"))
+        .expect("Should have CALLERS section");
+
+    // Check that production callers show (none)
+    let callers_section: Vec<&str> = lines[callers_idx + 1..]
+        .iter()
+        .take_while(|l| !l.starts_with("STATISTICS:") && !l.starts_with("CALLERS (test):"))
+        .copied()
+        .collect();
+
+    let has_none = callers_section.iter().any(|l| l.trim() == "(none)");
+    assert!(has_none, "Production callers should show (none)");
+
+    // Verify test summary exists
+    let has_test_summary = output.formatted.contains("CALLERS (test):");
+    assert!(has_test_summary, "Should have CALLERS (test): summary line");
+}
+
+#[test]
+fn test_callers_all_prod_no_test_line() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Arrange: Create a crate with only production callers
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn target() {}
+
+pub fn caller_one() {
+    target();
+}
+
+pub fn caller_two() {
+    target();
+}
+"#,
+    )
+    .unwrap();
+
+    // Act: Format focused output
+    let output = analyze_focused(root, "target", 1, None, None).unwrap();
+
+    // Assert: CALLERS section shows callers, no CALLERS (test) line
+    assert!(
+        output.formatted.contains("CALLERS:"),
+        "Should have CALLERS section"
+    );
+    assert!(
+        output.formatted.contains("caller_one") || output.formatted.contains("caller_two"),
+        "Should have production callers"
+    );
+    assert!(
+        !output.formatted.contains("CALLERS (test):"),
+        "Should NOT have CALLERS (test) line with only production callers"
+    );
+}


### PR DESCRIPTION
## Summary

Partition the CALLERS section in `format_focused()` output so production callers display in full tree-indent detail and test callers collapse into a single summary line with count and unique file locations.

## Changes

- **`src/formatter.rs`**: After computing `incoming_chains`, partition into `prod_chains` and `test_chains` using `is_test_file()` on the caller's file path and a `test_` prefix check on the caller function name. Production callers render via `format_chains_as_tree()`; test callers render as a one-line summary: `CALLERS (test): N test functions (in file1.rs, file2.rs)`. STATISTICS and FILES sections updated to count production callers only.
- **`tests/integration_tests.rs`**: Three new integration tests covering mixed prod/test callers, all-test callers, and all-production callers.

## Target format

```
CALLERS:
  fetch <- from_path
  recurse_into <- from_path
CALLERS (test): 50 test functions (in display.rs, sort.rs, meta/mod.rs)
```

## Edge cases

- All-test callers: `CALLERS: (none)` + test summary line
- All-production callers: normal output, no `CALLERS (test)` line
- No callers: existing `(none)` format unchanged

## Testing

```
cargo test       # 108 passed, 0 failed
cargo clippy     # clean
cargo fmt --check # clean
cargo deny check # clean
```

Closes #132