### PR TITLE
refactor(pagination): reduce verbosity in FileDetails and SymbolFocus

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -3,7 +3,7 @@ use crate::graph::CallChain;
 use crate::graph::CallGraph;
 use crate::test_detection::is_test_file;
 use crate::traversal::WalkEntry;
-use crate::types::{FileInfo, FunctionInfo, SemanticAnalysis};
+use crate::types::{ClassInfo, FileInfo, FunctionInfo, ImportInfo, SemanticAnalysis};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::path::Path;
@@ -273,45 +273,7 @@ pub fn format_file_details(
     }
 
     // C: section with classes
-    if !analysis.classes.is_empty() {
-        output.push_str("C:\n");
-        if analysis.classes.len() <= MULTILINE_THRESHOLD {
-            // Inline format for <= 10 classes
-            let class_strs: Vec<String> = analysis
-                .classes
-                .iter()
-                .map(|class| {
-                    if class.inherits.is_empty() {
-                        format!("{}:{}", class.name, class.line)
-                    } else {
-                        format!(
-                            "{}:{} ({})",
-                            class.name,
-                            class.line,
-                            class.inherits.join(", ")
-                        )
-                    }
-                })
-                .collect();
-            output.push_str("  ");
-            output.push_str(&class_strs.join("; "));
-            output.push('\n');
-        } else {
-            // Multiline format for > 10 classes
-            for class in &analysis.classes {
-                if class.inherits.is_empty() {
-                    output.push_str(&format!("  {}:{}\n", class.name, class.line));
-                } else {
-                    output.push_str(&format!(
-                        "  {}:{} ({})\n",
-                        class.name,
-                        class.line,
-                        class.inherits.join(", ")
-                    ));
-                }
-            }
-        }
-    }
+    output.push_str(&format_classes_section(&analysis.classes));
 
     // F: section with functions, parameters, return types and call frequency
     if !analysis.functions.is_empty() {
@@ -347,39 +309,7 @@ pub fn format_file_details(
     }
 
     // I: section with imports grouped by module
-    if !analysis.imports.is_empty() {
-        output.push_str("I:\n");
-        let mut module_map: HashMap<String, usize> = HashMap::new();
-        for import in &analysis.imports {
-            module_map
-                .entry(import.module.clone())
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-        }
-
-        let mut modules: Vec<_> = module_map.keys().cloned().collect();
-        modules.sort();
-
-        // Format modules with count notation
-        let formatted_modules: Vec<String> = modules
-            .iter()
-            .map(|module| format!("{}({})", module, module_map[module]))
-            .collect();
-
-        if formatted_modules.len() <= MULTILINE_THRESHOLD {
-            // Inline format for <= 10 modules
-            output.push_str("  ");
-            output.push_str(&formatted_modules.join("; "));
-            output.push('\n');
-        } else {
-            // Multiline format for > 10 modules
-            for module_str in formatted_modules {
-                output.push_str("  ");
-                output.push_str(&module_str);
-                output.push('\n');
-            }
-        }
-    }
+    output.push_str(&format_imports_section(&analysis.imports));
 
     output
 }
