### PR TITLE
docs: add language tags to fenced code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Walks a directory tree, counts lines of code, functions, and classes per file. R
 
 **Example output:**
 
-```
+```text
 src/                                [328 LOC | F:28 C:5]
   main.rs                           [18 LOC | F:1 C:0]
   lib.rs                            [156 LOC | F:12 C:3]
@@ -118,7 +118,7 @@ Extracts functions, classes, imports, and type references from a single file.
 
 **Example output:**
 
-```
+```text
 FILE: src/lib.rs [156 LOC | F:12 C:3]
 
 CLASSES:
@@ -165,7 +165,7 @@ Builds a call graph for a named symbol across all files in a directory. Uses sen
 
 **Example output:**
 
-```
+```text
 FOCUS: analyze
 DEPTH: 2
 FILES: 12 analyzed
@@ -199,7 +199,7 @@ For large codebases, two mechanisms prevent context overflow:
 
 `analyze_file` and `analyze_symbol` append a `NEXT_CURSOR:` line when output is truncated. Pass the token back as `cursor` to fetch the next page.
 
-```
+```text
 # Response ends with:
 NEXT_CURSOR: eyJvZmZzZXQiOjUwfQ==
 


### PR DESCRIPTION
## Summary

All plain fenced code blocks (no language identifier) have been tagged as `text`.

## Why

- Plain fences violate [markdownlint MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md)
- GitHub uses Linguist to select syntax highlighting; a missing identifier means the highlighter falls back to heuristics. `text` is an explicit no-highlight signal, listed as a supported language in [linguist's languages.yml](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
- `bash` blocks were already correctly tagged; no changes to those

## What changed

Four blocks updated from ```` to ```text```:
- `analyze_directory` example output
- `analyze_file` example output
- `analyze_symbol` example output
- Pagination cursor example

## Testing

Rendered locally; verified tags appear in the linguist languages.yml file.