### PR TITLE
chore(ci): remove merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Remove the `merge_group` workflow trigger. We do not use merge queue.