### PR TITLE
fix(build): pass ref to upload-rust-binary-action

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -72,6 +72,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
           archive: code-analyze-mcp-${{ inputs.version }}-$target
+          ref: refs/tags/v${{ inputs.version }}
 
       - name: Build binary (dry-run)
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Problem

`taiki-e/upload-rust-binary-action` reads `GITHUB_REF` to determine the release tag. On `workflow_dispatch`, `GITHUB_REF` is `refs/heads/main`, not a tag ref. The action hard-fails with:

```
tag ref should start with 'refs/tags/': 'refs/heads/main'
```

## Fix

Add `ref: refs/tags/v${{ inputs.version }}` to the action inputs. The action accepts an explicit `ref` input that overrides `GITHUB_REF`.

## Context

Observed in run [22979982474](https://github.com/clouatre-labs/code-analyze-mcp/actions/runs/22979982474) on all Linux build jobs. The macOS job also failed but with a transient 401 on cosign-installer download (unrelated runner network issue, not a code bug).