### PR TITLE
feat(formatter): add summary counts to FOCUS header

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -438,8 +438,39 @@ pub fn format_focused(
 ) -> Result<String, FormatterError> {
     let mut output = String::new();
 
-    // FOCUS section
-    output.push_str(&format!("FOCUS: {}\n", symbol));
+    // Compute all counts BEFORE output begins
+    let def_count = graph.definitions.get(symbol).map_or(0, |d| d.len());
+    let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
+    let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
+
+    // Partition incoming_chains into production and test callers
+    let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
+        incoming_chains.clone().into_iter().partition(|chain| {
+            chain
+                .chain
+                .first()
+                .is_none_or(|(name, path, _)| !is_test_file(path) && !name.starts_with("test_"))
+        });
+
+    // Count unique callers
+    let callers_count = prod_chains
+        .iter()
+        .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    // Count unique callees
+    let callees_count = outgoing_chains
+        .iter()
+        .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    // FOCUS section - with inline counts
+    output.push_str(&format!(
+        "FOCUS: {} ({} defs, {} callers, {} callees)\n",
+        symbol, def_count, callers_count, callees_count
+    ));
 
     // DEPTH section
     output.push_str(&format!("DEPTH: {}\n", follow_depth));
@@ -459,17 +490,6 @@ pub fn format_focused(
     }
 
     // CALLERS section - who calls this symbol
-    let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
-
-    // Partition incoming_chains into production and test callers
-    let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
-        incoming_chains.into_iter().partition(|chain| {
-            chain
-                .chain
-                .first()
-                .is_none_or(|(name, path, _)| !is_test_file(path) && !name.starts_with("test_"))
-        });
-
     output.push_str("CALLERS:\n");
 
     // Render production callers
@@ -521,7 +541,6 @@ pub fn format_focused(
     }
 
     // CALLEES section - what this symbol calls
-    let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
     output.push_str("CALLEES:\n");
     let outgoing_refs: Vec<_> = outgoing_chains
         .iter()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2368,6 +2368,58 @@ pub fn isolated() {
 }
 
 #[test]
+fn test_focus_header_includes_counts() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Arrange: Create a crate with known call graph for counting
+    fs::create_dir(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn main_func() {
+    helper_a();
+}
+
+pub fn helper_a() {
+    helper_b();
+}
+
+pub fn helper_b() {}
+"#,
+    )
+    .unwrap();
+
+    // Act: Format focused output for main_func with depth 2
+    let output = analyze_focused(root, "main_func", 2, None, None).unwrap();
+
+    // Assert: Header should contain counts
+    assert!(
+        output.formatted.starts_with("FOCUS: main_func (1 defs, "),
+        "Header should start with symbol name and def count: {}",
+        output.formatted.lines().next().unwrap()
+    );
+
+    // Verify the exact format: "FOCUS: main_func (1 defs, N callers, N callees)"
+    let first_line = output.formatted.lines().next().unwrap();
+    assert!(
+        first_line.contains("defs,"),
+        "Header should contain 'defs,': {}",
+        first_line
+    );
+    assert!(
+        first_line.contains("callers,"),
+        "Header should contain 'callers,': {}",
+        first_line
+    );
+    assert!(
+        first_line.contains("callees"),
+        "Header should contain 'callees': {}",
+        first_line
+    );
+}
+
+#[test]
 fn test_callers_mixed_prod_and_test() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();


### PR DESCRIPTION
## Summary

Add definition, caller, and callee counts to the FOCUS header line in symbol-focused analysis output. The parenthesized counts give the LLM an immediate structural overview, reducing follow-up queries.

**Before:** `FOCUS: from_path`
**After:** `FOCUS: from_path (2 defs, 68 callers, 70 callees)`

## Changes

- **src/formatter.rs**: Reorder chain computation before header output in `format_focused()`; interpolate `.len()` counts into the FOCUS format string
- **tests/integration_tests.rs**: Add `test_focus_header_includes_counts` validating header format and count keywords

## Testing

```
cargo test        # 74 passed, 0 failed
cargo clippy      # clean
cargo fmt --check # clean
cargo deny check  # clean
```

Closes #133