### PR TITLE
fix: skip tag ref checkout in dry-run mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,16 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ needs.create-tag.outputs.version }}
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (real run)
+        if: ${{ !inputs.dry_run }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/v${{ needs.create-tag.outputs.version }}
           fetch-tags: true
+
+      - name: Checkout repository (dry run)
+        if: ${{ inputs.dry_run }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}
@@ -239,11 +244,16 @@ jobs:
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (real run)
+        if: ${{ !inputs.dry_run }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/v${{ needs.create-release.outputs.version }}
           fetch-tags: true
+
+      - name: Checkout repository (dry run)
+        if: ${{ inputs.dry_run }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable


### PR DESCRIPTION
In dry-run mode no tag is created, so checking out `refs/tags/v{version}` fails with exit code 1. Split the checkout step: real runs check out the tag ref, dry runs check out HEAD.