### PR TITLE
chore: add rust-toolchain.toml and remove redundant toolchain inputs

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
           targets: ${{ inputs.target }}
 
       - name: Setup cross-compilation toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
-          toolchain: stable
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --check
@@ -111,7 +110,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
-          toolchain: stable
           components: clippy
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -131,8 +129,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -151,8 +147,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -187,8 +181,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-deny

--- a/.github/workflows/mcp-scan.yml
+++ b/.github/workflows/mcp-scan.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
-        with:
-          toolchain: stable
 
       - name: Rust cache
         uses: Swatinem/rust-cache@f51f967e158417aafa338a1e46ab22095f07aa01

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,8 +258,6 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
 
       - name: Publish to crates.io
         env:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Summary

Fixes the root cause of stuck Renovate PRs (e.g. #417). The `toolchain: stable` override added to workflow files was the wrong fix -- `dtolnay/rust-toolchain` reads `rust-toolchain.toml` automatically. Without that file, the action can receive an empty toolchain value in the `renovate-check` job context, failing with `'toolchain' is a required input`.

## Changes

- Add `rust-toolchain.toml` with `channel = "stable"` as the single source of truth
- Remove all `toolchain: stable` overrides from `.github/workflows/ci.yml`, `release.yml`, `mcp-scan.yml`, and `build-and-attest.yml`

## Test plan

- [ ] CI passes on this PR (all non-Renovate jobs use the file automatically)
- [ ] After merge, Renovate PR #417 should re-run `renovate-check` and pass