### PR TITLE
chore(deps): group renovate updates and add weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,15 +4,21 @@
   "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",
   "platformAutomerge": true,
+  "dependencyDashboard": false,
   "ignorePaths": ["fuzz/**"],
+  "schedule": ["before 6am on monday"],
   "packageRules": [
     {
+      "groupName": "non-major",
       "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     },
     {
+      "groupName": "github-actions",
       "matchManagers": ["github-actions"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
Groups patch/minor/digest into single weekly PR to minimize CI runs. Adds minimumReleaseAge=3 days for safety. Automerge enabled for non-major and GitHub Actions.