### PR TITLE
chore(release): bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-analyze-mcp"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 authors = ["Hugues Clouatre"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps the crate version from 0.1.8 to 0.1.9 in preparation for the signed release tag.

## Changes since v0.1.8

**Features**
- feat(analyze-symbol): add `impl_only` filter for trait impl sites (#435)
- feat(analyze-file): add `fields=` projection parameter and promote `analyze_module` (#436)
- feat(cache): extend LRU to `analyze_directory` with composite mtime key (#443)

**Performance**
- perf(instructions): remove `analyze_module` gate, add test scope directive (#438)
- refactor(perf): inline dead function, remove unused params and clones (#452)
- refactor(perf): remove dead fields, cache impl_trait query, async cleanup I/O (#454)

**Fixes**
- fix(bench): add missing `impl_only` argument to `analyze_focused_with_progress` call (#461)
- fix(ci): add missing toolchain input to Dependency Check job (#427)

**Docs / CI / Chore**
- docs: fix stale parameters, module map, and output examples (#458)
- chore(ci): remove mcp-scan workflow and references (#460)
- chore(deps): dependency updates (#439, #453, #459)

## Release checklist
- [x] Version bumped in `Cargo.toml` and `Cargo.lock`
- [x] Commit is GPG-signed and DCO signed-off
- [ ] PR merged to main
- [ ] Signed annotated tag `v0.1.9` pushed to trigger release workflow