### PR TITLE
feat(mcp): add aptu to .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 
 # Project-Specific
 .handoff/
+
+# Override global .gitignore to track MCP config
+!.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,33 @@
+{
+  "mcpServers": {
+    "code-analyze": {
+      "type": "stdio",
+      "command": "code-analyze-mcp",
+      "args": []
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    },
+    "brave_search": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "env": {
+        "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+      }
+    },
+    "aptu": {
+      "type": "stdio",
+      "command": "aptu-mcp",
+      "args": ["--read-only"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "GROQ_API_KEY": "${GROQ_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `aptu` MCP server to `.mcp.json` (read-only, matches global `mcp-servers.json` config)
- Add `!.mcp.json` exception to `.gitignore` to allow tracking (global `~/.gitignore` ignores `.mcp.json` by default)

## Test plan

- [ ] Restart Claude Code in this repo and verify `aptu` is available