### PR TITLE
docs: fix MCP best practices per spec 2025-06-18

### DIFF
--- a/docs/anthropic-mcp-agents-orchestration.md
+++ b/docs/anthropic-mcp-agents-orchestration.md
@@ -233,8 +233,8 @@ MCP supports three transport mechanisms (MCP specification, basic/transports):
 | Transport | Use Case | Protocol |
 |---|---|---|
 | STDIO | Local integrations, CLI tools, same-host servers | Standard input/output streams, bidirectional |
-| HTTP/SSE (legacy, pre-2025-03-26) | Distributed systems, remote servers | Legacy transport (pre-2025-03-26). Supported for backwards compatibility. |
-| Streamable HTTP (preferred) | Bidirectional streaming over HTTP | Preferred since 2025-03-26. |
+| HTTP/SSE | Distributed systems, remote servers (legacy, pre-2025-03-26) | HTTP POST for requests, persistent SSE stream for responses |
+| Streamable HTTP | Distributed systems, remote servers (preferred since 2025-03-26) | HTTP POST to single `/mcp` endpoint; inline response (stateless) or streaming session (stateful) |
 
 *Table 2: MCP transport types, use cases, and protocols.*
 
@@ -351,7 +351,7 @@ The MCP specification extends this with an optional `outputSchema` field that do
 }
 ```
 
-**Structured output:** When a tool defines `outputSchema`, compliant tool results must include a `structuredContent` field matching that schema alongside the traditional `content` array. The `content` array remains as the human-readable fallback. FastMCP automatically populates `structuredContent` from the tool's return type annotation -- explicit `output_schema` is optional in FastMCP but required for non-FastMCP servers to be spec-compliant. Example result:
+**Structured output:** `outputSchema` is optional. If defined, tool results must include a `structuredContent` field matching that schema alongside the traditional `content` array. The `content` array remains as the human-readable fallback. Some SDKs (including FastMCP) automatically populate `structuredContent` from the return type annotation; servers not using such an SDK must populate it explicitly. Example result:
 
 ```json
 {


### PR DESCRIPTION
## Summary

Amends `docs/anthropic-mcp-agents-orchestration.md` to align with MCP spec 2025-06-18 and FastMCP 3.0. Three categories of issues found during a cross-source research pass (Anthropic orchestration doc, code-analyze-mcp codebase, FastMCP 3.0 docs, MCP spec changelog).

## Changes

- `docs/anthropic-mcp-agents-orchestration.md` -- 76 insertions, 10 deletions

### #351 -- Annotation field names (critical)

All four annotation field names corrected from snake_case to camelCase throughout (table, prose, anti-patterns section, quick reference):

| Before | After |
|--------|-------|
| `read_only_hint` | `readOnlyHint` |
| `destructive_hint` | `destructiveHint` |
| `idempotent_hint` | `idempotentHint` |
| `open_world_hint` | `openWorldHint` |

Added missing `title` annotation field to section 3.3 table.

References: [MCP 2026-03-16 tool annotations blog](https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/), [awslabs/mcp#671](https://github.com/awslabs/mcp/issues/671), [gofastmcp.com/servers/tools](https://gofastmcp.com/servers/tools)

### #352 -- Transport section + Elicitation omission (major)

- HTTP/SSE marked as legacy (deprecated since 2025-03-26); Streamable HTTP marked as preferred
- Added Streamable HTTP mechanics: POST to single `/mcp` endpoint, stateless and stateful modes, proxy-compatible
- Added section 3.5 Elicitation covering: how it works, form vs URL modes, server constraints (MUST NOT request credentials via form mode), FastMCP `ctx.elicit()` usage

References: [MCP 2025-06-18 elicitation spec](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation), [gofastmcp.com/servers/elicitation](https://gofastmcp.com/servers/elicitation)

### #353 -- outputSchema and structuredContent (major)

- Added `outputSchema` field to Code Snippet 4
- Documented `structuredContent` response field requirement: when `outputSchema` is defined, compliant results must include `structuredContent` alongside the traditional `content` array
- Noted FastMCP auto-populates `structuredContent` from return type annotations

References: [MCP 2025-06-18 tools spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools), [gofastmcp.com/servers/tools#output-schema](https://gofastmcp.com/servers/tools)

## Test plan

- [x] Zero snake_case annotation names remaining (grep confirmed)
- [x] All four camelCase names present in table, prose, anti-patterns, quick reference
- [x] Code fences balanced (22, even)
- [x] No non-ASCII characters
- [x] Heading hierarchy intact
- [x] Line count 623 (557 original + 66 net additions)