### PR TITLE
fix(bench): add missing impl_only argument to analyze_focused_with_progress call

### DIFF
--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -63,6 +63,7 @@ fn symbol_focus_benchmark(c: &mut Criterion) {
                 progress,
                 ct,
                 false,
+                None,
             )
         });
     });


### PR DESCRIPTION
## Summary

The benchmark in `benches/analysis.rs` failed to compile because `analyze_focused_with_progress` was called with 9 arguments after the function gained a 10th parameter (`impl_only: Option<bool>`) in the `impl_only` filter feature. The benchmark was not updated alongside the production and test call sites, breaking CI on main after #460 merged.

## Changes

- `benches/analysis.rs`: append `None` as the 10th argument to the `analyze_focused_with_progress` call in `symbol_focus_benchmark`

## Test plan

- [x] `cargo build --benches` compiles cleanly
- [x] `cargo test` -- 147 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check` clean