### PR TITLE
chore: exclude docs, benches, tests from crate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/clouatre-labs/code-analyze-mcp"
 homepage = "https://github.com/clouatre-labs/code-analyze-mcp"
 keywords = ["mcp", "code-analysis", "tree-sitter", "lsp"]
 categories = ["development-tools", "command-line-utilities"]
+exclude = ["docs/", "benches/", ".github/", "tests/"]
 
 [dependencies]
 rmcp = { version = "1", features = ["server", "macros", "transport-io"] }


### PR DESCRIPTION
## Summary

- Adds `exclude` field to `Cargo.toml` to prevent `docs/`, `benches/`, `.github/`, and `tests/` from being included in the published crate
- Crate size on crates.io grew from ~317kb (v0.1.2) to ~922kb (v0.1.3) due to v9 benchmark artifacts in `docs/benchmarks/v9` (4.9MB uncompressed) being packed into the package

## Test plan

- [ ] `cargo package --list` shows only `src/`, config files, README, LICENSE — no `docs/` or `benches/` entries