### PR TITLE
docs(repo-standards): add Security Hardening section

### DIFF
--- a/docs/repo-standards.md
+++ b/docs/repo-standards.md
@@ -297,7 +297,7 @@ tar -xzf tool.tar.gz
 
 **7. Secret Scanning with gitleaks**
 
-Secret scanning runs on every PR and push as a required CI check using a shared org-level configuration and license secret. This prevents long-lived tokens committed to any repository from persisting in history or appearing in CI log artifacts.
+Secret scanning runs on every PR and push as a required CI check using a shared org-level configuration and license secret. This prevents long-lived tokens committed to any repository from persisting in history or appearing in CI log artifacts. Before enabling as a required check, run a full-history scan across all org repos with `gitleaks detect --source .` to resolve any pre-existing findings; a required check on a repo with unresolved history violations will block all PRs immediately.
 
 ```yaml
 # gitleaks workflow step referencing org-level license and config secrets


### PR DESCRIPTION
## Summary

Adds a Security Hardening section to `docs/repo-standards.md` covering 13 org-wide controls for GitHub Actions supply chain security and credential hygiene. Informed by the Trivy/Aqua (Feb-Mar 2026) and LiteLLM breach incidents.

## Changes

- `docs/repo-standards.md` — 365 lines added

## Controls added

| # | Control | Attack or Risk Blocked |
|---|---|---|
| 1 | Actions permissions (read-only GITHUB_TOKEN, allowlist) | Overprivileged token; unreviewed third-party actions |
| 2 | SHA pinning (zizmor required check + Dependabot) | Tag poisoning (Trivy breach) |
| 3 | OIDC Trusted Publishers; no stored registry tokens | Stored token exfiltration (LiteLLM breach) |
| 4 | \`pull_request_target\` audit and ban (poutine) | Fork PR PAT theft (Trivy breach) |
| 5 | Environment protection + required reviewers | Secrets reachable from fork PRs or unapproved refs |
| 6 | Fork PR workflow approval (\`outside_collaborators\`) | Untrusted code on runners; wasted CI minutes |
| 7 | Secret scanning (gitleaks) | Long-lived tokens persisting in repo history |
| 8 | Fine-grained PATs only; classic banned; 90-day expiry | Wide-scope token exfiltration |
| 9 | GitHub Apps; 2FA; SAML SSO | Long-lived automation secrets; phishing |
| 10 | Tag immutability ruleset + signed commits | Tag force-push (Trivy breach) |
| 11 | Pinned tool versions + SHA256 verification | Unpinned install compromise (LiteLLM breach) |
| 12 | Audit log streaming and alerting | Breach invisible until external disclosure |
| 13 | CODEOWNERS on \`.github/workflows/\` | Workflow modification by compromised account |

## Format

Follows `DESIGN-GUIDE.md` conventions: captioned figures (Figure 1), tables (Table 2-3), and code snippets (Code Snippets 1-15) with sequential numbering continuing from the existing document.

## Test plan

- [ ] Markdown renders correctly
- [ ] Caption numbering is sequential (Table 1 exists in Artifact Map; new tables are 2 and 3)
- [ ] All action references use commit SHAs, not tags