### PR TITLE
chore(ci): switch crates.io publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,9 @@ jobs:
     needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -262,8 +265,6 @@ jobs:
           toolchain: stable
 
       - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
           VERSION="${{ needs.create-release.outputs.version }}"
           if curl -sf -A "code-analyze-mcp-release/1.0" "https://crates.io/api/v1/crates/code-analyze-mcp/${VERSION}" > /dev/null; then


### PR DESCRIPTION
## Summary

Replace the long-lived `CRATES_IO_TOKEN` org secret with short-lived OIDC tokens via crates.io trusted publishing.

## Changes

- `.github/workflows/release.yml`: add `id-token: write` permission to the `publish` job; remove `CARGO_REGISTRY_TOKEN` env from the `cargo publish` step

## Prerequisites (already done)

Trusted publisher registered on crates.io for `code-analyze-mcp` against `clouatre-labs/code-analyze-mcp` / `release.yml`.

## After merge

Delete the `CRATES_IO_TOKEN` secret from the org once the next release confirms OIDC publish succeeds.