### PR TITLE
docs(resources): add MCP resources design to ARCHITECTURE.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,12 @@ Note: `act` can also run Linux jobs locally, but `aarch64-apple-darwin` builds a
 
 We follow [SemVer](https://semver.org/): MAJOR (breaking), MINOR (features), PATCH (fixes).
 
+## Planned enhancements
+
+### MCP resources
+
+Resource endpoints (`list_resources`, `read_resource`) are designed but not yet implemented. See the [MCP Resources design in ARCHITECTURE.md](docs/ARCHITECTURE.md#mcp-resources-planned) for the URI scheme, content catalogue, and implementation path before starting work on this feature.
+
 ## AI Agent Contributions
 
 This section covers workflows for using **GitHub Copilot coding agent** to implement issues.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,3 +83,46 @@ Adding a language requires: a tree-sitter grammar crate, a language module with 
 ## Call Graph Design
 
 BFS from the target symbol outward, tracking callers and callees at each depth level. Visited symbols are memoized to avoid cycles. Call frequency is counted across the walk; symbols exceeding the threshold are annotated in output. Sentinel values (`<module>`, `<reference>`) represent call sites that have no enclosing function or are type-level references rather than call expressions.
+
+## MCP Resources (Planned)
+
+### Current state
+
+`CodeAnalyzer` implements `ServerHandler` but does not override `list_resources()` or `read_resource()`. The default implementations return empty results and `method_not_found` respectively. No resource endpoints exist.
+
+### Value proposition
+
+With resources, agents can discover tool capabilities without making exploratory tool calls:
+
+- Which languages and file extensions are supported?
+- What are example queries for each analysis mode?
+- What are the performance characteristics for different codebase sizes?
+
+Without resources, agents must read documentation out-of-band or infer capabilities through trial and error.
+
+### Resource URI scheme
+
+| URI | Content | Format |
+|-----|---------|--------|
+| `catalog/languages` | Supported languages and file extensions | JSON |
+| `catalog/modes` | Tool names, descriptions, when to use each | JSON |
+| `patterns/overview/examples` | Example queries for `analyze_directory` | JSON |
+| `patterns/file-details/examples` | Example queries for `analyze_file` | JSON |
+| `patterns/symbol-focus/examples` | Example queries for `analyze_symbol` | JSON |
+| `performance/characteristics` | Token and latency estimates by codebase size | JSON |
+
+### Implementation path
+
+Override two methods on `CodeAnalyzer`'s `ServerHandler` impl in `src/lib.rs`:
+
+- `list_resources()` -- enumerate the URIs above with name and MIME type
+- `read_resource()` -- route by URI and return static JSON content
+
+Resource data (language registry, example queries) should be defined as static constants close to the relevant logic (language registry in `src/lang.rs`, mode examples adjacent to tool definitions).
+
+### Notes
+
+- This is a planned design, not a committed API contract. URI scheme and content may evolve before Phase 2 implementation.
+- MCP resource subscription (`resources/subscribe`) is out of scope; all resources are static.
+- Client adoption of MCP resources is still emerging. Validate real-world agent behavior before prioritising above other enhancements.
+- Phase 2 implementation is tracked in a separate issue.


### PR DESCRIPTION
## Summary

Document the planned MCP resources design (Phase 1 of issue #244).

## Changes

- **docs/ARCHITECTURE.md**: New "MCP Resources (Planned)" section covering current state, value proposition, resource URI scheme, implementation path, and deferral notes
- **CONTRIBUTING.md**: New "Planned enhancements" section with a brief entry linking to the ARCHITECTURE.md design

## Resource URI scheme documented

| URI | Content |
|-----|---------|
| `catalog/languages` | Supported languages and file extensions |
| `catalog/modes` | Tool names, descriptions, when to use each |
| `patterns/overview/examples` | Example queries for `analyze_directory` |
| `patterns/file-details/examples` | Example queries for `analyze_file` |
| `patterns/symbol-focus/examples` | Example queries for `analyze_symbol` |
| `performance/characteristics` | Token and latency estimates by codebase size |

## Testing

Documentation only -- no code changes, no tests required.

Closes #244