### PR TITLE
fix(server): return CallToolResult error instead of JSON-RPC protocol error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,10 @@ fn error_meta(
     }))
 }
 
+fn err_to_tool_result(e: ErrorData) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(e.message)])
+}
+
 fn no_cache_meta() -> Meta {
     let mut m = serde_json::Map::new();
     m.insert(
@@ -547,7 +551,10 @@ impl CodeAnalyzer {
         let ct = context.ct.clone();
 
         // Call handler for analysis and progress tracking
-        let mut output = self.handle_overview_mode(&params, ct).await?;
+        let mut output = match self.handle_overview_mode(&params, ct).await {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
 
         // summary=true (explicit) and cursor are mutually exclusive.
         // Auto-summarization (summary=None + large output) must NOT block cursor pagination.
@@ -555,12 +562,12 @@ impl CodeAnalyzer {
             params.output_control.summary,
             params.pagination.cursor.as_deref(),
         ) {
-            return Err(ErrorData::new(
+            return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 "summary=true is incompatible with a pagination cursor; use one or the other"
                     .to_string(),
                 error_meta("validation", false, "remove cursor or set summary=false"),
-            ));
+            )));
         }
 
         // Apply summary/output size limiting logic
@@ -586,27 +593,33 @@ impl CodeAnalyzer {
         // Decode pagination cursor if provided
         let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
         let offset = if let Some(ref cursor_str) = params.pagination.cursor {
-            let cursor_data = decode_cursor(cursor_str).map_err(|e| {
+            let cursor_data = match decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     e.to_string(),
                     error_meta("validation", false, "invalid cursor format"),
                 )
-            })?;
+            }) {
+                Ok(v) => v,
+                Err(e) => return Ok(err_to_tool_result(e)),
+            };
             cursor_data.offset
         } else {
             0
         };
 
         // Apply pagination to files
-        let paginated = paginate_slice(&output.files, offset, page_size, PaginationMode::Default)
-            .map_err(|e| {
-            ErrorData::new(
-                rmcp::model::ErrorCode::INTERNAL_ERROR,
-                e.to_string(),
-                error_meta("transient", true, "retry the request"),
-            )
-        })?;
+        let paginated =
+            match paginate_slice(&output.files, offset, page_size, PaginationMode::Default) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Ok(err_to_tool_result(ErrorData::new(
+                        rmcp::model::ErrorCode::INTERNAL_ERROR,
+                        e.to_string(),
+                        error_meta("transient", true, "retry the request"),
+                    )));
+                }
+            };
 
         let verbose = params.output_control.verbose.unwrap_or(false);
         if !use_summary && (paginated.next_cursor.is_some() || offset > 0 || !verbose) {
@@ -662,7 +675,10 @@ impl CodeAnalyzer {
         let _ct = context.ct.clone();
 
         // Call handler for analysis and caching
-        let arc_output = self.handle_file_details_mode(&params).await?;
+        let arc_output = match self.handle_file_details_mode(&params).await {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
 
         // Clone only the two fields that may be mutated per-request (formatted and
         // next_cursor). The heavy SemanticAnalysis data is shared via Arc and never
@@ -694,42 +710,47 @@ impl CodeAnalyzer {
                 formatted.len(),
                 estimated_tokens
             );
-            return Err(ErrorData::new(
+            return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 message,
                 error_meta("validation", false, "use force=true or narrow scope"),
-            ));
+            )));
         }
 
         // Decode pagination cursor if provided (analyze_file)
         let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
         let offset = if let Some(ref cursor_str) = params.pagination.cursor {
-            let cursor_data = decode_cursor(cursor_str).map_err(|e| {
+            let cursor_data = match decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     e.to_string(),
                     error_meta("validation", false, "invalid cursor format"),
                 )
-            })?;
+            }) {
+                Ok(v) => v,
+                Err(e) => return Ok(err_to_tool_result(e)),
+            };
             cursor_data.offset
         } else {
             0
         };
 
         // Paginate functions
-        let paginated = paginate_slice(
+        let paginated = match paginate_slice(
             &arc_output.semantic.functions,
             offset,
             page_size,
             PaginationMode::Default,
-        )
-        .map_err(|e| {
-            ErrorData::new(
-                rmcp::model::ErrorCode::INTERNAL_ERROR,
-                e.to_string(),
-                error_meta("transient", true, "retry the request"),
-            )
-        })?;
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    error_meta("transient", true, "retry the request"),
+                )));
+            }
+        };
 
         // Regenerate formatted output from the paginated slice when pagination is active
         let verbose = params.output_control.verbose.unwrap_or(false);
