### PR TITLE
chore(deps): upgrade rmcp from 0.17 to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0ce46f9101dc911f07e1468084c057839d15b08040d110820c5513312ef56a"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.17.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad6f5f46e220e3bda2fc90fd1ad64c1c2a2bd716d52c845eb5c9c64cda7542"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "MCP server for code structure analysis using tree-sitter"
 
 [dependencies]
-rmcp = { version = "0.17", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
 tree-sitter = "0.26.6"
 tree-sitter-rust = "0.24.0"
 tree-sitter-python = "0.25.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,38 +773,30 @@ impl CodeAnalyzer {
             final_text.push_str(&format!("NEXT_CURSOR: {}", cursor));
         }
 
-        Ok(CallToolResult {
-            content: vec![Content::text(final_text)],
-            structured_content: Some(structured_value),
-            is_error: Some(false),
-            meta: None,
-        })
+        let mut result = CallToolResult::success(vec![Content::text(final_text)]);
+        result.structured_content = Some(structured_value);
+        Ok(result)
     }
 }
 
 #[tool_handler]
 impl ServerHandler for CodeAnalyzer {
     fn get_info(&self) -> InitializeResult {
-        InitializeResult {
-            protocol_version: ProtocolVersion::V_2025_06_18,
-            capabilities: ServerCapabilities::builder()
+        InitializeResult::new(
+            ServerCapabilities::builder()
                 .enable_logging()
                 .enable_tools()
                 .enable_tool_list_changed()
                 .enable_completions()
                 .build(),
-            server_info: Implementation {
-                name: "code-analyze-mcp".into(),
-                version: "0.1.0".into(),
-                description: Some(
-                    "MCP server for code structure analysis using tree-sitter".into(),
-                ),
-                title: Some("Code Analyze MCP".into()),
-                icons: None,
-                website_url: None,
-            },
-            instructions: Some("Use overview mode to map a codebase (pass a directory). Use file_details mode to extract functions, classes, and imports from a specific file (pass a file path). Use symbol_focus mode to trace call graphs for a named function or class (pass a directory and set focus to the symbol name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes next_cursor, pass it back as cursor to retrieve the next page.".into()),
-        }
+        )
+        .with_protocol_version(ProtocolVersion::V_2025_06_18)
+        .with_server_info(
+            Implementation::new("code-analyze-mcp", "0.1.0")
+                .with_title("Code Analyze MCP")
+                .with_description("MCP server for code structure analysis using tree-sitter"),
+        )
+        .with_instructions("Use overview mode to map a codebase (pass a directory). Use file_details mode to extract functions, classes, and imports from a specific file (pass a file path). Use symbol_focus mode to trace call graphs for a named function or class (pass a directory and set focus to the symbol name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes next_cursor, pass it back as cursor to retrieve the next page.")
     }
 
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
@@ -919,9 +911,7 @@ impl ServerHandler for CodeAnalyzer {
                 }
             };
 
-        Ok(CompleteResult {
-            completion: completion_info,
-        })
+        Ok(CompleteResult::new(completion_info))
     }
 
     async fn set_level(


### PR DESCRIPTION
## Summary

Upgrades rmcp from 0.17.0 to 1.2.0 (latest stable).

## API changes

rmcp 1.x made several structs non-exhaustive, requiring migration to factory constructors and builder chains:

| Type | Change |
|------|--------|
| `CallToolResult` | `success()` factory + field mutation |
| `InitializeResult` | `new(caps)` + `.with_protocol_version()`, `.with_server_info()`, `.with_instructions()` |
| `Implementation` | `new(name, version)` + `.with_title()`, `.with_description()` |
| `CompleteResult` | `new(completion_info)` constructor |

SSE transport was removed in 1.x but was not used in this project.

## Testing

- `cargo build`: clean
- `cargo test`: 131 passed, 1 skipped, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean