### PR TITLE
perf(instructions): remove analyze_module gate, add test scope directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1236,7 +1236,7 @@ impl ServerHandler for CodeAnalyzer {
             "Recommended workflow for unknown repositories:\n\
             1. Start with analyze_directory(path=<repo_root>, max_depth=2, summary=true) to identify the source package directory \
             (typically the largest directory by file count; exclude {excluded}).\n\
-            2. Re-run analyze_directory(path=<source_package>, max_depth=2, summary=true) for a module map with per-package class and function counts. Include test directories (e.g., tests/, testutil/, files matching *_test.go, test_*.py, *_spec.rs) in the module map; test files are valid analysis targets and must not be skipped.\n\
+            2. Re-run analyze_directory(path=<source_package>, max_depth=2, summary=true) for a module map with per-package class and function counts. Include test directories (e.g., tests/, testutil/, files matching *_test.go, test_*.py, test_*.rs, *_test.rs, *.spec.ts, *.spec.js) in the module map; test files are valid analysis targets and must not be skipped.\n\
             3. For key files identified in step 2, prefer analyze_module to get a lightweight function/import index (~75% smaller output) when you only need function names and imports; call analyze_file when you need signatures, types, or class structure.\n\
             4. Use analyze_symbol to trace call graphs for specific functions found in step 3.\n\
             Prefer summary=true on large directories (1000+ files). Set max_depth=2 for the first call; increase only if packages are too large to differentiate. \


### PR DESCRIPTION
## Summary

Removes the mandatory analyze_module-first gate introduced in #436, which benchmark data shows degrades the cost/accuracy ratio for both Sonnet (+78% cost, unconfirmed accuracy gain) and Haiku (+24% cost, zero accuracy gain). Rewrites step 3 of server instructions from mandatory to advisory. Also adds a test directory scope directive to step 2 to fix the independent miss of test files.

## Changes

- `src/lib.rs`: Remove "Use analyze_module first..." prefix sentence from `analyze_file` tool description
- `src/lib.rs`: Rewrite server instructions step 3 from mandatory gate to advisory preference
- `src/lib.rs`: Delete duplicate trailing mandatory sentence from server instructions
- `src/lib.rs`: Add test directory scope directive to step 2 (tests/, testutil/, *_test.go, test_*.py, *_spec.rs)

## Test plan

- [x] 227 tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Security scan clean (gitleaks: no leaks found)

Closes #437