### PR TITLE
docs(benchmarks,config): disable prompt caching for Haiku in non-interactive pipelines

### DIFF
--- a/docs/benchmarks/ISOLATION.md
+++ b/docs/benchmarks/ISOLATION.md
@@ -131,7 +131,7 @@ All benchmark runs must set the following environment variables to ensure symmet
 export DISABLE_PROMPT_CACHING=1
 ```
 
-**Rationale:** Bedrock and Claude Code both enable prompt caching by default. In single-session benchmark runs, the cache is written once and never read — a net +25% token cost overhead with no corresponding benefit. Disabling caching ensures cost measurements reflect tool efficiency, not cache overhead.
+**Rationale:** Bedrock and Claude Code both enable prompt caching by default. In benchmark runs, caches are not reused across independent runs — cache_write overhead accumulates with limited cross-run cache_read benefit. Disabling caching ensures cost measurements reflect tool efficiency, not cache overhead.
 
 All conditions must have `DISABLE_PROMPT_CACHING=1` set to avoid confounding the analysis with platform-specific caching behavior.
 

--- a/docs/benchmarks/v8/README.md
+++ b/docs/benchmarks/v8/README.md
@@ -80,7 +80,7 @@ Mann-Whitney U=20.0, z=1.57, r=-0.60 (medium-large effect favouring A). N=5 per 
 
 B costs 63% more per quality point. Median total tokens: A=1.41M, B=1.63M (+16%). The cost premium comes from MCP responses writing more to the prompt cache (median cache_write: A=49K tokens, B=98K tokens), inflating cache_read costs on every subsequent turn.
 
-**Caching Confound:** v8 did not disable prompt caching (both conditions ran with Bedrock default-on caching). In single-session benchmarks, the cache is never reused; every turn pays the cache_write tax with zero cache_read benefit. This inflates the cost premium for Condition B. See v9 benchmark (#268) which repeats v8 with `DISABLE_PROMPT_CACHING=1` to isolate the MCP efficiency signal from the platform-specific caching overhead.
+**Caching Confound:** v8 did not disable prompt caching (both conditions ran with Bedrock default-on caching). Caches are not reused across independent benchmark runs; cache_write overhead accumulates with limited within-run reuse benefit, disproportionately inflating the cost premium for Condition B which writes ~2x more to the cache. See v9 benchmark (#268) which repeats v8 with `DISABLE_PROMPT_CACHING=1` to isolate the MCP efficiency signal from the platform-specific caching overhead.
 
 ### Hypotheses
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -861,7 +861,7 @@ impl ServerHandler for CodeAnalyzer {
             .with_description("MCP server for code structure analysis using tree-sitter");
         InitializeResult::new(capabilities)
             .with_server_info(server_info)
-            .with_instructions("Use analyze_directory to map a codebase (pass a directory). Use analyze_file to extract functions, classes, and imports from a specific file (pass a file path). Use analyze_symbol to trace call graphs for a named function or class (pass a directory and set symbol to the function name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes next_cursor, pass it back as cursor to retrieve the next page. For non-interactive single-session workflows (e.g. subagents), disable prompt caching to avoid redundant cache writes: DISABLE_PROMPT_CACHING=1.")
+            .with_instructions("Use analyze_directory to map a codebase (pass a directory). Use analyze_file to extract functions, classes, and imports from a specific file (pass a file path). Use analyze_symbol to trace call graphs for a named function or class (pass a directory and set symbol to the function name, case-sensitive). Prefer summary=true on large directories to reduce output size. When the response includes a NEXT_CURSOR: line, pass that value back as cursor to retrieve the next page. For non-interactive single-session workflows (e.g. subagents), disable prompt caching to avoid redundant cache writes: DISABLE_PROMPT_CACHING=1.")
     }
 
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {


### PR DESCRIPTION
## Summary

Implement documentation and configuration for disabling prompt caching in non-interactive multi-agent pipelines and benchmarks. Addresses #263.

Bedrock and Claude Code both enable prompt caching by default. In benchmark runs, caches are not reused across independent runs — cache_write overhead accumulates with limited cross-run benefit. In subagent pipelines (single-session, spawned via the `Agent` tool), the same overhead applies with no reuse.

## Changes

- **serverInstructions advisory** — MCP server initialization now includes caching guidance for non-interactive clients; updated cursor instruction to reference `NEXT_CURSOR:` text marker
- **CLAUDE.md** (Claude Code-specific config) — Document `DISABLE_PROMPT_CACHING=1` for non-interactive subagent pipelines under Subagent Orchestration
- **docs/benchmarks/ISOLATION.md** — Require `DISABLE_PROMPT_CACHING=1` as mandatory benchmark environment variable
- **docs/benchmarks/v8/README.md** — Add caching confound note explaining the 63% cost premium; reference v9 benchmark (#268) which reruns v8 with caching disabled

## Acceptance Criteria

- [x] `DISABLE_PROMPT_CACHING=1` documented in `CLAUDE.md` with rationale
- [x] `serverInstructions` added to MCP server with caching advisory
- [x] `docs/benchmarks/ISOLATION.md` updated with benchmark environment variables section
- [x] `docs/benchmarks/v8/README.md` updated with caching confound note
- [x] Commit GPG signed and DCO signed-off
- [x] Build passes

## Test Plan

- [x] `cargo build` — verify serverInstructions change parses correctly
- [x] All markdown files are syntactically valid

Note: `_meta` caching hint in tool results (for server-side advisory) tracked separately in #269.