### PR TITLE
fix(release): skip crates.io publish if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,4 +270,10 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          if cargo search code-analyze-mcp --limit 1 2>/dev/null | grep -q "^code-analyze-mcp = \"${VERSION}\""; then
+            echo "code-analyze-mcp@${VERSION} already published, skipping"
+          else
+            cargo publish
+          fi


### PR DESCRIPTION
The publish job now checks whether the version is already indexed on crates.io before running `cargo publish`. This makes the job idempotent so a re-run after a partial failure does not error out.

**What changed**
- `cargo search code-analyze-mcp --limit 1` checks if `version` is already published; skips if so, otherwise publishes

**Why**
The 0.1.0 crate publish succeeded in a previous run before the build jobs failed. The next run errored with `code-analyze-mcp@0.1.0 already exists on crates.io index`.