### PR TITLE
ci: add release infrastructure with homebrew tap and crates.io publish

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -1,0 +1,89 @@
+name: Build and Attest
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+        description: "Rust target triple (e.g., x86_64-unknown-linux-musl)"
+      os:
+        required: true
+        type: string
+        description: "Runner OS (ubuntu-latest, macos-latest)"
+      cross:
+        required: true
+        type: boolean
+        description: "Use cross-compilation toolchain"
+      version:
+        required: true
+        type: string
+        description: "Release version tag"
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: "Dry run (skip uploads and signatures)"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build-and-attest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          targets: ${{ inputs.target }}
+
+      - name: Setup cross-compilation toolchain
+        if: ${{ inputs.cross }}
+        uses: taiki-e/setup-cross-toolchain-action@20dbac418ca692fd1a9377acf2cec38161169a39 # v1
+        with:
+          target: ${{ inputs.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: code-analyze-mcp
+          key: ${{ inputs.target }}
+
+      - name: Upload Rust binary
+        if: ${{ !inputs.dry_run }}
+        id: upload
+        uses: taiki-e/upload-rust-binary-action@381995c84a8e242b8736ec80211c563d7bd07ce7 # v1
+        with:
+          bin: code-analyze-mcp
+          target: ${{ inputs.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checksum: sha256
+          archive: code-analyze-mcp-${{ inputs.version }}-${{ inputs.target }}
+
+      - name: Build binary (dry-run)
+        if: ${{ inputs.dry_run }}
+        run: cargo build --release --target ${{ inputs.target }}
+
+      - name: Sign tarball with cosign
+        if: ${{ !inputs.dry_run }}
+        run: cosign sign-blob --yes --bundle "${{ steps.upload.outputs.tar }}.bundle" "${{ steps.upload.outputs.tar }}"
+
+      - name: Upload bundle to release
+        if: ${{ !inputs.dry_run }}
+        run: gh release upload ${{ github.ref_name }} "${{ steps.upload.outputs.tar }}.bundle" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: ${{ steps.upload.outputs.tar }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,271 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip publish, release creation, homebrew)'
+        required: true
+        type: boolean
+        default: true
+      version:
+        description: 'Version to simulate (e.g., 0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+
+jobs:
+  verify-tag-signature:
+    name: Verify Tag Signature
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify tag is signed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "Verifying signature for tag: $TAG"
+          
+          # Get tag ref to find the tag object SHA
+          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.sha')
+          TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.type')
+          
+          if [ "$TAG_TYPE" != "tag" ]; then
+            echo "ERROR: $TAG is a lightweight tag (type: $TAG_TYPE), not an annotated/signed tag"
+            exit 1
+          fi
+          
+          # Verify the tag signature via GitHub API
+          VERIFIED=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.verified')
+          REASON=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.reason')
+          
+          echo "Tag verification: verified=$VERIFIED, reason=$REASON"
+          
+          if [ "$VERIFIED" != "true" ]; then
+            echo "ERROR: Tag $TAG signature is not valid (reason: $REASON)"
+            exit 1
+          fi
+          
+          echo "Tag $TAG is signed and verified by GitHub"
+
+  create-release:
+    name: Create Release
+    needs: [verify-tag-signature]
+    if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ env.VERSION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version from tag or input
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Validate version matches Cargo.toml
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ "$VERSION" != "$CARGO_VERSION" ]; then
+            echo "Tag version $VERSION does not match Cargo.toml version $CARGO_VERSION"
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != 'true' }}
+        id: create_release
+        uses: taiki-e/create-gh-release-action@c5baa0b5dc700cf06439d87935e130220a6882d9 # v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+
+      - name: Dry run - skip release creation
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: echo "DRY RUN - Would create release for v$VERSION"
+
+  build-and-attest:
+    name: Build ${{ matrix.target }}
+    needs: create-release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
+    uses: ./.github/workflows/build-and-attest.yml
+    with:
+      target: ${{ matrix.target }}
+      os: ${{ matrix.os }}
+      cross: ${{ matrix.cross }}
+      version: ${{ needs.create-release.outputs.version }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+    secrets: inherit
+
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: build-and-attest
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-tap repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: clouatre-labs/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Download SHA256 checksums
+        run: |
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_URL="https://api.github.com/repos/clouatre-labs/code-analyze-mcp/releases/tags/${RELEASE_TAG}"
+          
+          # Get release assets
+          ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[] | select(.name | endswith(".tar.gz")) | {name: .name, url: .browser_download_url}')
+          
+          # Download each asset and compute SHA256
+          echo "$ASSETS" | jq -r '.url' | while read -r url; do
+            filename=$(basename "$url")
+            curl -sL "$url" -o "/tmp/$filename"
+            sha256=$(sha256sum "/tmp/$filename" | cut -d' ' -f1)
+            echo "$filename:$sha256" >> /tmp/checksums.txt
+          done
+
+      - name: Update formula with SHA256 values
+        run: |
+          cd homebrew-tap
+          
+          # Read checksums
+          declare -A shas
+          while IFS=':' read -r filename sha; do
+            shas["$filename"]="$sha"
+          done < /tmp/checksums.txt
+          
+          # Update formula with if/elsif syntax
+          FORMULA="Formula/code-analyze-mcp.rb"
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          VERSION_NUMBER="${RELEASE_TAG#v}"
+          
+          # Generate formula content with if/elsif for architecture detection
+          cat > "$FORMULA" << 'FORMULA_EOF'
+          class CodeAnalyzeMcp < Formula
+            desc "MCP server for code structure analysis using tree-sitter"
+            homepage "https://github.com/clouatre-labs/code-analyze-mcp"
+            license "Apache-2.0"
+            
+            if OS.mac? && Hardware::CPU.arm?
+              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
+              sha256 "SHA256_MACOS_ARM_PLACEHOLDER"
+            elsif OS.linux? && Hardware::CPU.arm?
+              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
+              sha256 "SHA256_LINUX_ARM_PLACEHOLDER"
+            elsif OS.linux? && Hardware::CPU.intel?
+              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
+              sha256 "SHA256_LINUX_INTEL_PLACEHOLDER"
+            end
+            
+            def install
+              bin.install "code-analyze-mcp"
+            end
+            
+            test do
+              assert_match version.to_s, shell_output("#{bin}/code-analyze-mcp --version")
+            end
+          end
+          FORMULA_EOF
+          
+          # Replace placeholders with actual values
+          sed -i "s/VERSION_NUMBER_PLACEHOLDER/${VERSION_NUMBER}/g" "$FORMULA"
+          sed -i "s/TAG_PLACEHOLDER/${RELEASE_TAG}/g" "$FORMULA"
+          sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["code-analyze-mcp-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_ARM_PLACEHOLDER/${shas["code-analyze-mcp-${VERSION_NUMBER}-aarch64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+          sed -i "s/SHA256_LINUX_INTEL_PLACEHOLDER/${shas["code-analyze-mcp-${VERSION_NUMBER}-x86_64-unknown-linux-musl.tar.gz"]}/g" "$FORMULA"
+
+      - name: Create feature branch and commit formula update
+        run: |
+          cd homebrew-tap
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          BRANCH_NAME="update-code-analyze-mcp-${RELEASE_TAG}"
+          
+          git config user.email "hugues@linux.com"
+          git config user.name "Hugues Clouatre"
+          git checkout -b "$BRANCH_NAME"
+          git add Formula/code-analyze-mcp.rb
+          git commit --signoff -m "Update code-analyze-mcp formula for ${RELEASE_TAG}"
+          git push origin "$BRANCH_NAME"
+
+      - name: Create pull request with auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          cd homebrew-tap
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          BRANCH_NAME="update-code-analyze-mcp-${RELEASE_TAG}"
+          
+          gh pr create \
+            --title "Update code-analyze-mcp formula for ${RELEASE_TAG}" \
+            --body "Automated formula update with SHA256 checksums for release ${RELEASE_TAG}" \
+            --head "$BRANCH_NAME" \
+            --base main
+          
+          # Auto-merge after Audit check passes (ruleset requires status checks)
+          gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch
+
+  publish:
+    name: Publish to crates.io
+    needs: create-release
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          toolchain: stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 authors = ["Hugues Clouatre"]
 license = "Apache-2.0"
 description = "MCP server for code structure analysis using tree-sitter"
+repository = "https://github.com/clouatre-labs/code-analyze-mcp"
+homepage = "https://github.com/clouatre-labs/code-analyze-mcp"
+keywords = ["mcp", "code-analysis", "tree-sitter", "lsp"]
+categories = ["development-tools", "command-line-utilities"]
 
 [dependencies]
 rmcp = { version = "1", features = ["server", "macros", "transport-io"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,11 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if std::env::args().any(|a| a == "--version") {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     // Create shared peer Arc for logging layer
     let peer = Arc::new(TokioMutex::new(None));
 


### PR DESCRIPTION
## Summary

Add release infrastructure mirroring `clouatre-labs/aptu`, adapted for this single-binary repo.

## What this adds

- `.github/workflows/build-and-attest.yml` - reusable cross-compile workflow; builds `code-analyze-mcp` for 3 targets, cosign-signs each tarball, attests build provenance
- `.github/workflows/release.yml` - tag-triggered release workflow:
  - Verifies GPG-signed tag
  - Creates GitHub Release via `taiki-e/create-gh-release-action`
  - Builds all 3 targets (aarch64-apple-darwin, x86_64-unknown-linux-musl, aarch64-unknown-linux-musl)
  - Auto-updates `clouatre-labs/homebrew-tap` formula with correct SHA256s (PR + auto-merge)
  - Publishes to crates.io
  - `workflow_dispatch` dry-run mode for testing without publishing
- `src/main.rs` - `--version` flag (no new deps, required for `brew audit --strict`)
- `Cargo.toml` - adds `repository`, `homepage`, `keywords`, `categories` (required for crates.io)

## Secrets required (pre-existing in aptu)

| Secret | Used by |
|--------|---------|
| `HOMEBREW_TAP_TOKEN` | update-homebrew job (same token as aptu) |
| `CRATES_IO_TOKEN` | publish job |

Both secrets need to be added to this repo's settings before the first release.

## Testing

Dry-run via `workflow_dispatch` (set `dry_run: true`, provide a version string) exercises build and verification without publishing or updating the tap.