### PR TITLE
fix(ci): add missing toolchain input to Dependency Check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          toolchain: stable
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-deny


### PR DESCRIPTION
## Summary

The `Dependency Check (Renovate)` job uses `dtolnay/rust-toolchain` without specifying the required `toolchain` input, causing all Renovate PRs to fail with:

```
'toolchain' is a required input
```

All other jobs in the workflow already specify `toolchain: stable`. This adds the missing `with: toolchain: stable` to the Renovate job.

## Changes

- `.github/workflows/ci.yml`: add `with: toolchain: stable` to the `Install Rust toolchain` step in the `Dependency Check (Renovate)` job

## Test plan

- [ ] Renovate PR #413 CI passes after this merges to main