### PR TITLE
docs: improve MCP client setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,16 @@ The binary is at `target/release/code-analyze-mcp`.
 
 ### Configure MCP Client
 
-After installation, register with the Claude Code CLI:
+After installation via brew or cargo, register with the Claude Code CLI:
 
 ```bash
 claude mcp add --transport stdio code-analyze -- code-analyze-mcp
+```
+
+If you built from source, use the binary path directly:
+
+```bash
+claude mcp add --transport stdio code-analyze -- /path/to/repo/target/release/code-analyze-mcp
 ```
 
 stdio is intentional: this server runs locally and processes files directly on disk. The low-latency, zero-network-overhead transport matches the use case. Streamable HTTP adds a network hop with no benefit for a local tool.


### PR DESCRIPTION
## Summary

- Replaces hardcoded `/path/to/code-analyze-mcp` with the binary name, resolved from PATH after installation
- Uses the correct `--transport stdio -- <command>` syntax per Claude Code docs
- Leads with the `claude mcp add` CLI command; keeps `.mcp.json` as the manual fallback
- Adds a brief explanation for why stdio is used over streamable HTTP (local tool, zero network overhead)

## Test plan

- [ ] Verify `claude mcp add --transport stdio code-analyze -- code-analyze-mcp` registers the server correctly after a brew/cargo install
- [ ] Confirm `.mcp.json` snippet works as a manual alternative