### PR TITLE
fix(parser): treat ast_recursion_limit=0 as unlimited

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -977,6 +977,10 @@ fn process(user: &User) {
         assert!(result_zero.is_ok(), "extract with Some(0) failed");
         let analysis_none = result_none.unwrap();
         let analysis_zero = result_zero.unwrap();
+        assert!(
+            analysis_none.functions.len() >= 1,
+            "extract with None should find at least one function in the test source"
+        );
         assert_eq!(
             analysis_none.functions.len(),
             analysis_zero.functions.len(),

--- a/src/schema_helpers.rs
+++ b/src/schema_helpers.rs
@@ -28,8 +28,8 @@ pub fn option_integer_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
 
 /// Returns a nullable integer schema for Option<usize> ast_recursion_limit fields.
 /// Enforces minimum: 1 because 0 would limit tree-sitter traversal to the root
-/// node only, silently returning zero results. Values below 1 are treated as
-/// unlimited at runtime; the schema minimum signals to callers that 0 is not useful.
+/// node only, silently returning zero results. Passing 0 is treated as unlimited
+/// at runtime; the schema minimum signals to callers that 0 is not a useful value.
 pub fn option_ast_limit_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     let map = json!({
         "type": ["integer", "null"],

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,7 +48,7 @@ pub struct AnalyzeFileParams {
     /// File path to analyze
     pub path: String,
 
-    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code.
+    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code. Minimum value is 1; passing 0 is treated as unlimited (same as unset).
     #[schemars(schema_with = "crate::schema_helpers::option_ast_limit_schema")]
     pub ast_recursion_limit: Option<usize>,
 
@@ -99,7 +99,7 @@ pub struct AnalyzeSymbolParams {
     #[schemars(schema_with = "crate::schema_helpers::option_integer_schema")]
     pub max_depth: Option<u32>,
 
-    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code.
+    /// Maximum AST node depth for tree-sitter queries. Internal tuning parameter; leave unset in normal use. Increase only if query results are missing constructs in deeply nested or generated code. Minimum value is 1; passing 0 is treated as unlimited (same as unset).
     #[schemars(schema_with = "crate::schema_helpers::option_ast_limit_schema")]
     pub ast_recursion_limit: Option<usize>,
 
@@ -504,6 +504,24 @@ mod tests {
         assert!(
             symbol_props.contains_key("summary"),
             "summary must be top-level in AnalyzeSymbolParams schema"
+        );
+
+        // Verify ast_recursion_limit enforces minimum: 1 in both parameter schemas.
+        let file_ast = file_props
+            .get("ast_recursion_limit")
+            .expect("ast_recursion_limit must be present in AnalyzeFileParams schema");
+        assert_eq!(
+            file_ast.get("minimum").and_then(|v| v.as_u64()),
+            Some(1),
+            "ast_recursion_limit in AnalyzeFileParams must have minimum: 1"
+        );
+        let symbol_ast = symbol_props
+            .get("ast_recursion_limit")
+            .expect("ast_recursion_limit must be present in AnalyzeSymbolParams schema");
+        assert_eq!(
+            symbol_ast.get("minimum").and_then(|v| v.as_u64()),
+            Some(1),
+            "ast_recursion_limit in AnalyzeSymbolParams must have minimum: 1"
         );
     }
 }


### PR DESCRIPTION
## Summary

`ast_recursion_limit=0` caused `analyze_file` and `analyze_symbol` to silently return zero functions, zero classes, and zero imports. The tool call succeeded with no error, making the failure indistinguishable from a genuinely empty file.

Root cause: `Some(0)` was forwarded to `cursor.set_max_start_depth(Some(0))`, which limits tree-sitter traversal to the root node only. Agents (especially smaller models) commonly send 0 intending "no limit."

## Changes

- `src/parser.rs`: Add `.filter(|&limit| limit > 0)` before `.map()` so `Some(0)` becomes `None` (unlimited traversal)
- `src/schema_helpers.rs`: Add `option_ast_limit_schema` with `minimum: 1` (mirrors `option_page_size_schema` pattern)
- `src/types.rs`: Apply `option_ast_limit_schema` to `ast_recursion_limit` in both `AnalyzeFileParams` and `AnalyzeSymbolParams`

## Test plan

- [x] New unit test `test_ast_recursion_limit_zero_is_unlimited`: asserts `Some(0)` returns identical function count to `None` on a non-empty Rust source
- [x] All 185 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] GPG signed and DCO signed-off

Fixes #339