### PR TITLE
docs(resources): fix spelling (catalogue -> catalog, prioritising -> prioritizing)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ We follow [SemVer](https://semver.org/): MAJOR (breaking), MINOR (features), PAT
 
 ### MCP resources
 
-Resource endpoints (`list_resources`, `read_resource`) are designed but not yet implemented. See the [MCP Resources design in ARCHITECTURE.md](docs/ARCHITECTURE.md#mcp-resources-planned) for the URI scheme, content catalogue, and implementation path before starting work on this feature.
+Resource endpoints (`list_resources`, `read_resource`) are designed but not yet implemented. See the [MCP Resources design in ARCHITECTURE.md](docs/ARCHITECTURE.md#mcp-resources-planned) for the URI scheme, content catalog, and implementation path before starting work on this feature.
 
 ## AI Agent Contributions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,5 +128,5 @@ Resource data (language registry, example queries) should be defined as static c
 
 - This is a planned design, not a committed API contract. URI scheme and content may evolve before Phase 2 implementation.
 - MCP resource subscription (`resources/subscribe`) is out of scope; all resources are static.
-- Client adoption of MCP resources is still emerging. Validate real-world agent behavior before prioritising above other enhancements.
+- Client adoption of MCP resources is still emerging. Validate real-world agent behavior before prioritizing above other enhancements.
 - Phase 2 implementation is tracked in a separate issue.


### PR DESCRIPTION
Fix two spelling errors introduced in #255:

- `catalogue` -> `catalog` (CONTRIBUTING.md)
- `prioritising` -> `prioritizing` (docs/ARCHITECTURE.md)