### PR TITLE
chore(deps): update criterion 0.5.1 -> 0.8, migrate to std::hint::black_box

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,25 +228,24 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -245,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -522,12 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,21 +594,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -730,6 +721,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1498,6 +1499,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1522,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "analysis"

--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -10,8 +10,8 @@ fn overview_benchmark(c: &mut Criterion) {
 
     group.bench_function("analyze_directory_src", |b| {
         b.iter(|| {
-            let path = black_box(Path::new("src"));
-            let max_depth = black_box(None);
+            let path = std::hint::black_box(Path::new("src"));
+            let max_depth = std::hint::black_box(None);
             let progress = Arc::new(AtomicUsize::new(0));
             let ct = CancellationToken::new();
 
@@ -30,8 +30,8 @@ fn file_details_benchmark(c: &mut Criterion) {
 
     group.bench_function("analyze_file_lib_rs", |b| {
         b.iter(|| {
-            let path = black_box("src/lib.rs");
-            let ast_recursion_limit = black_box(None);
+            let path = std::hint::black_box("src/lib.rs");
+            let ast_recursion_limit = std::hint::black_box(None);
 
             code_analyze_mcp::analyze::analyze_file(path, ast_recursion_limit)
         });
@@ -46,11 +46,11 @@ fn symbol_focus_benchmark(c: &mut Criterion) {
 
     group.bench_function("analyze_focused_src", |b| {
         b.iter(|| {
-            let path = black_box(Path::new("src"));
-            let focus = black_box("analyze_directory");
-            let follow_depth = black_box(2);
-            let max_depth = black_box(None);
-            let ast_recursion_limit = black_box(None);
+            let path = std::hint::black_box(Path::new("src"));
+            let focus = std::hint::black_box("analyze_directory");
+            let follow_depth = std::hint::black_box(2);
+            let max_depth = std::hint::black_box(None);
+            let ast_recursion_limit = std::hint::black_box(None);
             let progress = Arc::new(AtomicUsize::new(0));
             let ct = CancellationToken::new();
 


### PR DESCRIPTION
## Summary

Upgrades the `criterion` dev-dependency from the pinned `0.5.1` to the semver-flexible `0.8`, and migrates the bench file from the deprecated `criterion::black_box` to `std::hint::black_box` per the 0.6.0 migration guide.

No production source files are changed.

## Changes

- `Cargo.toml`: `criterion = "0.5.1"` -> `criterion = "0.8"` (keeps `html_reports` feature)
- `benches/analysis.rs`: drop `black_box` from `use criterion::...` import; replace all 9 call sites with `std::hint::black_box`
- `Cargo.lock`: updated criterion and transitive deps (criterion-plot, itertools, tokio patch, etc.)

## Testing

```
cargo fmt --check   # clean
cargo clippy        # clean
cargo test          # 6 passed, 0 failed
cargo bench --no-run  # compiles successfully
```