### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-analyze-mcp"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Hugues Clouatre"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump crate version from 0.1.4 to 0.1.5 in preparation for release.

## Changes

- `Cargo.toml`: version 0.1.4 -> 0.1.5
- `Cargo.lock`: regenerated

## Test plan

- [x] `cargo build` clean