### PR TITLE
chore: remove AGENTS.md from repo .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ target/
 .goosehints
 .kiro/
 .windsurf/
-AGENTS.md
 CLAUDE.md
 opencode.json
 


### PR DESCRIPTION
AGENTS.md is now covered by the global gitignore (`~/.gitignore` via `core.excludesFile`). No need to maintain it in every repo's `.gitignore`.