### PR TITLE
ci: switch to workflow-driven release with RELEASE_TOKEN tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,17 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version to release (e.g., 0.1.0)'
+        required: true
+        type: string
       dry_run:
-        description: 'Dry run (skip publish, release creation, homebrew)'
+        description: 'Dry run (skip tag creation, publish, release creation, homebrew)'
         required: true
         type: boolean
         default: true
-      version:
-        description: 'Version to simulate (e.g., 0.1.0)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -25,93 +22,86 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+  DRY_RUN: ${{ inputs.dry_run }}
 
 jobs:
-  verify-tag-signature:
-    name: Verify Tag Signature
+  create-tag:
+    name: Create Release Tag
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ inputs.version }}
+      tag: v${{ inputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
 
-      - name: Verify tag is signed
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Validate version matches Cargo.toml
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          echo "Verifying signature for tag: $TAG"
-          
-          # Get tag ref to find the tag object SHA
-          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.sha')
-          TAG_TYPE=$(gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" --jq '.object.type')
-          
-          if [ "$TAG_TYPE" != "tag" ]; then
-            echo "ERROR: $TAG is a lightweight tag (type: $TAG_TYPE), not an annotated/signed tag"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ "${{ inputs.version }}" != "$CARGO_VERSION" ]; then
+            echo "ERROR: Input version ${{ inputs.version }} does not match Cargo.toml version $CARGO_VERSION"
             exit 1
           fi
-          
-          # Verify the tag signature via GitHub API
-          VERIFIED=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.verified')
-          REASON=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA" --jq '.verification.reason')
-          
-          echo "Tag verification: verified=$VERIFIED, reason=$REASON"
-          
-          if [ "$VERIFIED" != "true" ]; then
-            echo "ERROR: Tag $TAG signature is not valid (reason: $REASON)"
-            exit 1
-          fi
-          
-          echo "Tag $TAG is signed and verified by GitHub"
+
+      - name: Create annotated tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          TAG="v${{ inputs.version }}"
+          COMMIT_SHA=$(git rev-parse HEAD)
+
+          # Create annotated tag object
+          TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
+            -X POST \
+            -f tag="$TAG" \
+            -f message="Release $TAG" \
+            -f object="$COMMIT_SHA" \
+            -f type="commit" \
+            --jq '.sha')
+
+          # Create the ref pointing to the tag object
+          gh api repos/${{ github.repository }}/git/refs \
+            -X POST \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$TAG_SHA"
+
+          echo "Created annotated tag $TAG -> $TAG_SHA"
+
+      - name: Dry run - skip tag creation
+        if: ${{ inputs.dry_run }}
+        run: echo "DRY RUN - Would create annotated tag v${{ inputs.version }}"
 
   create-release:
     name: Create Release
-    needs: [verify-tag-signature]
-    if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
+    needs: create-tag
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ env.VERSION }}
+      version: ${{ needs.create-tag.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Extract version from tag or input
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          fi
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-
-      - name: Validate version matches Cargo.toml
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        shell: bash
-        run: |
-          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          if [ "$VERSION" != "$CARGO_VERSION" ]; then
-            echo "Tag version $VERSION does not match Cargo.toml version $CARGO_VERSION"
-            exit 1
-          fi
+        with:
+          ref: v${{ needs.create-tag.outputs.version }}
+          fetch-tags: true
 
       - name: Create GitHub release
-        if: ${{ env.DRY_RUN != 'true' }}
+        if: ${{ !inputs.dry_run }}
         id: create_release
         uses: taiki-e/create-gh-release-action@c5baa0b5dc700cf06439d87935e130220a6882d9 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          ref: refs/tags/v${{ needs.create-tag.outputs.version }}
 
       - name: Dry run - skip release creation
-        if: ${{ env.DRY_RUN == 'true' }}
-        run: echo "DRY RUN - Would create release for v$VERSION"
+        if: ${{ inputs.dry_run }}
+        run: echo "DRY RUN - Would create release for v${{ needs.create-tag.outputs.version }}"
 
   build-and-attest:
     name: Build ${{ matrix.target }}
@@ -139,13 +129,13 @@ jobs:
       os: ${{ matrix.os }}
       cross: ${{ matrix.cross }}
       version: ${{ needs.create-release.outputs.version }}
-      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+      dry_run: ${{ inputs.dry_run }}
     secrets: inherit
 
   update-homebrew:
     name: Update Homebrew Formula
-    needs: build-and-attest
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    needs: [create-release, build-and-attest]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout homebrew-tap repository
@@ -156,14 +146,15 @@ jobs:
           path: homebrew-tap
 
       - name: Download SHA256 checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
+          VERSION_NUMBER="${{ needs.create-release.outputs.version }}"
           RELEASE_URL="https://api.github.com/repos/clouatre-labs/code-analyze-mcp/releases/tags/${RELEASE_TAG}"
-          
-          # Get release assets
+
           ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_URL" | jq '.assets[] | select(.name | endswith(".tar.gz")) | {name: .name, url: .browser_download_url}')
-          
-          # Download each asset and compute SHA256
+
           echo "$ASSETS" | jq -r '.url' | while read -r url; do
             filename=$(basename "$url")
             curl -sL "$url" -o "/tmp/$filename"
@@ -174,47 +165,43 @@ jobs:
       - name: Update formula with SHA256 values
         run: |
           cd homebrew-tap
-          
-          # Read checksums
+
           declare -A shas
           while IFS=':' read -r filename sha; do
             shas["$filename"]="$sha"
           done < /tmp/checksums.txt
-          
-          # Update formula with if/elsif syntax
+
           FORMULA="Formula/code-analyze-mcp.rb"
-          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
-          VERSION_NUMBER="${RELEASE_TAG#v}"
-          
-          # Generate formula content with if/elsif for architecture detection
+          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
+          VERSION_NUMBER="${{ needs.create-release.outputs.version }}"
+
           cat > "$FORMULA" << 'FORMULA_EOF'
-          class CodeAnalyzeMcp < Formula
-            desc "MCP server for code structure analysis using tree-sitter"
-            homepage "https://github.com/clouatre-labs/code-analyze-mcp"
-            license "Apache-2.0"
-            
-            if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
-              sha256 "SHA256_MACOS_ARM_PLACEHOLDER"
-            elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
-              sha256 "SHA256_LINUX_ARM_PLACEHOLDER"
-            elsif OS.linux? && Hardware::CPU.intel?
-              url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
-              sha256 "SHA256_LINUX_INTEL_PLACEHOLDER"
-            end
-            
-            def install
-              bin.install "code-analyze-mcp"
-            end
-            
-            test do
-              assert_match version.to_s, shell_output("#{bin}/code-analyze-mcp --version")
-            end
-          end
-          FORMULA_EOF
-          
-          # Replace placeholders with actual values
+class CodeAnalyzeMcp < Formula
+  desc "MCP server for code structure analysis using tree-sitter"
+  homepage "https://github.com/clouatre-labs/code-analyze-mcp"
+  license "Apache-2.0"
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-apple-darwin.tar.gz"
+    sha256 "SHA256_MACOS_ARM_PLACEHOLDER"
+  elsif OS.linux? && Hardware::CPU.arm?
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-aarch64-unknown-linux-musl.tar.gz"
+    sha256 "SHA256_LINUX_ARM_PLACEHOLDER"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/TAG_PLACEHOLDER/code-analyze-mcp-VERSION_NUMBER_PLACEHOLDER-x86_64-unknown-linux-musl.tar.gz"
+    sha256 "SHA256_LINUX_INTEL_PLACEHOLDER"
+  end
+
+  def install
+    bin.install "code-analyze-mcp"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/code-analyze-mcp --version")
+  end
+end
+FORMULA_EOF
+
           sed -i "s/VERSION_NUMBER_PLACEHOLDER/${VERSION_NUMBER}/g" "$FORMULA"
           sed -i "s/TAG_PLACEHOLDER/${RELEASE_TAG}/g" "$FORMULA"
           sed -i "s/SHA256_MACOS_ARM_PLACEHOLDER/${shas["code-analyze-mcp-${VERSION_NUMBER}-aarch64-apple-darwin.tar.gz"]}/g" "$FORMULA"
@@ -224,9 +211,9 @@ jobs:
       - name: Create feature branch and commit formula update
         run: |
           cd homebrew-tap
-          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
           BRANCH_NAME="update-code-analyze-mcp-${RELEASE_TAG}"
-          
+
           git config user.email "hugues@linux.com"
           git config user.name "Hugues Clouatre"
           git checkout -b "$BRANCH_NAME"
@@ -239,26 +226,28 @@ jobs:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           cd homebrew-tap
-          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
           BRANCH_NAME="update-code-analyze-mcp-${RELEASE_TAG}"
-          
+
           gh pr create \
             --title "Update code-analyze-mcp formula for ${RELEASE_TAG}" \
             --body "Automated formula update with SHA256 checksums for release ${RELEASE_TAG}" \
             --head "$BRANCH_NAME" \
             --base main
-          
-          # Auto-merge after Audit check passes (ruleset requires status checks)
+
           gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch
 
   publish:
     name: Publish to crates.io
     needs: create-release
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: v${{ needs.create-release.outputs.version }}
+          fetch-tags: true
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable


### PR DESCRIPTION
Replace push-tag trigger and verify-tag-signature job with a workflow_dispatch that creates an annotated tag via the GitHub API using RELEASE_TOKEN (org admin PAT, bypasses Release Tag Protection ruleset). Removes the requirement to GPG-sign tags locally.

Changes:
- Single trigger: workflow_dispatch with version and dry_run inputs
- New create-tag job: validates Cargo.toml version match, creates annotated tag via gh api using secrets.RELEASE_TOKEN
- create-release checks out the tag ref explicitly
- publish job checks out the tag ref explicitly
- All downstream jobs (build-and-attest, update-homebrew, publish) use needs outputs for version, no GITHUB_REF parsing
- Dry run path preserved