### PR TITLE
perf(lib): cache peer reference to eliminate per-progress-event lock contention

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,12 +106,12 @@ impl CodeAnalyzer {
     #[instrument(skip(self))]
     async fn emit_progress(
         &self,
+        peer: Option<Peer<RoleServer>>,
         token: &ProgressToken,
         progress: f64,
         total: f64,
         message: String,
     ) {
-        let peer = self.peer.lock().await.clone();
         if let Some(peer) = peer {
             let notification = ServerNotification::ProgressNotification(Notification::new(
                 ProgressNotificationParam {
@@ -171,6 +171,7 @@ impl CodeAnalyzer {
             )
             .into(),
         ));
+        let peer = self.peer.lock().await.clone();
         let mut last_progress = 0usize;
         let mut cancelled = false;
         loop {
@@ -182,6 +183,7 @@ impl CodeAnalyzer {
             let current = counter.load(std::sync::atomic::Ordering::Relaxed);
             if current != last_progress && total_files > 0 {
                 self.emit_progress(
+                    peer.clone(),
                     &token,
                     current as f64,
                     total_files as f64,
@@ -198,6 +200,7 @@ impl CodeAnalyzer {
         // Emit final 100% progress only if not cancelled
         if !cancelled && total_files > 0 {
             self.emit_progress(
+                peer.clone(),
                 &token,
                 total_files as f64,
                 total_files as f64,
@@ -319,6 +322,7 @@ impl CodeAnalyzer {
             )
             .into(),
         ));
+        let peer = self.peer.lock().await.clone();
         let mut last_progress = 0usize;
         let mut cancelled = false;
         loop {
@@ -330,6 +334,7 @@ impl CodeAnalyzer {
             let current = counter.load(std::sync::atomic::Ordering::Relaxed);
             if current != last_progress && total_files > 0 {
                 self.emit_progress(
+                    peer.clone(),
                     &token,
                     current as f64,
                     total_files as f64,
@@ -349,6 +354,7 @@ impl CodeAnalyzer {
         // Emit final 100% progress only if not cancelled
         if !cancelled && total_files > 0 {
             self.emit_progress(
+                peer.clone(),
                 &token,
                 total_files as f64,
                 total_files as f64,
@@ -926,5 +932,23 @@ impl ServerHandler for CodeAnalyzer {
         let mut filter_lock = self.log_level_filter.lock().unwrap();
         *filter_lock = level_filter;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_emit_progress_none_peer_is_noop() {
+        let peer = Arc::new(TokioMutex::new(None));
+        let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let analyzer = CodeAnalyzer::new(peer, log_level_filter, rx);
+        let token = ProgressToken(NumberOrString::String("test".into()));
+        // Should complete without panic
+        analyzer
+            .emit_progress(None, &token, 0.0, 10.0, "test".to_string())
+            .await;
     }
 }


### PR DESCRIPTION
## Summary

Acquire `self.peer` lock once at analysis start in `handle_overview_mode` and `handle_focused_mode` rather than on every `emit_progress` call. Pass the cached `Option<Peer<RoleServer>>` as a parameter to `emit_progress`, removing the internal lock acquisition.

## Motivation

`emit_progress` was acquiring `self.peer.lock().await` on every progress notification (~10 per second during analysis). Under concurrent tool invocations this caused unnecessary lock contention. Caching the peer once per analysis invocation reduces lock acquisitions by ~90-99%.

## Changes

- `emit_progress`: new signature accepts `peer: Option<Peer<RoleServer>>` as first parameter; internal `self.peer.lock().await` removed
- `handle_overview_mode`: acquires peer once before the progress polling loop; passes `peer.clone()` to both `emit_progress` call sites
- `handle_focused_mode`: same pattern
- Added unit test: `test_emit_progress_none_peer_is_noop` verifying the None peer edge case is handled gracefully

## Testing

- All 41 unit tests pass
- cargo fmt, clippy, and test all clean
- Progress notification behavior and message format unchanged

Closes #203