### PR TITLE
chore(ci): pin GitHub runner from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -10,7 +10,7 @@ on:
       os:
         required: true
         type: string
-        description: "Runner OS (ubuntu-latest, macos-latest)"
+        description: "Runner OS (ubuntu-24.04, macos-latest)"
       cross:
         required: true
         type: boolean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   commitlint:
     name: Lint Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
@@ -61,7 +61,7 @@ jobs:
 
   check-base:
     name: Check Branch Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   format:
     name: Check Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -101,7 +101,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -122,7 +122,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -142,7 +142,7 @@ jobs:
 
   bench:
     name: Benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true' && github.actor != 'renovate[bot]'
     timeout-minutes: 15
@@ -162,7 +162,7 @@ jobs:
 
   deny:
     name: Audit Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -178,7 +178,7 @@ jobs:
 
   renovate-check:
     name: Dependency Check (Renovate)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
     if: github.actor == 'renovate[bot]'
@@ -202,7 +202,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     needs: [changes, commitlint, check-base, format, lint, test, bench, deny, renovate-check]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify-tag-signature:
     name: Verify Tag Signature
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
     name: Create Release
     needs: [verify-tag-signature]
     if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     outputs:
@@ -123,10 +123,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cross: true
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cross: true
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -144,7 +144,7 @@ jobs:
     name: Update Homebrew Formula
     needs: [create-release, build-and-attest]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout homebrew-tap repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -251,7 +251,7 @@ jobs:
     name: Publish to crates.io
     needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Pin all GitHub Actions runners from `ubuntu-latest` to `ubuntu-24.04` to prevent silent drift when GitHub bumps the `latest` label.

## Changes

- `.github/workflows/build-and-attest.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

## Notes

`ubuntu-latest` currently resolves to `ubuntu-24.04` so this is a no-op change in behavior. Renovate will propose label bumps (e.g., to `ubuntu-26.04`) when GitHub introduces a new LTS runner.

## Test plan

- [ ] CI passes on the pinned label