### PR TITLE
refactor(analyze_module): replace JSON text with compact formatter, fix silent failures

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1243,7 +1243,7 @@ fn format_file_entry(file: &FileInfo, base_path: Option<&Path>) -> String {
 /// F:
 ///   func1:10, func2:42
 /// I:
-///   module1:item1, item2 | module2:item1
+///   module1:item1, item2; module2:item1; module3
 /// ```
 ///
 /// The `F:` section is omitted when there are no functions; likewise `I:` when
@@ -1274,9 +1274,15 @@ pub fn format_module_info(info: &ModuleInfo) -> String {
         let parts: Vec<String> = info
             .imports
             .iter()
-            .map(|i| format!("{}:{}", i.module, i.items.join(", ")))
+            .map(|i| {
+                if i.items.is_empty() {
+                    i.module.clone()
+                } else {
+                    format!("{}:{}", i.module, i.items.join(", "))
+                }
+            })
             .collect();
-        out.push_str(&parts.join(" | "));
+        out.push_str(&parts.join("; "));
         out.push('\n');
     }
     out
@@ -1627,6 +1633,7 @@ mod tests {
         assert!(result.contains("I:"));
         assert!(result.contains("crate::types:Token, Expr"));
         assert!(result.contains("std::io:BufReader"));
+        assert!(result.contains("; "));
         assert!(!result.contains('{'));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self))]
     #[tool(
         name = "analyze_module",
-        description = "Index functions and imports in a single source file with minimal token cost. Returns name, line_count, language, function names with line numbers, and import list only -- no signatures, no types, no call graphs, no references. ~75% smaller output than analyze_file. Use analyze_file when you need function signatures, types, or class details; use analyze_module when you only need a function/import index to orient in a file or survey many files in sequence. Use analyze_directory for multi-file overviews; use analyze_symbol to trace call graphs for a specific function. Supported languages: Rust, Go, Java, Python, TypeScript, TSX; unsupported extensions return an error. Example queries: What functions are defined in src/analyze.rs?; List all imports in src/lib.rs Pagination, summary, force, and verbose parameters are not supported by this tool.",
+        description = "Index functions and imports in a single source file with minimal token cost. Returns name, line_count, language, function names with line numbers, and import list only -- no signatures, no types, no call graphs, no references. ~75% smaller output than analyze_file. Use analyze_file when you need function signatures, types, or class details; use analyze_module when you only need a function/import index to orient in a file or survey many files in sequence. Use analyze_directory for multi-file overviews; use analyze_symbol to trace call graphs for a specific function. Supported languages: Rust, Go, Java, Python, TypeScript, TSX; unsupported extensions return an error. Example queries: What functions are defined in src/analyze.rs?; List all imports in src/lib.rs. Pagination, summary, force, and verbose parameters are not supported by this tool.",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",
@@ -912,7 +912,7 @@ impl CodeAnalyzer {
             ErrorData::new(
                 rmcp::model::ErrorCode::INTERNAL_ERROR,
                 format!("serialization failed: {}", e),
-                error_meta("transient", false, "report this as a bug"),
+                error_meta("internal", false, "report this as a bug"),
             )
         })?;
         result.structured_content = Some(structured);


### PR DESCRIPTION
## Summary

`analyze_module` was the only tool whose `Content::text` returned pretty-printed JSON instead of a compact human-readable format. This inflated output by ~71% and contradicted the tool's stated token-budget goal. Two silent serde failure paths also existed. This PR aligns `analyze_module` with the other three tools.

## Changes

- **`src/formatter.rs`**: Added `format_module_info(info: &ModuleInfo) -> String` following the existing `FILE:/F:/I:` convention from `format_file_details`. Added two unit tests (`test_format_module_info_happy_path`, `test_format_module_info_empty`). Extended `use crate::types` import to include `ModuleInfo`, `ModuleFunctionInfo`, `ModuleImportInfo`.
- **`src/lib.rs`**: Added `format_module_info` to formatter imports. Replaced `serde_json::to_string_pretty(...).unwrap_or_default()` with `format_module_info(&module_info)`. Replaced `serde_json::to_value(...).unwrap_or(Value::Null)` with `.map_err(|e| ErrorData::new(INTERNAL_ERROR, ...))?`. Appended parameter limitation note to tool description.

## Test plan

- [x] 167 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)
- [x] No `unwrap()`, `expect()`, `println!`, or silent `unwrap_or_default()` in changed code
- [x] `structured_content` output unchanged (same `ModuleInfo` JSON shape)
- [x] `ModuleInfo` struct fields and schema unchanged

Closes #306
