### PR TITLE
chore(deps): update taiki-e/install-action to v2.69.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install cargo-deny
-        uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2.69.1
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2.69.6
         with:
           tool: cargo-deny
       - name: Check advisories and licenses
@@ -190,7 +190,7 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-deny
-        uses: taiki-e/install-action@e24b8b7a939c6a537188f34a4163cb153dd85cf6 # v2.69.1
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2.69.6
         with:
           tool: cargo-deny
       - name: Check advisories and licenses


### PR DESCRIPTION
## Summary

Renovate PR #413 only bumped `taiki-e/install-action` to v2.69.3, but v2.69.6 is already available (noted as pending in the renovate PR itself). This PR supersedes #413 by updating directly to v2.69.6.

## Changes

- `.github/workflows/ci.yml`: update both `taiki-e/install-action` usages from `e24b8b7` (v2.69.1) to `06203676` (v2.69.6)

## Test plan

- [ ] CI passes with updated action
- [ ] SHA pinned to exact commit for v2.69.6

Closes #413 (renovate PR superseded)