### PR TITLE
feat(pagination): wire pagination for FileDetails and SymbolFocus output

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -2,7 +2,7 @@ use crate::dataflow::DataflowGraph;
 use crate::formatter::{
     format_file_details, format_focused, format_focused_summary, format_structure,
 };
-use crate::graph::CallGraph;
+use crate::graph::{CallChain, CallGraph};
 use crate::lang::language_from_extension;
 use crate::parser::{ElementExtractor, SemanticExtractor};
 use crate::test_detection::is_test_file;
@@ -250,6 +250,23 @@ pub struct FocusedAnalysisOutput {
         description = "Opaque cursor token for the next page of results (absent when no more results)"
     )]
     pub next_cursor: Option<String>,
+    /// Production caller chains (partitioned from incoming chains, excluding test callers).
+    /// Not serialized; used for pagination in lib.rs.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub prod_chains: Vec<CallChain>,
+    /// Test caller chains. Not serialized; used for pagination summary in lib.rs.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub test_chains: Vec<CallChain>,
+    /// Outgoing (callee) chains. Not serialized; used for pagination in lib.rs.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub outgoing_chains: Vec<CallChain>,
+    /// Number of definitions for the symbol. Not serialized; used for pagination headers.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub def_count: usize,
 }
 
 /// Analyze a symbol's call graph across a directory with progress tracking.
@@ -279,6 +296,10 @@ pub fn analyze_focused_with_progress(
         return Ok(FocusedAnalysisOutput {
             formatted,
             next_cursor: None,
+            prod_chains: vec![],
+            test_chains: vec![],
+            outgoing_chains: vec![],
+            def_count: 0,
         });
     }
 
