### PR TITLE
refactor(types): extract shared params structs and use doc comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,8 @@ impl CodeAnalyzer {
         let ct_clone = ct.clone();
 
         // Compute use_summary before spawning: explicit params only
-        let use_summary_for_task = params.force != Some(true) && params.summary == Some(true);
+        let use_summary_for_task = params.output_control.force != Some(true)
+            && params.output_control.summary == Some(true);
 
         // Get total file count for progress reporting
         let total_files = match walk_directory(path, max_depth) {
@@ -392,8 +393,8 @@ impl CodeAnalyzer {
 
         // Auto-detect: if no explicit summary param and output exceeds limit,
         // re-run analysis with use_summary=true
-        if params.summary.is_none()
-            && params.force != Some(true)
+        if params.output_control.summary.is_none()
+            && params.output_control.force != Some(true)
             && output.formatted.len() > SIZE_LIMIT
         {
             let path_owned2 = Path::new(&params.path).to_path_buf();
@@ -436,8 +437,8 @@ impl CodeAnalyzer {
                 }
             }
         } else if output.formatted.len() > SIZE_LIMIT
-            && params.force != Some(true)
-            && params.summary == Some(false)
+            && params.output_control.force != Some(true)
+            && params.output_control.summary == Some(false)
         {
             // Explicit summary=false with large output: return error
             let estimated_tokens = output.formatted.len() / 4;
@@ -484,11 +485,11 @@ impl CodeAnalyzer {
         let mut output = self.handle_overview_mode(&params, ct).await?;
 
         // Apply summary/output size limiting logic
-        let use_summary = if params.force == Some(true) {
+        let use_summary = if params.output_control.force == Some(true) {
             false
-        } else if params.summary == Some(true) {
+        } else if params.output_control.summary == Some(true) {
             true
-        } else if params.summary == Some(false) {
+        } else if params.output_control.summary == Some(false) {
             false
         } else {
             output.formatted.len() > SIZE_LIMIT
@@ -504,8 +505,8 @@ impl CodeAnalyzer {
         }
 
         // Decode pagination cursor if provided
-        let page_size = params.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
-        let offset = if let Some(ref cursor_str) = params.cursor {
+        let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let offset = if let Some(ref cursor_str) = params.pagination.cursor {
             let cursor_data = decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, e.to_string(), None)
             })?;
@@ -576,11 +577,11 @@ impl CodeAnalyzer {
         let line_count = arc_output.line_count;
 
         // Apply summary/output size limiting logic
-        let use_summary = if params.force == Some(true) {
+        let use_summary = if params.output_control.force == Some(true) {
             false
-        } else if params.summary == Some(true) {
+        } else if params.output_control.summary == Some(true) {
             true
-        } else if params.summary == Some(false) {
+        } else if params.output_control.summary == Some(false) {
             false
         } else {
             formatted.len() > SIZE_LIMIT
@@ -588,7 +589,7 @@ impl CodeAnalyzer {
 
         if use_summary {
             formatted = format_file_details_summary(&arc_output.semantic, &params.path, line_count);
-        } else if formatted.len() > SIZE_LIMIT && params.force != Some(true) {
+        } else if formatted.len() > SIZE_LIMIT && params.output_control.force != Some(true) {
             let estimated_tokens = formatted.len() / 4;
             let message = format!(
                 "Output exceeds 50K chars ({} chars, ~{} tokens). Use one of:\n\
@@ -606,9 +607,9 @@ impl CodeAnalyzer {
             ));
         }
 
-        // Decode pagination cursor if provided
-        let page_size = params.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
-        let offset = if let Some(ref cursor_str) = params.cursor {
+        // Decode pagination cursor if provided (analyze_file)
+        let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let offset = if let Some(ref cursor_str) = params.pagination.cursor {
             let cursor_data = decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, e.to_string(), None)
             })?;
@@ -686,9 +687,9 @@ impl CodeAnalyzer {
         // Call handler for analysis and progress tracking
         let mut output = self.handle_focused_mode(&params, ct).await?;
 
-        // Decode pagination cursor if provided
-        let page_size = params.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
-        let offset = if let Some(ref cursor_str) = params.cursor {
+        // Decode pagination cursor if provided (analyze_symbol)
+        let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let offset = if let Some(ref cursor_str) = params.pagination.cursor {
             let cursor_data = decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, e.to_string(), None)
             })?;
@@ -698,7 +699,7 @@ impl CodeAnalyzer {
         };
 
         // SymbolFocus pagination: decode cursor mode to determine callers vs callees
-        let cursor_mode = if let Some(ref cursor_str) = params.cursor {
+        let cursor_mode = if let Some(ref cursor_str) = params.pagination.cursor {
             decode_cursor(cursor_str)
                 .map(|c| c.mode)
                 .unwrap_or(PaginationMode::Callers)

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,112 +6,76 @@ use std::fmt::Write;
 #[allow(unused_imports)]
 use crate::analyze::{AnalysisOutput, FileAnalysisOutput, FocusedAnalysisOutput};
 
+/// Pagination parameters shared across all tools.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PaginationParams {
+    /// Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page. Omit on the first call.
+    pub cursor: Option<String>,
+    /// Files per page for pagination (default: 100). Reduce below 100 to limit response size; increase above 100 to reduce round trips.
+    pub page_size: Option<usize>,
+}
+
+/// Output control parameters shared across all tools.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OutputControlParams {
+    /// Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses.
+    pub force: Option<bool>,
+    /// true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars.
+    pub summary: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeDirectoryParams {
-    #[schemars(description = "Directory path to analyze")]
+    /// Directory path to analyze
     pub path: String,
 
-    #[schemars(
-        description = "Maximum directory traversal depth for overview mode only. 0 or unset = unlimited depth. Use 1-3 for large monorepos to manage output size. Ignored in other modes."
-    )]
+    /// Maximum directory traversal depth for overview mode only. 0 or unset = unlimited depth. Use 1-3 for large monorepos to manage output size. Ignored in other modes.
     pub max_depth: Option<u32>,
 
-    #[schemars(
-        description = "Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses."
-    )]
-    pub force: Option<bool>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
 
-    #[schemars(
-        description = "true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars."
-    )]
-    pub summary: Option<bool>,
-
-    #[schemars(
-        description = "Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page. Omit on the first call."
-    )]
-    pub cursor: Option<String>,
-
-    #[schemars(
-        description = "Files per page for pagination (default: 100). Reduce below 100 to limit response size; increase above 100 to reduce round trips."
-    )]
-    pub page_size: Option<usize>,
+    #[serde(flatten)]
+    pub output_control: OutputControlParams,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeFileParams {
-    #[schemars(description = "File path to analyze")]
+    /// File path to analyze
     pub path: String,
 
-    #[schemars(
-        description = "Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code."
-    )]
+    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code.
     pub ast_recursion_limit: Option<usize>,
 
