### PR TITLE
fix(parser): extend enclosing-scope walk to all languages in analyze_symbol

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -639,15 +639,21 @@ impl SemanticExtractor {
                 | "method_declaration"
                 | "method_definition" => parent.child_by_field_name("name"),
                 // Fortran subroutine: name is inside subroutine_statement child
-                "subroutine" => parent
-                    .children(&mut parent.walk())
-                    .find(|c| c.kind() == "subroutine_statement")
-                    .and_then(|s| s.child_by_field_name("name")),
+                "subroutine" => {
+                    let mut cursor = parent.walk();
+                    parent
+                        .children(&mut cursor)
+                        .find(|c| c.kind() == "subroutine_statement")
+                        .and_then(|s| s.child_by_field_name("name"))
+                }
                 // Fortran function: name is inside function_statement child
-                "function" => parent
-                    .children(&mut parent.walk())
-                    .find(|c| c.kind() == "function_statement")
-                    .and_then(|s| s.child_by_field_name("name")),
+                "function" => {
+                    let mut cursor = parent.walk();
+                    parent
+                        .children(&mut cursor)
+                        .find(|c| c.kind() == "function_statement")
+                        .and_then(|s| s.child_by_field_name("name"))
+                }
                 _ => {
                     node = parent;
                     continue;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3981,9 +3981,10 @@ fn test_analyze_symbol_python_callees() {
     .unwrap();
     let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
     let output = result.formatted;
+    // CALLEES section format: "  outer -> outer\n    -> inner"
     assert!(
-        output.contains("inner"),
-        "expected callees to contain 'inner', got:\n{output}"
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
     );
 }
 
@@ -3999,8 +4000,8 @@ fn test_analyze_symbol_go_callees() {
     let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
     let output = result.formatted;
     assert!(
-        output.contains("inner"),
-        "expected callees to contain 'inner', got:\n{output}"
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
     );
 }
 
@@ -4016,8 +4017,8 @@ fn test_analyze_symbol_typescript_callees() {
     let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
     let output = result.formatted;
     assert!(
-        output.contains("inner"),
-        "expected callees to contain 'inner', got:\n{output}"
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
     );
 }
 
@@ -4033,8 +4034,8 @@ fn test_analyze_symbol_fortran_callees() {
     let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
     let output = result.formatted;
     assert!(
-        output.contains("inner"),
-        "expected callees to contain 'inner', got:\n{output}"
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
     );
 }
 
@@ -4050,7 +4051,24 @@ fn test_analyze_symbol_rust_method_item_callees() {
     let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
     let output = result.formatted;
     assert!(
-        output.contains("inner"),
-        "expected callees to contain 'inner', got:\n{output}"
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
+    );
+}
+
+#[test]
+fn test_analyze_symbol_java_callees() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("Foo.java");
+    fs::write(
+        &src,
+        "class Foo {\n    void inner() {}\n\n    void outer() {\n        inner();\n    }\n}\n",
+    )
+    .unwrap();
+    let result = analyze_focused(dir.path(), "outer", 1, None, None).unwrap();
+    let output = result.formatted;
+    assert!(
+        output.contains("CALLEES:") && output.contains("-> inner"),
+        "expected CALLEES section with callee 'inner', got:\n{output}"
     );
 }


### PR DESCRIPTION
## Summary

`analyze_symbol` never populated the callee direction for any language except Rust. The ancestor-walk in `extract_calls()`, `extract_assignments()`, and `extract_field_accesses()` checked `parent.kind() == "function_item"`, which is the Rust-only tree-sitter node kind. Call sites in every other language were attributed to the synthetic `<module>` caller, leaving the callee map empty for all real function names.

## Changes

- `src/parser.rs`: Add private `enclosing_function_name()` helper that walks ancestors and matches all language-specific function container node kinds. Replace the three identical hardcoded checks with a call to this helper.
- `tests/integration_tests.rs`: Add 5 integration tests covering callee direction for Python, Go, TypeScript, Fortran (subroutine), and Rust `method_item`.

### Node kinds handled

| Language | Node kinds |
|---|---|
| Rust | `function_item`, `method_item` |
| Python | `function_definition` |
| Go | `function_declaration`, `method_declaration` |
| Java | `method_declaration` |
| TypeScript / TSX | `function_declaration`, `method_definition` |
| Fortran | `subroutine`, `function` (indirect: name via `subroutine_statement`/`function_statement` child) |

## Test plan

- [ ] 5 new tests pass (Python, Go, TypeScript, Fortran, Rust method_item callees)
- [ ] Existing callee tests pass (`test_format_focused_tree_indent_callees`, `test_format_focused_dedup_callees`)
- [ ] Full suite: 118 tests, 0 failures
- [ ] `cargo clippy -- -D warnings`: clean
- [ ] `cargo fmt --check`: clean
- [ ] `cargo deny check advisories licenses`: clean

Closes #415