@@ -1121,9 +1051,7 @@ pub fn format_file_details_paginated(
     path: &str,
     line_count: usize,
     offset: usize,
-    page_size: usize,
 ) -> String {
-    let _ = page_size; // kept for API symmetry; end is derived from slice length
     let mut output = String::new();
 
     let start = offset + 1; // 1-indexed for display
@@ -1142,76 +1070,8 @@ pub fn format_file_details_paginated(
 
     // Classes and imports sections only on first page
     if offset == 0 {
-        // C: section with classes
-        if !semantic.classes.is_empty() {
-            output.push_str("C:\n");
-            if semantic.classes.len() <= MULTILINE_THRESHOLD {
-                let class_strs: Vec<String> = semantic
-                    .classes
-                    .iter()
-                    .map(|class| {
-                        if class.inherits.is_empty() {
-                            format!("{}:{}", class.name, class.line)
-                        } else {
-                            format!(
-                                "{}:{} ({})",
-                                class.name,
-                                class.line,
-                                class.inherits.join(", ")
-                            )
-                        }
-                    })
-                    .collect();
-                output.push_str("  ");
-                output.push_str(&class_strs.join("; "));
-                output.push('\n');
-            } else {
-                for class in &semantic.classes {
-                    if class.inherits.is_empty() {
-                        output.push_str(&format!("  {}:{}\n", class.name, class.line));
-                    } else {
-                        output.push_str(&format!(
-                            "  {}:{} ({})\n",
-                            class.name,
-                            class.line,
-                            class.inherits.join(", ")
-                        ));
-                    }
-                }
-            }
-        }
-
-        // I: section with imports
-        if !semantic.imports.is_empty() {
-            output.push_str("I:\n");
-            let mut module_map: HashMap<String, usize> = HashMap::new();
-            for import in &semantic.imports {
-                module_map
-                    .entry(import.module.clone())
-                    .and_modify(|count| *count += 1)
-                    .or_insert(1);
-            }
-
-            let mut modules: Vec<_> = module_map.keys().cloned().collect();
-            modules.sort();
-
-            let formatted_modules: Vec<String> = modules
-                .iter()
-                .map(|module| format!("{}({})", module, module_map[module]))
-                .collect();
-
-            if formatted_modules.len() <= MULTILINE_THRESHOLD {
-                output.push_str("  ");
-                output.push_str(&formatted_modules.join("; "));
-                output.push('\n');
-            } else {
-                for module_str in formatted_modules {
-                    output.push_str("  ");
-                    output.push_str(&module_str);
-                    output.push('\n');
-                }
-            }
-        }
+        output.push_str(&format_classes_section(&semantic.classes));
+        output.push_str(&format_imports_section(&semantic.imports));
     }
 
     // F: section with paginated function slice
@@ -1540,4 +1400,79 @@ mod tests {
         // Should contain import count
         assert!(result.contains("Imports: 0"));
     }
+}
+
+fn format_classes_section(classes: &[ClassInfo]) -> String {
+    let mut output = String::new();
+    if classes.is_empty() {
+        return output;
+    }
+    output.push_str("C:\n");
+    if classes.len() <= MULTILINE_THRESHOLD {
+        let class_strs: Vec<String> = classes
+            .iter()
+            .map(|class| {
+                if class.inherits.is_empty() {
+                    format!("{}:{}", class.name, class.line)
+                } else {
+                    format!(
+                        "{}:{} ({})",
+                        class.name,
+                        class.line,
+                        class.inherits.join(", ")
+                    )
+                }
+            })
+            .collect();
+        output.push_str("  ");
+        output.push_str(&class_strs.join("; "));
+        output.push('\n');
+    } else {
+        for class in classes {
+            if class.inherits.is_empty() {
+                output.push_str(&format!("  {}:{}\n", class.name, class.line));
+            } else {
+                output.push_str(&format!(
+                    "  {}:{} ({})\n",
+                    class.name,
+                    class.line,
+                    class.inherits.join(", ")
+                ));
+            }
+        }
+    }
+    output
+}
+
+fn format_imports_section(imports: &[ImportInfo]) -> String {
+    let mut output = String::new();
+    if imports.is_empty() {
+        return output;
+    }
+    output.push_str("I:\n");
+    let mut module_map: HashMap<String, usize> = HashMap::new();
+    for import in imports {
+        module_map
+            .entry(import.module.clone())
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+    }
+    let mut modules: Vec<_> = module_map.keys().cloned().collect();
+    modules.sort();
+    let formatted_modules: Vec<String> = modules
+        .iter()
+        .map(|module| format!("{}({})", module, module_map[module]))
+        .collect();
+    if formatted_modules.len() <= MULTILINE_THRESHOLD {
+        output.push_str("  ");
+        output.push_str(&formatted_modules.join("; "));
+        output.push('\n');
+    } else {
+        for module_str in formatted_modules {
+            output.push_str("  ");
+            output.push_str(&module_str);
+            output.push('\n');
+        }
+    }
+    output
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,41 @@ use types::{AnalysisMode, AnalyzeParams};
 
 const SIZE_LIMIT: usize = 50_000;
 
+/// Helper function for paginating focus chains (callers or callees).
+/// Returns (items, re-encoded_cursor_option).
+fn paginate_focus_chains(
+    chains: &[graph::CallChain],
+    mode: &str,
+    offset: usize,
+    page_size: usize,
+) -> Result<(Vec<graph::CallChain>, Option<String>), ErrorData> {
+    let paginated = paginate_slice(chains, offset, page_size)
+        .map_err(|e| ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+
+    if paginated.next_cursor.is_none() && offset == 0 {
+        return Ok((paginated.items, None));
+    }
+
+    let next = if let Some(raw_cursor) = paginated.next_cursor {
+        let decoded = decode_cursor(&raw_cursor).map_err(|e| {
+            ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
+        })?;
+        Some(
+            encode_cursor(&CursorData {
+                mode: mode.to_string(),
+                offset: decoded.offset,
+            })
+            .map_err(|e| {
+                ErrorData::new(rmcp::model::ErrorCode::INTERNAL_ERROR, e.to_string(), None)
+            })?,
+        )
+    } else {
+        None
+    };
+
+    Ok((paginated.items, next))
+}
+
 /// Helper function to create the output schema for the analyze tool
 fn create_analyze_output_schema() -> std::sync::Arc<serde_json::Map<String, Value>> {
     use serde_json::json;
@@ -568,7 +603,6 @@ impl CodeAnalyzer {
                         &params.path,
                         output.line_count,
                         offset,
-                        page_size,
                     );
                 }
 
@@ -656,48 +690,19 @@ impl CodeAnalyzer {
                 };
 
                 let paginated_next_cursor = if cursor_mode == SYMBOL_FOCUS_CALLERS_MODE {
-                    // Paginate production callers
-                    let paginated = paginate_slice(&output.prod_chains, offset, page_size)
-                        .map_err(|e| {
-                            ErrorData::new(
-                                rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                e.to_string(),
-                                None,
-                            )
-                        })?;
+                    let (paginated_items, paginated_next) = paginate_focus_chains(
+                        &output.prod_chains,
+                        SYMBOL_FOCUS_CALLERS_MODE,
+                        offset,
+                        page_size,
+                    )?;
 
-                    if paginated.next_cursor.is_some() || offset > 0 {
-                        // Re-encode cursor with correct mode
-                        let next = if let Some(raw_cursor) = paginated.next_cursor {
-                            let decoded = decode_cursor(&raw_cursor).map_err(|e| {
-                                ErrorData::new(
-                                    rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                    e.to_string(),
-                                    None,
-                                )
-                            })?;
-                            Some(
-                                encode_cursor(&CursorData {
-                                    mode: SYMBOL_FOCUS_CALLERS_MODE.to_string(),
-                                    offset: decoded.offset,
-                                })
-                                .map_err(|e| {
-                                    ErrorData::new(
-                                        rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                        e.to_string(),
-                                        None,
-                                    )
-                                })?,
-                            )
-                        } else {
-                            None
-                        };
-
+                    if paginated_next.is_some() || offset > 0 {
                         let focus_symbol = params.focus.as_deref().unwrap_or("");
                         let base_path = Path::new(&params.path);
                         output.formatted = format_focused_paginated(
-                            &paginated.items,
-                            paginated.total,
+                            &paginated_items,
+                            output.prod_chains.len(),
                             SYMBOL_FOCUS_CALLERS_MODE,
                             focus_symbol,
                             &output.prod_chains,
@@ -707,52 +712,24 @@ impl CodeAnalyzer {
                             offset,
                             Some(base_path),
                         );
-                        next
+                        paginated_next
                     } else {
                         None
                     }
                 } else {
-                    // Paginate callees (SYMBOL_FOCUS_CALLEES_MODE)
-                    let paginated = paginate_slice(&output.outgoing_chains, offset, page_size)
-                        .map_err(|e| {
-                            ErrorData::new(
-                                rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                e.to_string(),
-                                None,
-                            )
-                        })?;
+                    let (paginated_items, paginated_next) = paginate_focus_chains(
+                        &output.outgoing_chains,
+                        SYMBOL_FOCUS_CALLEES_MODE,
+                        offset,
+                        page_size,
+                    )?;
 
-                    if paginated.next_cursor.is_some() || offset > 0 {
-                        let next = if let Some(raw_cursor) = paginated.next_cursor {
-                            let decoded = decode_cursor(&raw_cursor).map_err(|e| {
-                                ErrorData::new(
-                                    rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                    e.to_string(),
-                                    None,
-                                )
-                            })?;
-                            Some(
-                                encode_cursor(&CursorData {
-                                    mode: SYMBOL_FOCUS_CALLEES_MODE.to_string(),
-                                    offset: decoded.offset,
-                                })
-                                .map_err(|e| {
-                                    ErrorData::new(
-                                        rmcp::model::ErrorCode::INTERNAL_ERROR,
-                                        e.to_string(),
-                                        None,
-                                    )
-                                })?,
-                            )
-                        } else {
-                            None
-                        };
-
+                    if paginated_next.is_some() || offset > 0 {
                         let focus_symbol = params.focus.as_deref().unwrap_or("");
                         let base_path = Path::new(&params.path);
                         output.formatted = format_focused_paginated(
-                            &paginated.items,
-                            paginated.total,
+                            &paginated_items,
+                            output.outgoing_chains.len(),
                             SYMBOL_FOCUS_CALLEES_MODE,
                             focus_symbol,
                             &output.prod_chains,
@@ -762,7 +739,7 @@ impl CodeAnalyzer {
                             offset,
                             Some(base_path),
                         );
-                        next
+                        paginated_next
                     } else {
                         None
                     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2845,7 +2845,6 @@ fn test_file_details_pagination_first_page() {
         "src/lib.rs",
         500,
         0,
-        10,
     );
 
     // Assert: header shows position, F: section present
@@ -2910,7 +2909,6 @@ fn test_file_details_pagination_last_page() {
         "src/lib.rs",
         500,
         10,
-        20,
     );
 
     // Assert: header shows correct range
@@ -3181,15 +3179,8 @@ fn test_format_file_details_paginated_unit() {
     };
 
     // Act: format page 2 (offset=10)
-    let formatted = format_file_details_paginated(
-        &page_functions,
-        30,
-        &semantic,
-        "src/formatter.rs",
-        750,
-        10,
-        10,
-    );
+    let formatted =
+        format_file_details_paginated(&page_functions, 30, &semantic, "src/formatter.rs", 750, 10);
 
     // Assert: header shows correct range
     assert!(


### PR DESCRIPTION
## Summary

Closes #153

Three pure refactors with no behavior change. All 100 tests pass.

## Changes

**formatter.rs:** Extract `format_classes_section` and `format_imports_section` private helpers to eliminate the verbatim C: and I: section duplication between `format_file_details` and `format_file_details_paginated`.

**lib.rs:** Extract `paginate_focus_chains` private helper to collapse the structurally identical callers and callees pagination arms (~112 lines) to ~40 lines.

**formatter.rs + lib.rs + integration_tests.rs:** Drop the unused `page_size` parameter from `format_file_details_paginated` and update all four call sites.

## Result

- Code files: 497 -> ~370 added lines (net -97 lines, 137 added / 234 removed)
- No behavior change
- No test changes
- All 100 tests pass, clippy clean, gitleaks clean

## Testing

```
cargo clippy -- -D warnings  # clean
cargo test                   # 100 passed, 0 failed
```