-    #[schemars(
-        description = "Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses."
-    )]
-    pub force: Option<bool>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
 
-    #[schemars(
-        description = "true = compact summary (no per-function details); false = full output; unset = auto-summarize when output exceeds 50K chars."
-    )]
-    pub summary: Option<bool>,
-
-    #[schemars(
-        description = "Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page. Omit on the first call."
-    )]
-    pub cursor: Option<String>,
-
-    #[schemars(
-        description = "Items per page for pagination (default: 100). Items are functions. Reduce below 100 to limit response size; increase above 100 to reduce round trips."
-    )]
-    pub page_size: Option<usize>,
+    #[serde(flatten)]
+    pub output_control: OutputControlParams,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AnalyzeSymbolParams {
-    #[schemars(description = "Directory path to search for the symbol")]
+    /// Directory path to search for the symbol
     pub path: String,
 
-    #[schemars(
-        description = "Symbol name to build call graph for (function or method). Exact case-sensitive match required; searched across all files in the specified directory. Example: 'parse_config' finds all callers and callees of that function."
-    )]
+    /// Symbol name to build call graph for (function or method). Exact case-sensitive match required; searched across all files in the specified directory. Example: 'parse_config' finds all callers and callees of that function.
     pub symbol: String,
 
-    #[schemars(
-        description = "Call graph traversal depth for this tool (default 1). Level 1 = direct callers and callees; level 2 = one more hop, etc. Output size grows exponentially with graph branching. Warn user on levels above 2."
-    )]
+    /// Call graph traversal depth for this tool (default 1). Level 1 = direct callers and callees; level 2 = one more hop, etc. Output size grows exponentially with graph branching. Warn user on levels above 2.
     pub follow_depth: Option<u32>,
 
