### PR TITLE
docs: add installation methods to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ code-analyze-mcp is a Model Context Protocol server that analyzes code structure
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew tap clouatre-labs/tap
-brew install code-analyze-mcp
+brew install clouatre-labs/tap/code-analyze-mcp
 ```
 
 Update: `brew upgrade code-analyze-mcp`


### PR DESCRIPTION
Documents the three installation paths (Homebrew, cargo-binstall, cargo install) ahead of the 0.1.0 release.