### PR TITLE
docs: fix language count and document pagination/summary params

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,16 @@ The `analyze` tool accepts these parameters:
 
 For large codebases, two mechanisms prevent context overflow:
 
-- **Pagination**: File details and symbol focus modes return a `next_cursor` when output is truncated. Pass it back as `cursor` to fetch the next page.
+- **Pagination**: File details and symbol focus modes append a `NEXT_CURSOR:` line when output is truncated. Pass the token back as `cursor` to fetch the next page.
+
+```
+# Response ends with:
+NEXT_CURSOR: eyJvZmZzZXQiOjUwfQ==
+
+# Fetch next page:
+analyze path: /my/project cursor: eyJvZmZzZXQiOjUwfQ==
+```
+
 - **Summary mode**: When output exceeds 50K chars, the server auto-compacts results using `(xN)` notation for repeated call chains. Override with `summary: true` (force) or `summary: false` (disable).
 
 ## Analysis Modes


### PR DESCRIPTION
## Summary

Fix two accuracy issues in README.md and document recently added parameters.

## Changes

- Fix overview: '9 programming languages' -> '5 programming languages'
- Add 4 missing rows to Tool Interface table: `mode`, `summary`, `cursor`, `page_size`
- Add Output Management section explaining pagination (`next_cursor`/`cursor`) and summary mode (auto-triggers at 50K chars)

## Testing

Documentation-only change. All parameter descriptions verified against `src/types.rs` schemars annotations. README remains 162 lines (under 200-line budget).