### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-analyze-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Hugues Clouatre"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps version from 0.1.1 to 0.1.2 in preparation for the 0.1.2 release.

After merging, tag `v0.1.2` on main to trigger the release workflow.