-    #[schemars(
-        description = "Maximum directory traversal depth. Unset means unlimited. Use 2-3 for large monorepos."
-    )]
+    /// Maximum directory traversal depth. Unset means unlimited. Use 2-3 for large monorepos.
     pub max_depth: Option<u32>,
 
-    #[schemars(
-        description = "Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code."
-    )]
+    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code.
     pub ast_recursion_limit: Option<usize>,
 
-    #[schemars(
-        description = "Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses."
-    )]
-    pub force: Option<bool>,
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
 
-    #[schemars(
-        description = "true = compact summary; false = full output; unset = auto-summarize when output exceeds 50K chars."
-    )]
-    pub summary: Option<bool>,
-
-    #[schemars(
-        description = "Pagination cursor from a previous response's next_cursor field. Pass unchanged to retrieve the next page. Omit on the first call."
-    )]
-    pub cursor: Option<String>,
-
-    #[schemars(
-        description = "Items per page for pagination (default: 100). Callers and callees are paginated separately. Reduce below 100 to limit response size; increase above 100 to reduce round trips."
-    )]
-    pub page_size: Option<usize>,
+    #[serde(flatten)]
+    pub output_control: OutputControlParams,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -133,7 +97,7 @@ pub struct FileInfo {
     pub line_count: usize,
     pub function_count: usize,
     pub class_count: usize,
-    #[schemars(description = "Whether this file is a test file")]
+    /// Whether this file is a test file
     pub is_test: bool,
 }
 
@@ -202,31 +166,31 @@ pub struct CallInfo {
     pub line: usize,
     pub column: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(description = "Number of arguments passed at the call site")]
+    /// Number of arguments passed at the call site
     pub arg_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AssignmentInfo {
-    #[schemars(description = "Variable name being assigned")]
+    /// Variable name being assigned
     pub variable: String,
-    #[schemars(description = "Value expression being assigned")]
+    /// Value expression being assigned
     pub value: String,
-    #[schemars(description = "Line number where assignment occurs")]
+    /// Line number where assignment occurs
     pub line: usize,
-    #[schemars(description = "Enclosing function scope or 'global'")]
+    /// Enclosing function scope or 'global'
     pub scope: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FieldAccessInfo {
-    #[schemars(description = "Object expression being accessed")]
+    /// Object expression being accessed
     pub object: String,
-    #[schemars(description = "Field name being accessed")]
+    /// Field name being accessed
     pub field: String,
-    #[schemars(description = "Line number where field access occurs")]
+    /// Line number where field access occurs
     pub line: usize,
-    #[schemars(description = "Enclosing function scope or 'global'")]
+    /// Enclosing function scope or 'global'
     pub scope: String,
 }
 
@@ -288,39 +252,33 @@ pub struct ElementQueryResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ImportInfo {
-    #[schemars(
-        description = "Full module path excluding the imported symbol (e.g., 'std::collections' for 'use std::collections::HashMap')"
-    )]
+    /// Full module path excluding the imported symbol (e.g., 'std::collections' for 'use std::collections::HashMap')
     pub module: String,
-    #[schemars(
-        description = "Imported symbols (e.g., ['HashMap'] for 'use std::collections::HashMap')"
-    )]
+    /// Imported symbols (e.g., ['HashMap'] for 'use std::collections::HashMap')
     pub items: Vec<String>,
-    #[schemars(description = "Line number where import appears")]
+    /// Line number where import appears
     pub line: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SemanticAnalysis {
-    #[schemars(description = "Functions with parameters and return types")]
+    /// Functions with parameters and return types
     pub functions: Vec<FunctionInfo>,
-    #[schemars(description = "Classes/structs")]
+    /// Classes/structs
     pub classes: Vec<ClassInfo>,
-    #[schemars(
-        description = "Flat list of imports; each entry carries its full module path and imported symbols"
-    )]
+    /// Flat list of imports; each entry carries its full module path and imported symbols
     pub imports: Vec<ImportInfo>,
-    #[schemars(description = "Type references with location information")]
+    /// Type references with location information
     pub references: Vec<ReferenceInfo>,
-    #[schemars(description = "Call frequency map (function name -> count)")]
+    /// Call frequency map (function name -> count)
     pub call_frequency: HashMap<String, usize>,
-    #[schemars(description = "Caller-callee pairs extracted from call expressions")]
+    /// Caller-callee pairs extracted from call expressions
     pub calls: Vec<CallInfo>,
+    /// Variable assignments and reassignments
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[schemars(description = "Variable assignments and reassignments")]
     pub assignments: Vec<AssignmentInfo>,