@@ -796,18 +817,24 @@ impl CodeAnalyzer {
         let ct = context.ct.clone();
 
         // Call handler for analysis and progress tracking
-        let mut output = self.handle_focused_mode(&params, ct).await?;
+        let mut output = match self.handle_focused_mode(&params, ct).await {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
 
         // Decode pagination cursor if provided (analyze_symbol)
         let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
         let offset = if let Some(ref cursor_str) = params.pagination.cursor {
-            let cursor_data = decode_cursor(cursor_str).map_err(|e| {
+            let cursor_data = match decode_cursor(cursor_str).map_err(|e| {
                 ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     e.to_string(),
                     error_meta("validation", false, "invalid cursor format"),
                 )
-            })?;
+            }) {
+                Ok(v) => v,
+                Err(e) => return Ok(err_to_tool_result(e)),
+            };
             cursor_data.offset
         } else {
             0
@@ -824,12 +851,15 @@ impl CodeAnalyzer {
 
         let paginated_next_cursor = match cursor_mode {
             PaginationMode::Callers => {
-                let (paginated_items, paginated_next) = paginate_focus_chains(
+                let (paginated_items, paginated_next) = match paginate_focus_chains(
                     &output.prod_chains,
                     PaginationMode::Callers,
                     offset,
                     page_size,
-                )?;
+                ) {
+                    Ok(v) => v,
+                    Err(e) => return Ok(err_to_tool_result(e)),
+                };
 
                 let verbose = params.output_control.verbose.unwrap_or(false);
                 if paginated_next.is_some() || offset > 0 || !verbose {
@@ -853,12 +883,15 @@ impl CodeAnalyzer {
                 }
             }
             PaginationMode::Callees => {
-                let (paginated_items, paginated_next) = paginate_focus_chains(
+                let (paginated_items, paginated_next) = match paginate_focus_chains(
                     &output.outgoing_chains,
                     PaginationMode::Callees,
                     offset,
                     page_size,
-                )?;
+                ) {
+                    Ok(v) => v,
+                    Err(e) => return Ok(err_to_tool_result(e)),
+                };
 
                 let verbose = params.output_control.verbose.unwrap_or(false);
                 if paginated_next.is_some() || offset > 0 || !verbose {
@@ -920,7 +953,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
 
-        let module_info = analyze::analyze_module_file(&params.path).map_err(|e| {
+        let module_info = match analyze::analyze_module_file(&params.path).map_err(|e| {
             ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 format!("Failed to analyze module: {}", e),
@@ -930,18 +963,24 @@ impl CodeAnalyzer {
                     "ensure file exists, is readable, and has a supported extension",
                 ),
             )
-        })?;
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
 
         let text = format_module_info(&module_info);
         let mut result =
             CallToolResult::success(vec![Content::text(text)]).with_meta(Some(no_cache_meta()));
-        let structured = serde_json::to_value(&module_info).map_err(|e| {
+        let structured = match serde_json::to_value(&module_info).map_err(|e| {
             ErrorData::new(
                 rmcp::model::ErrorCode::INTERNAL_ERROR,
                 format!("serialization failed: {}", e),
                 error_meta("internal", false, "report this as a bug"),
             )
-        })?;
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
         result.structured_content = Some(structured);
         Ok(result)
     }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -21,21 +21,21 @@ fn test_mcp_server_responds_to_tools_call() {
     let init_msg = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
     stdin
         .write_all(init_msg.as_bytes())
-        .expect("failed to write init");
+        .expect("failed to write");
     stdin.write_all(b"\n").expect("failed to write newline");
 
     // Send initialized notification
     let init_notif = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
     stdin
         .write_all(init_notif.as_bytes())
-        .expect("failed to write notification");
+        .expect("failed to write");
     stdin.write_all(b"\n").expect("failed to write newline");
 
-    // Send tools/call message
-    let tools_msg = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"analyze","arguments":{"path":"src/lib.rs"}}}"#;
+    // Send tool call
+    let tool_call = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"analyze_directory","arguments":{"path":"src","max_depth":1,"page_size":100,"summary":true}}}"#;
     stdin
-        .write_all(tools_msg.as_bytes())
-        .expect("failed to write tools call");
+        .write_all(tool_call.as_bytes())
+        .expect("failed to write");
     stdin.write_all(b"\n").expect("failed to write newline");
 
     drop(stdin); // Close stdin to signal end of input
@@ -84,5 +84,112 @@ fn test_mcp_server_responds_to_tools_call() {
     assert!(
         found_valid_response,
         "Expected at least one valid JSON-RPC 2.0 response with result field and no error field"
+    );
+}
+
+#[test]
+fn test_mcp_server_recovers_after_tool_error() {
+    let bin = std::env::var("CARGO_BIN_EXE_code_analyze_mcp")
+        .unwrap_or_else(|_| "target/debug/code-analyze-mcp".to_string());
+
+    let mut child = std::process::Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn server at {}: {}", bin, e));
+
+    let mut stdin = child.stdin.take().expect("failed to get stdin");
+
+    // Writer thread: pace messages to avoid EOF race with the server's async reader.
+    let writer = thread::spawn(move || {
+        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        stdin.write_all(init.as_bytes()).expect("write init");
+        stdin.write_all(b"\n").expect("newline");
+
+        let notif = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
+        stdin.write_all(notif.as_bytes()).expect("write notif");
+        stdin.write_all(b"\n").expect("newline");
+
+        thread::sleep(Duration::from_millis(500));
+
+        // Tool call with a nonexistent path — must return isError=true, not crash.
+        let bad = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"analyze_file","arguments":{"path":"/nonexistent/does_not_exist.py","ast_recursion_limit":null,"page_size":null}}}"#;
+        stdin.write_all(bad.as_bytes()).expect("write bad call");
+        stdin.write_all(b"\n").expect("newline");
+
+        thread::sleep(Duration::from_millis(2000));
+
+        // Follow-up call — server must still be alive.
+        let good = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"analyze_directory","arguments":{"path":"src","max_depth":1,"page_size":100,"summary":true}}}"#;
+        stdin.write_all(good.as_bytes()).expect("write good call");
+        stdin.write_all(b"\n").expect("newline");
+
+        thread::sleep(Duration::from_millis(3000));
+        // stdin dropped here, server will exit cleanly
+    });
+
+    let stdout = child.stdout.take().expect("failed to get stdout");
+    let reader = std::io::BufReader::new(stdout);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let reader_thread = thread::spawn(move || {
+        use std::io::BufRead;
+        for line in reader.lines().flatten() {
+            let _ = tx.send(line);
+        }
+    });
+
+    let timeout = Duration::from_secs(12);
+    let start = std::time::Instant::now();
+    let mut got_error_response = false;
+    let mut got_recovery_response = false;
+
+    while start.elapsed() < timeout && !(got_error_response && got_recovery_response) {
+        match rx.try_recv() {
+            Ok(line) => {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
+                    if json.get("id") == Some(&serde_json::json!(2)) {
+                        assert!(
+                            json.get("error").is_none(),
+                            "id:2 must not be a JSON-RPC protocol error: {}",
+                            line
+                        );
+                        assert!(
+                            json.get("result").is_some(),
+                            "id:2 must have result field: {}",
+                            line
+                        );
+                        let is_error = json["result"]["isError"].as_bool().unwrap_or(false);
+                        assert!(is_error, "id:2 result must have isError=true: {}", line);
+                        got_error_response = true;
+                    }
+                    if json.get("id") == Some(&serde_json::json!(3)) {
+                        assert!(
+                            json.get("result").is_some(),
+                            "id:3 must have result field (server must be alive after tool error): {}",
+                            line
+                        );
+                        got_recovery_response = true;
+                    }
+                }
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    let _ = writer.join();
+    let _ = child.wait();
+    let _ = reader_thread.join();
+
+    assert!(
+        got_error_response,
+        "Did not receive a result for id:2 (tool error call)"
+    );
+    assert!(
+        got_recovery_response,
+        "Server did not respond to id:3 after a tool error (transport closed)"
     );
 }


### PR DESCRIPTION
## Summary

Tool functions returning \`Err(ErrorData)\` caused rmcp 1.2.0 to emit a JSON-RPC \`-32603\` protocol error frame instead of a \`CallToolResult\` with \`isError=true\`. MCP clients that receive a protocol error on \`tools/call\` treat it as fatal and close the transport, making the server unresponsive to all subsequent calls.

This was the root cause of the transport crashes observed during v10 benchmark runs (conditions D and E), where a model calling \`analyze_file\` with a wrong filename caused the server to become permanently unresponsive.

## Changes

- **src/lib.rs**: Add \`err_to_tool_result(e: ErrorData) -> CallToolResult\` private helper. Convert all four tool functions (\`analyze_directory\`, \`analyze_file\`, \`analyze_symbol\`, \`analyze_module\`) to return \`Ok(err_to_tool_result(e))\` on every error path. The \`Err\` variant of \`Result<CallToolResult, ErrorData>\` is now unreachable in tool functions; helper functions (\`handle_overview_mode\`, etc.) keep their existing \`Result\` signatures unchanged.
- **tests/mcp_smoke.rs**: Add \`test_mcp_server_recovers_after_tool_error\`: sends \`analyze_file\` with a nonexistent path, asserts response has \`result.isError=true\` (not a JSON-RPC error), then sends a valid \`analyze_directory\` call and asserts the server still responds.

## Test plan

- [x] 183 tests pass (\`cargo test\`)
- [x] Linter clean (\`cargo clippy -- -D warnings\`)
- [x] Format clean (\`cargo fmt --check\`)
- [x] \`cargo deny check advisories licenses\` clean
- [x] Smoke test: \`test_mcp_server_recovers_after_tool_error\` passes, verifying error recovery end-to-end