### PR TITLE
ci: skip workflows on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'clippy.toml'
-      - '.github/workflows/**'
-      - 'tests/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from `mcp-scan.yml`, which was accidentally re-added in #278. The intent from #277 was to run mcp-scan only on pushes to main and release tags, not on every PR -- the scan is expensive (builds the binary + LLM call) and only needs to gate merged code.

No changes to `ci.yml`. The existing `changes` job (dorny/paths-filter) already handles docs-only PRs correctly: expensive jobs (`format`, `lint`, `test`, `deny`) are guarded by `needs.changes.outputs.code == 'true'` and skip when no code files changed. `CI Result` runs via `if: always()` and passes on skipped jobs, so required checks are never blocked.

## Effect

| Workflow | Docs-only PR (before) | Docs-only PR (after) |
|---|---|---|
| CI | triggers; skips expensive jobs | unchanged |
| mcp-scan | triggers; full build + LLM scan | does not trigger |