### PR TITLE
chore(deps): upgrade rmcp from 0.17 to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "MCP server for code structure analysis using tree-sitter"
 
 [dependencies]
-rmcp = { version = "0.17", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
 tree-sitter = "0.26.6"
 tree-sitter-rust = "0.24.0"
 tree-sitter-python = "0.25.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         title = "Code Structure Analyzer",
-        description = "Analyze code structure in 3 modes: 1) Directory overview - file tree with LOC/function/class counts to max_depth. 2) File details - functions, classes, imports. 3) Symbol focus - call graphs across directory to max_depth (requires directory path, case-sensitive). Typical flow: directory → files → symbols. Functions called >3x show •N.",
+        description = "Analyze code structure in 3 modes: 1) Overview - directory tree with LOC/function/class counts (use max_depth to limit). 2) FileDetails - functions, classes, imports for one file. 3) SymbolFocus - call graph for a named symbol across a directory (requires focus, case-sensitive). Typical flow: directory overview -> file details -> symbol focus. For large overview output (>50K chars), use summary=true to get totals and top-level structure without per-file detail; output auto-summarizes at the 50K threshold. Use cursor/page_size to paginate files (overview) or functions (file_details) when next_cursor appears in the response. Functions called >3x show N.",
         output_schema = create_analyze_output_schema(),
         annotations(
             read_only_hint = true,
@@ -773,38 +773,30 @@ impl CodeAnalyzer {
             final_text.push_str(&format!("NEXT_CURSOR: {}", cursor));
         }
 
-        Ok(CallToolResult {
-            content: vec![Content::text(final_text)],
-            structured_content: Some(structured_value),
-            is_error: Some(false),
-            meta: None,
-        })
+        let mut result = CallToolResult::success(vec![Content::text(final_text)]);
+        result.structured_content = Some(structured_value);
+        Ok(result)
     }
 }
 
 #[tool_handler]
 impl ServerHandler for CodeAnalyzer {
     fn get_info(&self) -> InitializeResult {
-        InitializeResult {
-            protocol_version: ProtocolVersion::V_2025_06_18,
-            capabilities: ServerCapabilities::builder()
+        InitializeResult::new(
+            ServerCapabilities::builder()
                 .enable_logging()
                 .enable_tools()
                 .enable_tool_list_changed()
                 .enable_completions()
                 .build(),
-            server_info: Implementation {
-                name: "code-analyze-mcp".into(),
-                version: "0.1.0".into(),
-                description: Some(
-                    "MCP server for code structure analysis using tree-sitter".into(),
-                ),
-                title: Some("Code Analyze MCP".into()),
-                icons: None,
-                website_url: None,
-            },
-            instructions: Some("Analyze code structure using three modes: directory overview (file tree with metrics), file details (functions/classes/imports), or symbol focus (call graphs). Provide a path and optionally specify mode and max_depth.".into()),
-        }
+        )
+        .with_protocol_version(ProtocolVersion::V_2025_06_18)
+        .with_server_info(
+            Implementation::new("code-analyze-mcp", "0.1.0")
+                .with_title("Code Analyze MCP")
+                .with_description("MCP server for code structure analysis using tree-sitter"),
+        )
+        .with_instructions("Use overview mode to map a codebase (pass a directory). Use file_details mode to extract functions, classes, and imports from a specific file (pass a file path). Use symbol_focus mode to trace call graphs for a named function or class (pass a directory and set focus to the symbol name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes next_cursor, pass it back as cursor to retrieve the next page.")
     }
 
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
@@ -919,9 +911,7 @@ impl ServerHandler for CodeAnalyzer {
                 }
             };
 
-        Ok(CompleteResult {
-            completion: completion_info,
-        })
+        Ok(CompleteResult::new(completion_info))
     }
 
     async fn set_level(

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,41 +15,53 @@ pub enum ModeResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeParams {
-    #[schemars(description = "Path to the file or directory to analyze")]
+    #[schemars(description = "File or directory path to analyze")]
     pub path: String,
 
     #[schemars(
-        description = "Analysis mode: 'overview', 'file_details', or 'symbol_focus' (auto-detected if not provided)"
+        description = "Analysis mode. Auto-detected: directory path without focus -> overview; file path -> file_details; focus parameter present -> symbol_focus. Override by setting explicitly."
     )]
     #[serde(default)]
     pub mode: Option<AnalysisMode>,
 
-    #[schemars(description = "Maximum recursion depth for directory traversal")]
+    #[schemars(
+        description = "Maximum directory traversal depth for overview mode. Unset means unlimited. Use 2-3 for large monorepos to limit output size."
+    )]
     pub max_depth: Option<u32>,
 
-    #[schemars(description = "Symbol to focus on for symbol_focus mode")]
+    #[schemars(
+        description = "Symbol name for symbol_focus mode (required for symbol_focus). Case-sensitive function or method name. Triggers symbol_focus auto-detection when mode is not set explicitly."
+    )]
     pub focus: Option<String>,
 
-    #[schemars(description = "Call graph depth for symbol_focus mode")]
+    #[schemars(
+        description = "Call graph traversal depth for symbol_focus mode. Default 1 (callers and callees one level out). Increase for deeper dependency traces; each level multiplies output size."
+    )]
     pub follow_depth: Option<u32>,
 
-    #[schemars(description = "Maximum AST recursion depth for tree-sitter queries")]
+    #[schemars(
+        description = "Maximum AST node recursion depth for tree-sitter queries. Default is sufficient for all standard source files; increase only for pathologically deep nesting in generated code."
+    )]
     pub ast_recursion_limit: Option<usize>,
 
-    #[schemars(description = "Bypass output size limiting (default: false)")]
+    #[schemars(
+        description = "Return full output even when it exceeds the 50K char limit. Prefer summary=true (overview) or narrowing scope over force=true; force=true can produce very large responses."
+    )]
     pub force: Option<bool>,
 
     #[schemars(
-        description = "Generate compact summary instead of full output. true=force summary, false=force full, unset=auto-detect when output exceeds 50K chars"
+        description = "Overview mode primarily; file_details has same 3-way logic (true/false/auto) but size-error still triggers if output exceeds 50K even after summary is applied. true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars. Use true proactively on large codebases to avoid the size threshold and reduce token consumption."
     )]
     pub summary: Option<bool>,
 
     #[schemars(
-        description = "Opaque cursor token for pagination (from previous response's next_cursor)"
+        description = "Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page of files (overview) or functions (file_details). Omit on the first call."
     )]
     pub cursor: Option<String>,
 
-    #[schemars(description = "Number of items per page (default: 100)")]
+    #[schemars(
+        description = "Items per page for pagination (default: 100). Items are files in overview mode and functions in file_details mode. Reduce below 100 to limit response size; increase above 100 to reduce round trips."
+    )]
     pub page_size: Option<usize>,
 }
 


### PR DESCRIPTION
## Summary

Upgrades the rmcp SDK from 0.17.0 to 1.2.0 (latest stable).

## Breaking changes encountered

The 1.x line replaced struct literals with factory constructors and builder chains for several model types:

| Type | Before | After |
|------|--------|-------|
| `CallToolResult` | struct literal | `success()` factory + field setter |
| `InitializeResult` | struct literal | `new()` + builder chain |
| `Implementation` | struct literal | `new()` + builder chain |
| `CompleteResult` | struct literal | `new()` factory |

Removed unused `ServerCapabilities` import.

SSE transport was removed in 1.x but was not used in this project.

## Testing

- `cargo build`: passes
- `cargo test`: 32 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: compliant
- `cargo deny check advisories licenses`: ok