### PR TITLE
fix(release): fix gh release view existence check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ needs.create-tag.outputs.version }}"
-          if gh release view "$TAG" --json id --silent 2>/dev/null; then
+          if gh release view "$TAG" > /dev/null 2>&1; then
             echo "Release $TAG already exists, skipping creation"
           else
             gh release create "$TAG" --title "$TAG" --notes "" --draft=false


### PR DESCRIPTION
## Problem

`gh release view --silent` exits non-zero even when the release exists, causing the existence check in the `Create GitHub release` step to always fall through to `gh release create`, which then fails with HTTP 422 (`Release.tag_name already exists`).

## Fix

Replace `--json id --silent 2>/dev/null` with `> /dev/null 2>&1`. The exit code from `gh release view` is 0 when the release exists and non-zero when it does not -- the redirect-based check is reliable.