### PR TITLE
fix: read server version from CARGO_PKG_VERSION instead of hardcoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ impl ServerHandler for CodeAnalyzer {
             .enable_tool_list_changed()
             .enable_completions()
             .build();
-        let server_info = Implementation::new("code-analyze-mcp", "0.1.0")
+        let server_info = Implementation::new("code-analyze-mcp", env!("CARGO_PKG_VERSION"))
             .with_title("Code Analyze MCP")
             .with_description("MCP server for code structure analysis using tree-sitter");
         InitializeResult::new(capabilities)


### PR DESCRIPTION
## Summary

`serverInfo.version` in the MCP handshake was hardcoded to `"0.1.0"` instead of reading from the package manifest. This caused a mismatch where the binary reported `0.1.1` via `--version` but advertised `0.1.0` to MCP clients.

## Change

```rust
// before
Implementation::new("code-analyze-mcp", "0.1.0")

// after
Implementation::new("code-analyze-mcp", env!("CARGO_PKG_VERSION"))
```

## Testing

Verified the MCP handshake now returns `"version": "0.1.1"` matching `Cargo.toml`.