### PR TITLE
docs: add reference to mcp-agents-orchestration doc in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,9 @@
 # Architecture
 
+## See Also
+
+- [anthropic-mcp-agents-orchestration.md](anthropic-mcp-agents-orchestration.md) - MCP tool design principles and annotation semantics that informed this server's interface design
+
 ## Design Goals
 
 - **Minimize token usage**: Return only structured, relevant context - no prose, no noise


### PR DESCRIPTION
Adds a See Also section at the top of ARCHITECTURE.md linking to the `anthropic-mcp-agents-orchestration.md` reference doc, noting that it informed this server's interface design.