### PR TITLE
docs(tools): improve analyze_module tool description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self))]
     #[tool(
         name = "analyze_module",
-        description = "Extract minimal fixed schema from a single source file for lightweight code understanding. Returns name, line count, function list (name/line only), import list (module/items), and language. No call graphs, no field accesses, no complex types. Use analyze_file for detailed semantic analysis; use analyze_module when token budget is critical.",
+        description = "Index functions and imports in a single source file with minimal token cost. Returns name, line_count, language, function names with line numbers, and import list only -- no signatures, no types, no call graphs, no references. ~75% smaller output than analyze_file. Use analyze_file when you need function signatures, types, or class details; use analyze_module when you only need a function/import index to orient in a file or survey many files in sequence. Use analyze_directory for multi-file overviews; use analyze_symbol to trace call graphs for a specific function. Supported languages: Rust, Go, Java, Python, TypeScript, TSX; unsupported extensions return an error. Example queries: What functions are defined in src/analyze.rs?; List all imports in src/lib.rs",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",


### PR DESCRIPTION
## Summary

- Rewrites the `analyze_module` tool description to align with the MCP tool design principles in `docs/anthropic-mcp-agents-orchestration.md` (sections 3.2 and 4.2)
- Intent-first framing: opens with what the tool returns and when to use it, not implementation detail
- Explicit neighbour differentiation: names `analyze_file`, `analyze_directory`, and `analyze_symbol` with concrete decision rules for each so the model can route unambiguously
- Quantifies the size trade-off (~75% smaller than `analyze_file`) instead of the vague "token budget is critical"
- Lists supported languages and error behaviour, matching `analyze_file` style
- Adds example queries, matching the pattern used by all other tools

## Test plan

- [ ] No code change; description is a string literal in a `#[tool(...)]` attribute
- [ ] `cargo clippy -- -D warnings` clean