### PR TITLE
fix(release): use GITHUB_TOKEN for tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create annotated tag
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ inputs.version }}"
           COMMIT_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
## Problem

`RELEASE_TOKEN` is a fine-grained PAT scoped to `clouatre-labs/homebrew-tap` only. Every call it makes to the `code-analyze-mcp` API returns 404 -- including the existence check added in #183.

## Fix

Switch the `Create annotated tag` step to `GITHUB_TOKEN`. The `create-tag` job already declares `permissions: contents: write`, which is sufficient for creating annotated tags and refs via the REST API.

`RELEASE_TOKEN` is still used for the homebrew-tap step, which is its intended scope.

## History

- #174 introduced `RELEASE_TOKEN` under the assumption it was needed for tag creation
- #183 added idempotency but the token problem blocked the check itself
- This PR is the actual root-cause fix