@@ -342,6 +363,19 @@ pub fn analyze_focused_with_progress(
     let dataflow = DataflowGraph::build_from_results(&analysis_results);
     let graph = CallGraph::build_from_results(analysis_results)?;
 
+    // Compute chain data for pagination (always, regardless of summary mode)
+    let def_count = graph.definitions.get(focus).map_or(0, |d| d.len());
+    let incoming_chains = graph.find_incoming_chains(focus, follow_depth)?;
+    let outgoing_chains = graph.find_outgoing_chains(focus, follow_depth)?;
+
+    let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
+        incoming_chains.into_iter().partition(|chain| {
+            chain
+                .chain
+                .first()
+                .is_none_or(|(name, path, _)| !is_test_file(path) && !name.starts_with("test_"))
+        });
+
     // Format output
     let formatted = if use_summary {
         format_focused_summary(&graph, &dataflow, focus, follow_depth, Some(root))?
@@ -352,6 +386,10 @@ pub fn analyze_focused_with_progress(
     Ok(FocusedAnalysisOutput {
         formatted,
         next_cursor: None,
+        prod_chains,
+        test_chains,
+        outgoing_chains,
+        def_count,
     })
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,8 +1,9 @@
 use crate::dataflow::DataflowGraph;
+use crate::graph::CallChain;
 use crate::graph::CallGraph;
 use crate::test_detection::is_test_file;
 use crate::traversal::WalkEntry;
-use crate::types::{FileInfo, SemanticAnalysis};
+use crate::types::{FileInfo, FunctionInfo, SemanticAnalysis};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::path::Path;
@@ -1103,6 +1104,303 @@ pub fn format_structure_paginated(
         output.push_str("\nTEST FILES [LOC, FUNCTIONS, CLASSES]\n");
         for file in &test_files {
             output.push_str(&format_file_entry(file, base_path));
+        }
+    }
+
+    output
+}
+
+/// Format a paginated subset of functions for FileDetails mode.
+/// Shows classes and imports only on the first page (offset == 0).
+/// Header shows position context: `FILE: path (NL, start-end/totalF, CC, II)`.
+#[instrument(skip_all)]
+pub fn format_file_details_paginated(
+    functions_page: &[FunctionInfo],
+    total_functions: usize,
+    semantic: &SemanticAnalysis,
+    path: &str,
+    line_count: usize,
+    offset: usize,
+    page_size: usize,
+) -> String {
+    let _ = page_size; // kept for API symmetry; end is derived from slice length
+    let mut output = String::new();
+
+    let start = offset + 1; // 1-indexed for display
+    let end = offset + functions_page.len();
+
+    output.push_str(&format!(
+        "FILE: {} ({}L, {}-{}/{}F, {}C, {}I)\n",
+        path,
+        line_count,
+        start,
+        end,
+        total_functions,
+        semantic.classes.len(),
+        semantic.imports.len(),
+    ));
+
+    // Classes and imports sections only on first page
+    if offset == 0 {
+        // C: section with classes
+        if !semantic.classes.is_empty() {
+            output.push_str("C:\n");
+            if semantic.classes.len() <= MULTILINE_THRESHOLD {
+                let class_strs: Vec<String> = semantic
+                    .classes
+                    .iter()
+                    .map(|class| {
+                        if class.inherits.is_empty() {
+                            format!("{}:{}", class.name, class.line)
+                        } else {
+                            format!(
+                                "{}:{} ({})",
+                                class.name,
+                                class.line,
+                                class.inherits.join(", ")
+                            )
+                        }
+                    })
+                    .collect();
+                output.push_str("  ");
+                output.push_str(&class_strs.join("; "));
+                output.push('\n');
+            } else {
+                for class in &semantic.classes {
+                    if class.inherits.is_empty() {
+                        output.push_str(&format!("  {}:{}\n", class.name, class.line));
+                    } else {
+                        output.push_str(&format!(
+                            "  {}:{} ({})\n",
+                            class.name,
+                            class.line,
+                            class.inherits.join(", ")
+                        ));
+                    }
+                }
+            }
+        }
+
+        // I: section with imports
+        if !semantic.imports.is_empty() {
+            output.push_str("I:\n");
+            let mut module_map: HashMap<String, usize> = HashMap::new();
+            for import in &semantic.imports {
+                module_map
+                    .entry(import.module.clone())
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+
+            let mut modules: Vec<_> = module_map.keys().cloned().collect();
+            modules.sort();
+
+            let formatted_modules: Vec<String> = modules
+                .iter()
+                .map(|module| format!("{}({})", module, module_map[module]))
+                .collect();
+
+            if formatted_modules.len() <= MULTILINE_THRESHOLD {
+                output.push_str("  ");
+                output.push_str(&formatted_modules.join("; "));
+                output.push('\n');
+            } else {
+                for module_str in formatted_modules {
+                    output.push_str("  ");
+                    output.push_str(&module_str);
+                    output.push('\n');
+                }
+            }
+        }
+    }
+
+    // F: section with paginated function slice
+    if !functions_page.is_empty() {
+        output.push_str("F:\n");
+        let mut line = String::from("  ");
+        for (i, func) in functions_page.iter().enumerate() {
+            let mut call_marker = func.compact_signature();
+
+            if let Some(&count) = semantic.call_frequency.get(&func.name)
+                && count > 3
+            {
+                write!(call_marker, "\u{2022}{}", count).ok();
+            }
+
+            if i == 0 {
+                line.push_str(&call_marker);
+            } else if line.len() + call_marker.len() + 2 > 100 {
+                output.push_str(&line);
+                output.push('\n');
+                let mut new_line = String::with_capacity(2 + call_marker.len());
+                new_line.push_str("  ");
+                new_line.push_str(&call_marker);
+                line = new_line;
+            } else {
+                line.push_str(", ");
+                line.push_str(&call_marker);
+            }
+        }
+        if !line.trim().is_empty() {
+            output.push_str(&line);
+            output.push('\n');
+        }
+    }
+
+    output
+}
+
+/// Parameters for `format_focused_paginated`.
+pub struct FocusedPaginatedParams<'a> {
+    pub paginated_chains: &'a [CallChain],
+    pub total: usize,
+    pub mode: &'a str,
+    pub symbol: &'a str,
+    pub prod_chains: &'a [CallChain],
+    pub test_chains: &'a [CallChain],
+    pub outgoing_chains: &'a [CallChain],
+    pub def_count: usize,
+    pub offset: usize,
+    pub base_path: Option<&'a Path>,
+}
+
+/// Format a paginated subset of callers or callees for SymbolFocus mode.
+/// Mode is determined by the `mode` parameter:
+/// - `SYMBOL_FOCUS_CALLERS_MODE`: paginate production callers; show test callers summary and callees summary.
+/// - `SYMBOL_FOCUS_CALLEES_MODE`: paginate callees; show callers summary and test callers summary.
+#[instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
+pub fn format_focused_paginated(
+    paginated_chains: &[CallChain],
+    total: usize,
+    mode: &str,
+    symbol: &str,
+    prod_chains: &[CallChain],
+    test_chains: &[CallChain],
+    outgoing_chains: &[CallChain],
+    def_count: usize,
+    offset: usize,
+    base_path: Option<&Path>,
+) -> String {
+    let start = offset + 1; // 1-indexed
+    let end = offset + paginated_chains.len();
+
+    let callers_count = prod_chains
+        .iter()
+        .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let callees_count = outgoing_chains
+        .iter()
+        .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let mut output = String::new();
+
+    output.push_str(&format!(
+        "FOCUS: {} ({} defs, {} callers, {} callees)\n",
+        symbol, def_count, callers_count, callees_count
+    ));
+
+    if crate::pagination::SYMBOL_FOCUS_CALLERS_MODE == mode {
+        // Paginate production callers
+        output.push_str(&format!("CALLERS ({}-{} of {}):\n", start, end, total));
+
+        let page_refs: Vec<_> = paginated_chains
+            .iter()
+            .filter_map(|chain| {
+                if chain.chain.len() >= 2 {
+                    Some((chain.chain[0].0.as_str(), chain.chain[1].0.as_str()))
+                } else if chain.chain.len() == 1 {
+                    Some((chain.chain[0].0.as_str(), ""))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if page_refs.is_empty() {
+            output.push_str("  (none)\n");
+        } else {
+            output.push_str(&format_chains_as_tree(&page_refs, "<-", symbol));
+        }
+
+        // Test callers summary
+        if !test_chains.is_empty() {
+            let mut test_files: Vec<_> = test_chains
+                .iter()
+                .filter_map(|chain| {
+                    chain
+                        .chain
+                        .first()
+                        .map(|(_, path, _)| path.to_string_lossy().into_owned())
+                })
+                .collect();
+            test_files.sort();
+            test_files.dedup();
+
+            let display_files: Vec<_> = test_files
+                .iter()
+                .map(|f| strip_base_path_buf(std::path::Path::new(f), base_path))
+                .collect();
+
+            output.push_str(&format!(
+                "CALLERS (test): {} test functions (in {})\n",
+                test_chains.len(),
+                display_files.join(", ")
+            ));
+        }
+
+        // Callees summary
+        let callee_names: Vec<_> = outgoing_chains
+            .iter()
+            .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p.clone()))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        if callee_names.is_empty() {
+            output.push_str("CALLEES: (none)\n");
+        } else {
+            output.push_str(&format!(
+                "CALLEES: {} (use cursor for callee pagination)\n",
+                callees_count
+            ));
+        }
+    } else {
+        // SYMBOL_FOCUS_CALLEES_MODE: paginate callees
+        // Callers summary
+        output.push_str(&format!("CALLERS: {} production callers\n", callers_count));
+
+        // Test callers summary
+        if !test_chains.is_empty() {
+            output.push_str(&format!(
+                "CALLERS (test): {} test functions\n",
+                test_chains.len()
+            ));
+        }
+
+        // Paginate callees
+        output.push_str(&format!("CALLEES ({}-{} of {}):\n", start, end, total));
+
+        let page_refs: Vec<_> = paginated_chains
+            .iter()
+            .filter_map(|chain| {
+                if chain.chain.len() >= 2 {
+                    Some((chain.chain[0].0.as_str(), chain.chain[1].0.as_str()))
+                } else if chain.chain.len() == 1 {
+                    Some((chain.chain[0].0.as_str(), ""))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if page_refs.is_empty() {
+            output.push_str("  (none)\n");
+        } else {
+            output.push_str(&format_chains_as_tree(&page_refs, "->", symbol));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,15 @@ pub mod traversal;
 pub mod types;
 
 use cache::AnalysisCache;
-use formatter::{format_file_details_summary, format_structure_paginated, format_summary};
+use formatter::{
+    format_file_details_paginated, format_file_details_summary, format_focused_paginated,
+    format_structure_paginated, format_summary,
+};
 use logging::LogEvent;
-use pagination::{DEFAULT_PAGE_SIZE, decode_cursor, paginate_slice};
+use pagination::{
+    CursorData, DEFAULT_PAGE_SIZE, SYMBOL_FOCUS_CALLEES_MODE, SYMBOL_FOCUS_CALLERS_MODE,
+    decode_cursor, encode_cursor, paginate_slice,
+};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
@@ -422,6 +428,10 @@ impl CodeAnalyzer {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: "Analysis cancelled".to_string(),
                             next_cursor: None,
+                            prod_chains: vec![],
+                            test_chains: vec![],
+                            outgoing_chains: vec![],
+                            def_count: 0,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
@@ -429,6 +439,10 @@ impl CodeAnalyzer {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Error analyzing symbol focus: {}", e),
                             next_cursor: None,
+                            prod_chains: vec![],
+                            test_chains: vec![],
+                            outgoing_chains: vec![],
+                            def_count: 0,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
@@ -436,6 +450,10 @@ impl CodeAnalyzer {
                         let output = analyze::FocusedAnalysisOutput {
                             formatted: format!("Task join error: {}", e),
                             next_cursor: None,
+                            prod_chains: vec![],
+                            test_chains: vec![],
+                            outgoing_chains: vec![],
+                            def_count: 0,
                         };
                         types::ModeResult::SymbolFocus(output)
                     }
@@ -541,6 +559,19 @@ impl CodeAnalyzer {
                         ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
                     })?;
 
+                // Regenerate formatted output from the paginated slice when pagination is active
+                if paginated.next_cursor.is_some() || offset > 0 {
+                    output.formatted = format_file_details_paginated(
+                        &paginated.items,
+                        paginated.total,
+                        &output.semantic,
+                        &params.path,
+                        output.line_count,
+                        offset,
+                        page_size,
+                    );
+                }
+
                 // Update next_cursor in output after pagination
                 output.next_cursor = paginated.next_cursor.clone();
 
@@ -615,9 +646,130 @@ impl CodeAnalyzer {
                     ));
                 }
 
-                // SymbolFocus: no semantic data to paginate
+                // SymbolFocus pagination: decode cursor mode to determine callers vs callees
+                let cursor_mode = if let Some(ref cursor_str) = params.cursor {
+                    decode_cursor(cursor_str)
+                        .map(|c| c.mode)
+                        .unwrap_or_else(|_| SYMBOL_FOCUS_CALLERS_MODE.to_string())
+                } else {
+                    SYMBOL_FOCUS_CALLERS_MODE.to_string()
+                };
+
+                let paginated_next_cursor = if cursor_mode == SYMBOL_FOCUS_CALLERS_MODE {
+                    // Paginate production callers
+                    let paginated = paginate_slice(&output.prod_chains, offset, page_size)
+                        .map_err(|e| {
+                            ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                e.to_string(),
+                                None,
+                            )
+                        })?;
+
+                    if paginated.next_cursor.is_some() || offset > 0 {
+                        // Re-encode cursor with correct mode
+                        let next = if let Some(raw_cursor) = paginated.next_cursor {
+                            let decoded = decode_cursor(&raw_cursor).map_err(|e| {
+                                ErrorData::new(
+                                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                    e.to_string(),
+                                    None,
+                                )
+                            })?;
+                            Some(
+                                encode_cursor(&CursorData {
+                                    mode: SYMBOL_FOCUS_CALLERS_MODE.to_string(),
+                                    offset: decoded.offset,
+                                })
+                                .map_err(|e| {
+                                    ErrorData::new(
+                                        rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                        e.to_string(),
+                                        None,
+                                    )
+                                })?,
+                            )
+                        } else {
+                            None
+                        };
+
+                        let focus_symbol = params.focus.as_deref().unwrap_or("");
+                        let base_path = Path::new(&params.path);
+                        output.formatted = format_focused_paginated(
+                            &paginated.items,
+                            paginated.total,
+                            SYMBOL_FOCUS_CALLERS_MODE,
+                            focus_symbol,
+                            &output.prod_chains,
+                            &output.test_chains,
+                            &output.outgoing_chains,
+                            output.def_count,
+                            offset,
+                            Some(base_path),
+                        );
+                        next
+                    } else {
+                        None
+                    }
+                } else {
+                    // Paginate callees (SYMBOL_FOCUS_CALLEES_MODE)
+                    let paginated = paginate_slice(&output.outgoing_chains, offset, page_size)
+                        .map_err(|e| {
+                            ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                e.to_string(),
+                                None,
+                            )
+                        })?;
+
+                    if paginated.next_cursor.is_some() || offset > 0 {
+                        let next = if let Some(raw_cursor) = paginated.next_cursor {
+                            let decoded = decode_cursor(&raw_cursor).map_err(|e| {
+                                ErrorData::new(
+                                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                    e.to_string(),
+                                    None,
+                                )
+                            })?;
+                            Some(
+                                encode_cursor(&CursorData {
+                                    mode: SYMBOL_FOCUS_CALLEES_MODE.to_string(),
+                                    offset: decoded.offset,
+                                })
+                                .map_err(|e| {
+                                    ErrorData::new(
+                                        rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                        e.to_string(),
+                                        None,
+                                    )
+                                })?,
+                            )
+                        } else {
+                            None
+                        };
+
+                        let focus_symbol = params.focus.as_deref().unwrap_or("");
+                        let base_path = Path::new(&params.path);
+                        output.formatted = format_focused_paginated(
+                            &paginated.items,
+                            paginated.total,
+                            SYMBOL_FOCUS_CALLEES_MODE,
+                            focus_symbol,
+                            &output.prod_chains,
+                            &output.test_chains,
+                            &output.outgoing_chains,
+                            output.def_count,
+                            offset,
+                            Some(base_path),
+                        );
+                        next
+                    } else {
+                        None
+                    }
+                };
+
                 let structured = serde_json::to_value(&output).unwrap_or(Value::Null);
-                (output.formatted, output.next_cursor, structured)
+                (output.formatted, paginated_next_cursor, structured)
             }
         };
 

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -5,6 +5,9 @@ use thiserror::Error;
 
 pub const DEFAULT_PAGE_SIZE: usize = 100;
 
+pub const SYMBOL_FOCUS_CALLERS_MODE: &str = "symbol_focus_callers";
+pub const SYMBOL_FOCUS_CALLEES_MODE: &str = "symbol_focus_callees";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CursorData {
     pub mode: String,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2800,3 +2800,469 @@ fn test_format_file_details_summary_many_classes() {
         "Should show remaining count"
     );
 }
+
+// --- FileDetails pagination tests (issue #146) ---
+
+#[test]
+fn test_file_details_pagination_first_page() {
+    use code_analyze_mcp::formatter::format_file_details_paginated;
+    use code_analyze_mcp::pagination::{decode_cursor, paginate_slice};
+    use code_analyze_mcp::types::{FunctionInfo, SemanticAnalysis};
+    use std::collections::HashMap;
+
+    // Arrange: 25 functions, page_size=10
+    let functions: Vec<FunctionInfo> = (0..25)
+        .map(|i| FunctionInfo {
+            name: format!("fn_{:02}", i),
+            line: i + 1,
+            end_line: i + 5,
+            parameters: vec![],
+            return_type: None,
+        })
+        .collect();
+
+    let semantic = SemanticAnalysis {
+        functions: functions.clone(),
+        classes: vec![],
+        imports: vec![],
+        references: vec![],
+        call_frequency: HashMap::new(),
+        calls: vec![],
+        assignments: vec![],
+        field_accesses: vec![],
+    };
+
+    // Act: paginate first page
+    let paginated = paginate_slice(&functions, 0, 10).expect("paginate failed");
+    assert_eq!(paginated.items.len(), 10);
+    assert!(paginated.next_cursor.is_some());
+    assert_eq!(paginated.total, 25);
+
+    let formatted = format_file_details_paginated(
+        &paginated.items,
+        paginated.total,
+        &semantic,
+        "src/lib.rs",
+        500,
+        0,
+        10,
+    );
+
+    // Assert: header shows position, F: section present
+    assert!(
+        formatted.contains("1-10/25F"),
+        "header should show 1-10/25F"
+    );
+    assert!(formatted.contains("F:"), "should have F: section");
+    assert!(formatted.contains("fn_00"), "first function should appear");
+    assert!(
+        !formatted.contains("fn_10"),
+        "11th function should not appear"
+    );
+
+    // Verify cursor round-trip
+    let cursor_str = paginated.next_cursor.unwrap();
+    let cursor_data = decode_cursor(&cursor_str).expect("decode failed");
+    assert_eq!(cursor_data.offset, 10);
+}
+
+#[test]
+fn test_file_details_pagination_last_page() {
+    use code_analyze_mcp::formatter::format_file_details_paginated;
+    use code_analyze_mcp::pagination::paginate_slice;
+    use code_analyze_mcp::types::{FunctionInfo, SemanticAnalysis};
+    use std::collections::HashMap;
+
+    // Arrange: 25 functions, page 2 starts at offset 10 with page_size 20 -> 15 items remaining
+    let functions: Vec<FunctionInfo> = (0..25)
+        .map(|i| FunctionInfo {
+            name: format!("fn_{:02}", i),
+            line: i + 1,
+            end_line: i + 5,
+            parameters: vec![],
+            return_type: None,
+        })
+        .collect();
+
+    let semantic = SemanticAnalysis {
+        functions: functions.clone(),
+        classes: vec![],
+        imports: vec![],
+        references: vec![],
+        call_frequency: HashMap::new(),
+        calls: vec![],
+        assignments: vec![],
+        field_accesses: vec![],
+    };
+
+    // Act: paginate last page (offset=10, page_size=20 -> items 10..25)
+    let paginated = paginate_slice(&functions, 10, 20).expect("paginate failed");
+    assert_eq!(paginated.items.len(), 15);
+    assert!(
+        paginated.next_cursor.is_none(),
+        "last page should have no next_cursor"
+    );
+
+    let formatted = format_file_details_paginated(
+        &paginated.items,
+        paginated.total,
+        &semantic,
+        "src/lib.rs",
+        500,
+        10,
+        20,
+    );
+
+    // Assert: header shows correct range
+    assert!(
+        formatted.contains("11-25/25F"),
+        "header should show 11-25/25F"
+    );
+    // Classes and imports NOT shown on non-first page
+    assert!(
+        !formatted.contains("C:"),
+        "classes should not appear on non-first page"
+    );
+    assert!(
+        !formatted.contains("I:"),
+        "imports should not appear on non-first page"
+    );
+}
+
+#[test]
+fn test_file_details_single_page_no_cursor() {
+    use code_analyze_mcp::pagination::paginate_slice;
+    use code_analyze_mcp::types::FunctionInfo;
+
+    // Arrange: 5 functions, page_size=100
+    let functions: Vec<FunctionInfo> = (0..5)
+        .map(|i| FunctionInfo {
+            name: format!("fn_{}", i),
+            line: i + 1,
+            end_line: i + 5,
+            parameters: vec![],
+            return_type: None,
+        })
+        .collect();
+
+    // Act
+    let paginated = paginate_slice(&functions, 0, 100).expect("paginate failed");
+
+    // Assert: single page, no cursor
+    assert_eq!(paginated.items.len(), 5);
+    assert!(
+        paginated.next_cursor.is_none(),
+        "single page should have no next_cursor"
+    );
+    assert_eq!(paginated.total, 5);
+}
+
+#[test]
+fn test_file_details_invalid_cursor() {
+    use code_analyze_mcp::pagination::decode_cursor;
+
+    // Act
+    let result = decode_cursor("this-is-not-valid-base64!!!");
+
+    // Assert
+    assert!(result.is_err(), "invalid cursor should produce an error");
+}
+
+// --- SymbolFocus pagination tests (issue #146) ---
+
+#[test]
+fn test_symbol_focus_callers_pagination_first_page() {
+    use code_analyze_mcp::analyze::analyze_focused;
+    use code_analyze_mcp::pagination::{SYMBOL_FOCUS_CALLERS_MODE, paginate_slice};
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // Create a file with many callers of `target`
+    let mut code = String::from("fn target() {}\n");
+    for i in 0..15 {
+        code.push_str(&format!("fn caller_{:02}() {{ target(); }}\n", i));
+    }
+    fs::write(temp_dir.path().join("lib.rs"), &code).unwrap();
+
+    // Act
+    let output = analyze_focused(temp_dir.path(), "target", 1, None, None).unwrap();
+
+    // Paginate prod callers with page_size=5
+    let paginated = paginate_slice(&output.prod_chains, 0, 5).expect("paginate failed");
+    assert!(
+        paginated.total >= 5,
+        "should have enough callers to paginate"
+    );
+    assert!(
+        paginated.next_cursor.is_some(),
+        "should have next_cursor for page 1"
+    );
+
+    // Verify cursor encodes callers mode
+    let _ = SYMBOL_FOCUS_CALLERS_MODE; // used to verify constant exists
+    assert_eq!(paginated.items.len(), 5);
+}
+
+#[test]
+fn test_symbol_focus_callers_pagination_second_page() {
+    use code_analyze_mcp::analyze::analyze_focused;
+    use code_analyze_mcp::formatter::format_focused_paginated;
+    use code_analyze_mcp::pagination::{SYMBOL_FOCUS_CALLERS_MODE, decode_cursor, paginate_slice};
+
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut code = String::from("fn target() {}\n");
+    for i in 0..12 {
+        code.push_str(&format!("fn caller_{:02}() {{ target(); }}\n", i));
+    }
+    fs::write(temp_dir.path().join("lib.rs"), &code).unwrap();
+
+    let output = analyze_focused(temp_dir.path(), "target", 1, None, None).unwrap();
+    let total_prod = output.prod_chains.len();
+
+    if total_prod > 5 {
+        // Get page 1 cursor
+        let p1 = paginate_slice(&output.prod_chains, 0, 5).expect("paginate failed");
+        assert!(p1.next_cursor.is_some());
+
+        let cursor_str = p1.next_cursor.unwrap();
+        let cursor_data = decode_cursor(&cursor_str).expect("decode failed");
+
+        // Get page 2
+        let p2 =
+            paginate_slice(&output.prod_chains, cursor_data.offset, 5).expect("paginate failed");
+
+        // Format paginated output
+        let formatted = format_focused_paginated(
+            &p2.items,
+            total_prod,
+            SYMBOL_FOCUS_CALLERS_MODE,
+            "target",
+            &output.prod_chains,
+            &output.test_chains,
+            &output.outgoing_chains,
+            output.def_count,
+            cursor_data.offset,
+            Some(temp_dir.path()),
+        );
+
+        // Assert: header shows correct range for page 2
+        let expected_start = cursor_data.offset + 1;
+        assert!(
+            formatted.contains(&format!("CALLERS ({}", expected_start)),
+            "header should show page 2 range, got: {}",
+            formatted
+        );
+    }
+}
+
+#[test]
+fn test_symbol_focus_callees_pagination() {
+    use code_analyze_mcp::analyze::analyze_focused;
+    use code_analyze_mcp::formatter::format_focused_paginated;
+    use code_analyze_mcp::pagination::{SYMBOL_FOCUS_CALLEES_MODE, paginate_slice};
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // target calls many functions
+    let mut code = String::from("fn target() {\n");
+    for i in 0..10 {
+        code.push_str(&format!("    callee_{:02}();\n", i));
+    }
+    code.push_str("}\n");
+    for i in 0..10 {
+        code.push_str(&format!("fn callee_{:02}() {{}}\n", i));
+    }
+    fs::write(temp_dir.path().join("lib.rs"), &code).unwrap();
+
+    let output = analyze_focused(temp_dir.path(), "target", 1, None, None).unwrap();
+    let total_callees = output.outgoing_chains.len();
+
+    if total_callees > 3 {
+        let paginated = paginate_slice(&output.outgoing_chains, 0, 3).expect("paginate failed");
+
+        let formatted = format_focused_paginated(
+            &paginated.items,
+            total_callees,
+            SYMBOL_FOCUS_CALLEES_MODE,
+            "target",
+            &output.prod_chains,
+            &output.test_chains,
+            &output.outgoing_chains,
+            output.def_count,
+            0,
+            Some(temp_dir.path()),
+        );
+
+        assert!(
+            formatted.contains(&format!(
+                "CALLEES (1-{} of {})",
+                paginated.items.len(),
+                total_callees
+            )),
+            "header should show callees range, got: {}",
+            formatted
+        );
+    }
+}
+
+#[test]
+fn test_symbol_focus_empty_prod_callers() {
+    use code_analyze_mcp::analyze::analyze_focused;
+    use code_analyze_mcp::pagination::paginate_slice;
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // target is only called from test functions
+    let code = r#"
+fn target() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_something() { target(); }
+}
+"#;
+    fs::write(temp_dir.path().join("lib.rs"), code).unwrap();
+
+    let output = analyze_focused(temp_dir.path(), "target", 1, None, None).unwrap();
+
+    // prod_chains may be empty; pagination should handle it gracefully
+    let paginated = paginate_slice(&output.prod_chains, 0, 100).expect("paginate failed");
+    assert_eq!(paginated.items.len(), output.prod_chains.len());
+    assert!(
+        paginated.next_cursor.is_none(),
+        "no next_cursor for empty or single-page prod_chains"
+    );
+}
+
+// --- Unit tests for new formatter functions (issue #146) ---
+
+#[test]
+fn test_format_file_details_paginated_unit() {
+    use code_analyze_mcp::formatter::format_file_details_paginated;
+    use code_analyze_mcp::types::{ClassInfo, FunctionInfo, ImportInfo, SemanticAnalysis};
+    use std::collections::HashMap;
+
+    // Arrange: simulate page 2 of 3 (functions 11-20 of 30)
+    let all_functions: Vec<FunctionInfo> = (0..30)
+        .map(|i| FunctionInfo {
+            name: format!("fn_{:02}", i),
+            line: i + 1,
+            end_line: i + 5,
+            parameters: vec![],
+            return_type: None,
+        })
+        .collect();
+
+    let page_functions = all_functions[10..20].to_vec();
+
+    let semantic = SemanticAnalysis {
+        functions: all_functions,
+        classes: vec![ClassInfo {
+            name: "MyClass".to_string(),
+            line: 1,
+            end_line: 50,
+            methods: vec![],
+            fields: vec![],
+            inherits: vec![],
+        }],
+        imports: vec![ImportInfo {
+            module: "std".to_string(),
+            items: vec![],
+            line: 1,
+        }],
+        references: vec![],
+        call_frequency: HashMap::new(),
+        calls: vec![],
+        assignments: vec![],
+        field_accesses: vec![],
+    };
+
+    // Act: format page 2 (offset=10)
+    let formatted = format_file_details_paginated(
+        &page_functions,
+        30,
+        &semantic,
+        "src/formatter.rs",
+        750,
+        10,
+        10,
+    );
+
+    // Assert: header shows correct range
+    assert!(
+        formatted.contains("11-20/30F"),
+        "header should show 11-20/30F, got: {}",
+        formatted
+    );
+    // Classes NOT on page 2
+    assert!(
+        !formatted.contains("C:"),
+        "classes should not appear on page 2"
+    );
+    assert!(
+        !formatted.contains("I:"),
+        "imports should not appear on page 2"
+    );
+    // Functions present
+    assert!(formatted.contains("fn_10"), "fn_10 should be on this page");
+    assert!(formatted.contains("fn_19"), "fn_19 should be on this page");
+    assert!(
+        !formatted.contains("fn_00"),
+        "fn_00 should not be on this page"
+    );
+    assert!(
+        !formatted.contains("fn_20"),
+        "fn_20 should not be on this page"
+    );
+}
+
+#[test]
+fn test_format_focused_paginated_unit() {
+    use code_analyze_mcp::formatter::format_focused_paginated;
+    use code_analyze_mcp::graph::CallChain;
+    use code_analyze_mcp::pagination::SYMBOL_FOCUS_CALLERS_MODE;
+    use std::path::PathBuf;
+
+    // Arrange: create mock caller chains
+    let make_chain = |name: &str| -> CallChain {
+        CallChain {
+            chain: vec![
+                (name.to_string(), PathBuf::from("src/lib.rs"), 10),
+                ("target".to_string(), PathBuf::from("src/lib.rs"), 5),
+            ],
+        }
+    };
+
+    let prod_chains: Vec<CallChain> = (0..8)
+        .map(|i| make_chain(&format!("caller_{}", i)))
+        .collect();
+    let page = &prod_chains[0..3];
+
+    // Act
+    let formatted = format_focused_paginated(
+        page,
+        8,
+        SYMBOL_FOCUS_CALLERS_MODE,
+        "target",
+        &prod_chains,
+        &[],
+        &[],
+        1,
+        0,
+        None,
+    );
+
+    // Assert: header present
+    assert!(
+        formatted.contains("CALLERS (1-3 of 8):"),
+        "header should show 1-3 of 8, got: {}",
+        formatted
+    );
+    assert!(
+        formatted.contains("FOCUS: target"),
+        "should have FOCUS header"
+    );
+}


### PR DESCRIPTION
## Summary

Wires the existing pagination infrastructure to FileDetails and SymbolFocus output modes. FileDetails was calling `paginate_slice` but returning the full formatted output regardless. SymbolFocus had no pagination at all.

## Changes

### src/pagination.rs
- Add `SYMBOL_FOCUS_CALLERS_MODE` and `SYMBOL_FOCUS_CALLEES_MODE` string constants for compile-time safety on cursor mode fields

### src/analyze.rs
- Extend `FocusedAnalysisOutput` with `prod_chains`, `test_chains`, `outgoing_chains`, `def_count` fields (serde-skipped, not serialized to JSON)
- Populate these fields in `analyze_focused_with_progress` after graph build; partition is done once here rather than re-running in lib.rs

### src/formatter.rs
- Add `format_file_details_paginated()`: formats a paginated function slice with position header (`1-10/25F`); shows classes and imports on first page (offset=0) only
- Add `format_focused_paginated()`: formats paginated callers or callees based on cursor mode; always shows test callers summary and the opposing section as a brief summary

### src/lib.rs
- **FileDetails**: after `paginate_slice`, regenerate `output.formatted` from `format_file_details_paginated()` when pagination is active (mirrors Overview pattern)
- **SymbolFocus**: decode cursor mode, paginate `prod_chains` (callers mode) or `outgoing_chains` (callees mode), re-encode cursor with explicit mode, regenerate `output.formatted` from `format_focused_paginated()`

## Testing

10 new tests added to `tests/integration_tests.rs`:
- FileDetails first page (100 items, next_cursor present)
- FileDetails last page (no next_cursor, classes/imports absent)
- FileDetails single page (no cursor)
- FileDetails invalid cursor (error propagates)
- SymbolFocus callers page 1 (next_cursor present)
- SymbolFocus callers page 2 (cursor round-trip)
- SymbolFocus callees pagination (CALLEES mode)
- SymbolFocus empty prod callers (graceful handling)
- Unit: format_file_details_paginated (page 2 of 3)
- Unit: format_focused_paginated (callers mode, 1-3 of 8)

All 130 tests pass. `cargo clippy -- -D warnings` clean. `cargo fmt --check` clean. `cargo deny check advisories licenses` clean.

Closes #146