### PR TITLE
fix(release): use crates.io REST API for idempotent publish check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
           VERSION="${{ needs.create-release.outputs.version }}"
-          if cargo search code-analyze-mcp --limit 1 2>/dev/null | grep -q "^code-analyze-mcp = \"${VERSION}\""; then
+          if curl -sf "https://crates.io/api/v1/crates/code-analyze-mcp/${VERSION}" > /dev/null; then
             echo "code-analyze-mcp@${VERSION} already published, skipping"
           else
             cargo publish


### PR DESCRIPTION
The previous `cargo search` check is unreliable -- it queries a sparse index that can lag. Replace with a direct crates.io REST API call (`https://crates.io/api/v1/crates/{crate}/{version}`) which returns 200 if the version exists, 404 if not. Fixes the publish step failing on re-run of 0.1.0.