### PR TITLE
ci: pass --profile ci to cargo test, clippy, and bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run tests
-        run: cargo test --profile ci
+        run: cargo test
 
   bench:
     name: Benchmark

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,5 @@ strip = true
 inherits = "release"
 lto = false
 codegen-units = 16
+panic = "unwind"
+strip = false


### PR DESCRIPTION
Use the ci profile (lto=false, codegen-units=16) for all compilation-heavy CI jobs to reduce build times.

## Changes
- `cargo test` → `cargo test --profile ci`
- `cargo clippy ...` → `cargo clippy --profile ci ...`
- `cargo bench` → `cargo bench --profile ci`

## Motivation
The `profile.ci` block in `Cargo.toml` exists for this purpose but was never wired into CI, so every CI build compiled with full release LTO.