### PR TITLE
perf: replace double walk with single unbounded walk + in-memory count

### DIFF
--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -101,17 +101,20 @@ fn subtree_count_overhead(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("with_count_files_by_dir", |b| {
+    group.bench_function("with_single_walk_and_count", |b| {
         b.iter(|| {
-            let entries = code_analyze_mcp::traversal::walk_directory(
+            // Single unbounded walk; compute counts in-memory; filter for bounded subset.
+            let all_entries = code_analyze_mcp::traversal::walk_directory(
                 std::hint::black_box(root),
-                std::hint::black_box(Some(2)),
+                std::hint::black_box(None),
             )
             .unwrap();
-            let counts =
-                code_analyze_mcp::traversal::count_files_by_dir(std::hint::black_box(root))
-                    .unwrap();
-            std::hint::black_box((entries, counts))
+            let counts = code_analyze_mcp::traversal::subtree_counts_from_entries(
+                std::hint::black_box(root),
+                &all_entries,
+            );
+            let bounded: Vec<_> = all_entries.into_iter().filter(|e| e.depth <= 2).collect();
+            std::hint::black_box((bounded, counts))
         })
     });
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -15,6 +15,7 @@ use crate::types::{AnalysisMode, FileInfo, ImportInfo, SemanticAnalysis, SymbolM
 use rayon::prelude::*;
 use schemars::JsonSchema;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -48,6 +49,10 @@ pub struct AnalysisOutput {
     #[serde(skip)]
     #[schemars(skip)]
     pub entries: Vec<WalkEntry>,
+    /// Subtree file counts computed from an unbounded walk; used by format_summary; not serialized.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub subtree_counts: Option<HashMap<std::path::PathBuf, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(
         description = "Opaque cursor token for the next page of results (absent when no more results)"
@@ -167,6 +172,7 @@ pub fn analyze_directory_with_progress(
         files: analysis_results,
         entries,
         next_cursor: None,
+        subtree_counts: None,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,14 +228,33 @@ impl CodeAnalyzer {
         let max_depth = params.max_depth;
         let ct_clone = ct.clone();
 
-        // Collect entries once for analysis
-        let entries = walk_directory(path, max_depth).map_err(|e| {
+        // Single unbounded walk; filter in-memory to respect max_depth for analysis.
+        let all_entries = walk_directory(path, None).map_err(|e| {
             ErrorData::new(
                 rmcp::model::ErrorCode::INTERNAL_ERROR,
                 format!("Failed to walk directory: {}", e),
                 error_meta("resource", false, "check path permissions and availability"),
             )
         })?;
+
+        // Compute subtree counts from the full entry set before filtering.
+        let subtree_counts = if max_depth.is_some_and(|d| d > 0) {
+            Some(traversal::subtree_counts_from_entries(path, &all_entries))
+        } else {
+            None
+        };
+
+        // Filter to depth-bounded subset for analysis.
+        let entries: Vec<traversal::WalkEntry> = if let Some(depth) = max_depth
+            && depth > 0
+        {
+            all_entries
+                .into_iter()
+                .filter(|e| e.depth <= depth as usize)
+                .collect()
+        } else {
+            all_entries
+        };
 
         // Get total file count for progress reporting
         let total_files = entries.iter().filter(|e| !e.is_dir).count();
@@ -295,7 +314,10 @@ impl CodeAnalyzer {
         }
 
         match handle.await {
-            Ok(Ok(output)) => Ok(output),
+            Ok(Ok(mut output)) => {
+                output.subtree_counts = subtree_counts;
+                Ok(output)
+            }
             Ok(Err(analyze::AnalyzeError::Cancelled)) => Err(ErrorData::new(
                 rmcp::model::ErrorCode::INTERNAL_ERROR,
                 "Analysis cancelled".to_string(),
@@ -614,17 +636,12 @@ impl CodeAnalyzer {
         };
 
         if use_summary {
-            let subtree_counts = if params.max_depth.is_some_and(|d| d > 0) {
-                traversal::count_files_by_dir(std::path::Path::new(&params.path)).ok()
-            } else {
-                None
-            };
             output.formatted = format_summary(
                 &output.entries,
                 &output.files,
                 params.max_depth,
                 Some(Path::new(&params.path)),
-                subtree_counts.as_ref(),
+                output.subtree_counts.as_ref(),
             );
         }
 

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -90,47 +90,30 @@ pub fn walk_directory(
     Ok(entries)
 }
 
-/// Counts files per depth-1 subdirectory of `root` using an unbounded walk.
-/// Uses identical WalkBuilder filters as `walk_directory` (hidden + standard_filters).
+/// Compute files-per-depth-1-subdirectory counts from an already-collected entry list.
 /// Returns a map from each depth-1 child path to its total descendant file count.
-/// Does not allocate WalkEntry structs; only counts.
-pub fn count_files_by_dir(root: &Path) -> Result<HashMap<PathBuf, usize>, TraversalError> {
+/// Only counts file entries (not directories); skips entries containing EXCLUDED_DIRS components.
+pub fn subtree_counts_from_entries(root: &Path, entries: &[WalkEntry]) -> HashMap<PathBuf, usize> {
     let mut counts: HashMap<PathBuf, usize> = HashMap::new();
-    let walker = WalkBuilder::new(root)
-        .hidden(true)
-        .standard_filters(true)
-        .build();
-    for result in walker {
-        let entry = match result {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::warn!("count_files_by_dir walk error: {}", e);
-                continue;
-            }
-        };
-        // Skip directories; only count files
-        let ft = entry.file_type();
-        if ft.map(|f| f.is_dir()).unwrap_or(false) {
+    for entry in entries {
+        if entry.is_dir {
             continue;
         }
-        let path = entry.path();
         // Skip entries whose path components contain EXCLUDED_DIRS
-        if path.components().any(|c| {
+        if entry.path.components().any(|c| {
             let s = c.as_os_str().to_string_lossy();
             crate::EXCLUDED_DIRS.contains(&s.as_ref())
         }) {
             continue;
         }
-        // Find the depth-1 ancestor of this file relative to root
-        let rel = match path.strip_prefix(root) {
+        let rel = match entry.path.strip_prefix(root) {
             Ok(r) => r,
             Err(_) => continue,
         };
-        // First component of the relative path is the depth-1 child dir
         if let Some(first) = rel.components().next() {
             let depth1 = root.join(first);
             *counts.entry(depth1).or_insert(0) += 1;
         }
     }
-    Ok(counts)
+    counts
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4100,9 +4100,10 @@ fn test_format_summary_with_max_depth_annotation() {
     std::fs::write(root.join("subdir/nested/a.rs"), "fn a() {}").unwrap();
     std::fs::write(root.join("subdir/nested/b.rs"), "fn b() {}").unwrap();
 
-    // Act: walk with max_depth=1 (only sees subdir/, not the nested files)
+    // Act: unbounded walk for counts, bounded walk for analysis (mirrors new single-walk approach)
+    let all_entries = code_analyze_mcp::traversal::walk_directory(root, None).unwrap();
+    let counts = code_analyze_mcp::traversal::subtree_counts_from_entries(root, &all_entries);
     let output = analyze_directory(root, Some(1)).unwrap();
-    let counts = code_analyze_mcp::traversal::count_files_by_dir(root).unwrap();
     let summary = code_analyze_mcp::formatter::format_summary(
         &output.entries,
         &output.files,
@@ -4128,9 +4129,10 @@ fn test_format_summary_suggestion_uses_true_count() {
         std::fs::write(root.join(format!("big/deep/more/f{}.rs", i)), "fn f() {}").unwrap();
     }
 
-    // Act
+    // Act: unbounded walk for counts, bounded walk for analysis (mirrors new single-walk approach)
+    let all_entries = code_analyze_mcp::traversal::walk_directory(root, None).unwrap();
+    let counts = code_analyze_mcp::traversal::subtree_counts_from_entries(root, &all_entries);
     let output = analyze_directory(root, Some(1)).unwrap();
-    let counts = code_analyze_mcp::traversal::count_files_by_dir(root).unwrap();
     let summary = code_analyze_mcp::formatter::format_summary(
         &output.entries,
         &output.files,


### PR DESCRIPTION
## Summary

Follow-up to #399. The previous fix performed two filesystem walks for every `analyze_directory` call with `max_depth` set: a bounded walk via `walk_directory` and a second unbounded walk via `count_files_by_dir`. Benchmarks showed ~112% overhead on the 120-file fixture.

This PR replaces the double-walk with a single unbounded walk, computing per-directory subtree counts in memory from the full entry list, then filtering to the depth-limited subset for analysis.

## Changes

- `src/traversal.rs`: remove `count_files_by_dir`; add `subtree_counts_from_entries(root, entries)` which computes the same `HashMap<PathBuf, usize>` in memory from an existing entry slice
- `src/lib.rs`: always call `walk_directory(root, None)`; compute `subtree_counts` via `subtree_counts_from_entries` when `max_depth.is_some_and(|d| d > 0)`; filter entries in memory before passing to analysis
- `src/analyze.rs`: minor adjustments to analysis path following the entry-list change
- `benches/analysis.rs`: update `subtree_count_overhead` group -- replace `with_count_files_by_dir` with `with_single_walk_and_count`
- `tests/integration_tests.rs`: minor adjustments following the traversal API change

## Benchmark results

Fixture: 120 files, 3 levels of nesting, `sample_size=10`

| | Time |
|---|---|
| `baseline_walk_only` (bounded walk, no count) | 4.94 ms |
| `with_single_walk_and_count` (single unbounded walk + in-memory count) | 6.01 ms |

Overhead: **+21%** (down from +112% in #399).

## Test plan

- [x] All 211 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Fmt clean (`cargo fmt --check`)
- [x] Benchmark run locally (results above)