+    /// Field access patterns
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[schemars(description = "Field access patterns")]
     pub field_accesses: Vec<FieldAccessInfo>,
 }
 
@@ -375,5 +333,85 @@ mod tests {
 
         let sig = func.compact_signature();
         assert_eq!(sig, "main() :1-5");
+    }
+
+    #[test]
+    fn schema_flatten_inline() {
+        use schemars::schema_for;
+
+        // Test AnalyzeDirectoryParams: cursor, page_size, force, summary must be top-level
+        let dir_schema = schema_for!(AnalyzeDirectoryParams);
+        let dir_props = dir_schema
+            .as_object()
+            .and_then(|o| o.get("properties"))
+            .and_then(|v| v.as_object())
+            .expect("AnalyzeDirectoryParams must have properties");
+
+        assert!(
+            dir_props.contains_key("cursor"),
+            "cursor must be top-level in AnalyzeDirectoryParams schema"
+        );
+        assert!(
+            dir_props.contains_key("page_size"),
+            "page_size must be top-level in AnalyzeDirectoryParams schema"
+        );
+        assert!(
+            dir_props.contains_key("force"),
+            "force must be top-level in AnalyzeDirectoryParams schema"
+        );
+        assert!(
+            dir_props.contains_key("summary"),
+            "summary must be top-level in AnalyzeDirectoryParams schema"
+        );
+
+        // Test AnalyzeFileParams
+        let file_schema = schema_for!(AnalyzeFileParams);
+        let file_props = file_schema
+            .as_object()
+            .and_then(|o| o.get("properties"))
+            .and_then(|v| v.as_object())
+            .expect("AnalyzeFileParams must have properties");
+
+        assert!(
+            file_props.contains_key("cursor"),
+            "cursor must be top-level in AnalyzeFileParams schema"
+        );
+        assert!(
+            file_props.contains_key("page_size"),
+            "page_size must be top-level in AnalyzeFileParams schema"
+        );
+        assert!(
+            file_props.contains_key("force"),
+            "force must be top-level in AnalyzeFileParams schema"
+        );
+        assert!(
+            file_props.contains_key("summary"),
+            "summary must be top-level in AnalyzeFileParams schema"
+        );
+
+        // Test AnalyzeSymbolParams
+        let symbol_schema = schema_for!(AnalyzeSymbolParams);
+        let symbol_props = symbol_schema
+            .as_object()
+            .and_then(|o| o.get("properties"))
+            .and_then(|v| v.as_object())
+            .expect("AnalyzeSymbolParams must have properties");
+
+        assert!(
+            symbol_props.contains_key("cursor"),
+            "cursor must be top-level in AnalyzeSymbolParams schema"
+        );
+        assert!(
+            symbol_props.contains_key("page_size"),
+            "page_size must be top-level in AnalyzeSymbolParams schema"
+        );
+        assert!(
+            symbol_props.contains_key("force"),
+            "force must be top-level in AnalyzeSymbolParams schema"
+        );
+        assert!(
+            symbol_props.contains_key("summary"),
+            "summary must be top-level in AnalyzeSymbolParams schema"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #224.

Extract `PaginationParams` (`cursor`, `page_size`) and `OutputControlParams` (`force`, `summary`) to eliminate 12 duplicated field definitions across `AnalyzeDirectoryParams`, `AnalyzeFileParams`, and `AnalyzeSymbolParams`.

## Changes

- `src/types.rs`: add `PaginationParams` and `OutputControlParams` structs; replace duplicated fields with `#[serde(flatten)]`; replace all `#[schemars(description = ...)]` with `///` doc comments
- `src/lib.rs`: update field access paths to use nested struct paths (`params.pagination.cursor`, `params.output_control.force`, etc.) -- required because Rust field access does not alias through `serde(flatten)`; flatten only affects serialization/schema output
- `src/types.rs` (tests): add `schema_flatten_inline` test verifying `cursor`, `page_size`, `force`, `summary` appear as top-level properties in the generated JSON Schema for all three param structs

## MCP client compatibility

`#[serde(flatten)]` causes schemars to inline the shared fields at the top level of the generated JSON Schema -- MCP clients see `cursor`, `page_size`, `force`, and `summary` as direct tool parameters, identical to before. The `schema_flatten_inline` test asserts this explicitly.

## Testing

- 145 tests pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean