### PR TITLE
fix(release): make tag and release creation idempotent

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} "${{ steps.upload.outputs.tar }}.bundle" --clobber
+        run: gh release upload "v${{ inputs.version }}" "${{ steps.upload.outputs.tar }}.bundle" --clobber
 
       - name: Attest build provenance
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,20 +53,24 @@ jobs:
           TAG="v${{ inputs.version }}"
           COMMIT_SHA=$(git rev-parse HEAD)
 
-          TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
-            -X POST \
-            -f tag="$TAG" \
-            -f message="Release $TAG" \
-            -f object="$COMMIT_SHA" \
-            -f type="commit" \
-            --jq '.sha')
+          if gh api repos/${{ github.repository }}/git/refs/tags/"$TAG" --silent 2>/dev/null; then
+            echo "Tag $TAG already exists, skipping creation"
+          else
+            TAG_SHA=$(gh api repos/${{ github.repository }}/git/tags \
+              -X POST \
+              -f tag="$TAG" \
+              -f message="Release $TAG" \
+              -f object="$COMMIT_SHA" \
+              -f type="commit" \
+              --jq '.sha')
 
-          gh api repos/${{ github.repository }}/git/refs \
-            -X POST \
-            -f ref="refs/tags/$TAG" \
-            -f sha="$TAG_SHA"
+            gh api repos/${{ github.repository }}/git/refs \
+              -X POST \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$TAG_SHA"
 
-          echo "Created annotated tag $TAG -> $TAG_SHA"
+            echo "Created annotated tag $TAG -> $TAG_SHA"
+          fi
 
       - name: Dry run - skip tag creation
         if: ${{ inputs.dry_run }}
@@ -79,7 +83,6 @@ jobs:
     permissions:
       contents: write
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ needs.create-tag.outputs.version }}
     steps:
       - name: Checkout repository (real run)
@@ -96,11 +99,15 @@ jobs:
       - name: Create GitHub release
         if: ${{ !inputs.dry_run }}
         id: create_release
-        uses: taiki-e/create-gh-release-action@c5baa0b5dc700cf06439d87935e130220a6882d9 # v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: false
-          ref: refs/tags/v${{ needs.create-tag.outputs.version }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.create-tag.outputs.version }}"
+          if gh release view "$TAG" --json id --silent 2>/dev/null; then
+            echo "Release $TAG already exists, skipping creation"
+          else
+            gh release create "$TAG" --title "$TAG" --notes "" --draft=false
+          fi
 
       - name: Dry run - skip release creation
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Problem

Two bugs prevented a re-run of the release workflow after a partial failure:

1. **Tag creation not idempotent** -- `Create annotated tag` step POSTed to `/git/tags` unconditionally; if the tag already exists, GitHub returns 404 and the job fails
2. **Wrong release tag for artifact upload** -- `build-and-attest.yml` used `${{ github.ref_name }}` for `gh release upload`, which is the branch name (`main`) on `workflow_dispatch`, not the tag name

## Changes

### `.github/workflows/release.yml`
- `Create annotated tag`: check `/git/refs/tags/{tag}` first; skip creation if tag exists
- `Create GitHub release`: replace `taiki-e/create-gh-release-action` with `gh release create` wrapped in an existence check; removes the unused `upload_url` output

### `.github/workflows/build-and-attest.yml`
- `Upload bundle to release`: use `v${{ inputs.version }}` instead of `${{ github.ref_name }}`

## Testing

Dry run already passed (run [22979687728](https://github.com/clouatre-labs/code-analyze-mcp/actions/runs/22979687728)). Tag `v0.1.0` and release exist. After merging, the release workflow can be re-triggered with `version=0.1.0, dry_run=false` and will skip tag/release creation and proceed directly to builds.