### PR TITLE
docs(tool): improve descriptions for agent discoverability and efficiency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         title = "Code Structure Analyzer",
-        description = "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.",
+        description = "Analyze code structure in 3 modes: 1) Overview - directory tree with LOC/function/class counts (use max_depth to limit). 2) FileDetails - functions, classes, imports for one file. 3) SymbolFocus - call graph for a named symbol across a directory (requires focus, case-sensitive). Typical flow: directory overview -> file details -> symbol focus. For large overview output (>50K chars), use summary=true to get totals and top-level structure without per-file detail; output auto-summarizes at the 50K threshold. Use cursor/page_size to paginate files (overview) or functions (file_details) when next_cursor appears in the response. Functions called >3x show N.",
         output_schema = create_analyze_output_schema(),
         annotations(
             read_only_hint = true,
@@ -803,7 +803,7 @@ impl ServerHandler for CodeAnalyzer {
                 icons: None,
                 website_url: None,
             },
-            instructions: Some("Analyze code structure using three modes: directory overview (file tree with metrics), file details (functions/classes/imports), or symbol focus (call graphs). Provide a path and optionally specify mode and max_depth.".into()),
+            instructions: Some("Use overview mode to map a codebase (pass a directory). Use file_details mode to extract functions, classes, and imports from a specific file (pass a file path). Use symbol_focus mode to trace call graphs for a named function or class (pass a directory and set focus to the symbol name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes next_cursor, pass it back as cursor to retrieve the next page.".into()),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,41 +15,53 @@ pub enum ModeResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeParams {
-    #[schemars(description = "Path to the file or directory to analyze")]
+    #[schemars(description = "File or directory path to analyze")]
     pub path: String,
 
     #[schemars(
-        description = "Analysis mode: 'overview', 'file_details', or 'symbol_focus' (auto-detected if not provided)"
+        description = "Analysis mode. Auto-detected: directory path without focus -> overview; file path -> file_details; focus parameter present -> symbol_focus. Override by setting explicitly."
     )]
     #[serde(default)]
     pub mode: Option<AnalysisMode>,
 
-    #[schemars(description = "Maximum recursion depth for directory traversal")]
+    #[schemars(
+        description = "Maximum directory traversal depth for overview mode. Unset means unlimited. Use 2-3 for large monorepos to limit output size."
+    )]
     pub max_depth: Option<u32>,
 
-    #[schemars(description = "Symbol to focus on for symbol_focus mode")]
+    #[schemars(
+        description = "Symbol name for symbol_focus mode (required for symbol_focus). Case-sensitive function or method name. Triggers symbol_focus auto-detection when mode is not set explicitly."
+    )]
     pub focus: Option<String>,
 
-    #[schemars(description = "Call graph depth for symbol_focus mode")]
+    #[schemars(
+        description = "Call graph traversal depth for symbol_focus mode. Default 1 (callers and callees one level out). Increase for deeper dependency traces; each level multiplies output size."
+    )]
     pub follow_depth: Option<u32>,
 
-    #[schemars(description = "Maximum AST recursion depth for tree-sitter queries")]
+    #[schemars(
+        description = "Maximum AST node recursion depth for tree-sitter queries. Default is sufficient for all standard source files; increase only for pathologically deep nesting in generated code."
+    )]
     pub ast_recursion_limit: Option<usize>,
 
-    #[schemars(description = "Bypass output size limiting (default: false)")]
+    #[schemars(
+        description = "Return full output even when it exceeds the 50K char limit. Prefer summary=true (overview) or narrowing scope over force=true; force=true can produce very large responses."
+    )]
     pub force: Option<bool>,
 
     #[schemars(
-        description = "Generate compact summary instead of full output. true=force summary, false=force full, unset=auto-detect when output exceeds 50K chars"
+        description = "Overview mode primarily; file_details has same 3-way logic (true/false/auto) but size-error still triggers if output exceeds 50K even after summary is applied. true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars. Use true proactively on large codebases to avoid the size threshold and reduce token consumption."
     )]
     pub summary: Option<bool>,
 
     #[schemars(
-        description = "Opaque cursor token for pagination (from previous response's next_cursor)"
+        description = "Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page of files (overview) or functions (file_details). Omit on the first call."
     )]
     pub cursor: Option<String>,
 
-    #[schemars(description = "Number of items per page (default: 100)")]
+    #[schemars(
+        description = "Items per page for pagination (default: 100). Items are files in overview mode and functions in file_details mode. Reduce below 100 to limit response size; increase above 100 to reduce round trips."
+    )]
     pub page_size: Option<usize>,
 }
 


### PR DESCRIPTION
## Summary

Closes #161.

Adopts the proposed strings from issue #161 for tool description, server instructions, and all 10 `AnalyzeParams` field descriptions. Documentation-only; no behavior changes.

## Changes

**`src/lib.rs`:**
- Tool `description`: clarifies 3 modes with explicit labels (Overview, FileDetails, SymbolFocus), summary guidance for >50K output, cursor/page_size pagination trigger
- Server `instructions`: per-mode usage flow, summary recommendation, cursor pagination pattern

**`src/types.rs`:**
- All 10 `AnalyzeParams` field descriptions updated with actionable trigger conditions (when to use, what threshold, what default)

## Corrections over issue #161 proposal

| Field | Issue proposed | Corrected |
|---|---|---|
| `follow_depth` | Default 2 | Default 1 (verified: `unwrap_or(1)` at `src/lib.rs:332`) |
| `summary` | Overview mode only | Clarified: `file_details` has same 3-way logic but size-error still triggers if output exceeds 50K post-summary |
| Tool description | Silent on file_details/symbol_focus | Clarified: summary/force preference ordering across all modes |

## Motivation

Descriptions were mechanical (`what` a parameter is) without stating `when` to use it. This PR rewrites them with actionable trigger conditions.

## Benchmark validation (v8)

A lightweight v8 benchmark (4 runs: 2A control, 2B treatment) was run after PR #162 to validate adoption. Key finding: the updated schema descriptions alone did not drive `summary` adoption (0% in treatment vs 50% spontaneous in control). The v7 adoption result (80%) was driven by prompt-injected parameter docs, not schema quality.

The accuracy fixes (`follow_depth=1`, `summary` edge case, trigger phrasing) are valid improvements. The hypothesis that schema descriptions alone drive measurable adoption is unconfirmed and will be investigated in a follow-up issue.

## Testing

- 88 tests pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- Security scan: no findings