### PR TITLE
fix(types): remove prescriptive 'use proactively' guidance from summary parameter descriptions

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -22,7 +22,7 @@ pub struct AnalyzeDirectoryParams {
     pub force: Option<bool>,
 
     #[schemars(
-        description = "true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars. Use true proactively on large codebases to reduce token consumption."
+        description = "true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars."
     )]
     pub summary: Option<bool>,
 
@@ -53,7 +53,7 @@ pub struct AnalyzeFileParams {
     pub force: Option<bool>,
 
     #[schemars(
-        description = "true = compact summary (no per-function details); false = full output; unset = auto-summarize when output exceeds 50K chars. Use true proactively on large files to reduce token consumption."
+        description = "true = compact summary (no per-function details); false = full output; unset = auto-summarize when output exceeds 50K chars."
     )]
     pub summary: Option<bool>,
 
@@ -99,7 +99,7 @@ pub struct AnalyzeSymbolParams {
     pub force: Option<bool>,
 
     #[schemars(
-        description = "true = compact summary; false = full output; unset = auto-summarize when output exceeds 50K chars. Use true proactively on large codebases to reduce token consumption."
+        description = "true = compact summary; false = full output; unset = auto-summarize when output exceeds 50K chars."
     )]
     pub summary: Option<bool>,
 


### PR DESCRIPTION
## Summary

Removes the prescriptive 'Use true proactively on large files/codebases to reduce token consumption.' sentence from the `summary` parameter descriptions on `analyze_file`, `analyze_directory`, and `analyze_symbol`.

## Changes

Descriptions-only edit in `src/types.rs` (3 lines). No functional or schema change.

## Motivation

Per MCP specification, parameter descriptions should describe what a parameter does, not prescribe when the LLM should invoke it. The prescriptive guidance was causing LLMs to call `analyze_file(summary=true)` as a first move, then immediately fall back to multiple `rg` calls to retrieve the stripped function details -- adding a round-trip for zero net gain.

The auto-summarize default (`unset` behavior) already handles the token safety case correctly.

Closes #222