### PR TITLE
perf: eliminate redundant walks, parses, and BFS in analyze_symbol

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -4,11 +4,11 @@
 //! `analyze_symbol` (call graph), and `analyze_module` (lightweight index). Handles parallel processing and cancellation.
 
 use crate::formatter::{
-    format_file_details, format_focused, format_focused_summary, format_structure,
+    format_file_details, format_focused_internal, format_focused_summary_internal, format_structure,
 };
 use crate::graph::{CallGraph, InternalCallChain};
 use crate::lang::language_from_extension;
-use crate::parser::{ElementExtractor, SemanticExtractor, extract_impl_traits};
+use crate::parser::{ElementExtractor, SemanticExtractor};
 use crate::test_detection::is_test_file;
 use crate::traversal::{WalkEntry, walk_directory};
 use crate::types::{
@@ -293,7 +293,7 @@ pub struct FocusedAnalysisOutput {
 }
 
 /// Analyze a symbol's call graph across a directory with progress tracking.
-#[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
+/// Public API: matches the original signature before PR 491.
 #[allow(clippy::too_many_arguments)]
 pub fn analyze_focused_with_progress(
     root: &Path,
@@ -307,7 +307,38 @@ pub fn analyze_focused_with_progress(
     use_summary: bool,
     impl_only: Option<bool>,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
-    #[allow(clippy::too_many_arguments)]
+    let entries = walk_directory(root, max_depth)?;
+    analyze_focused_with_progress_with_entries(
+        root,
+        focus,
+        match_mode,
+        follow_depth,
+        max_depth,
+        ast_recursion_limit,
+        progress,
+        ct,
+        use_summary,
+        impl_only,
+        &entries,
+    )
+}
+
+/// Analyze a symbol's call graph using pre-walked directory entries.
+#[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn analyze_focused_with_progress_with_entries(
+    root: &Path,
+    focus: &str,
+    match_mode: SymbolMatchMode,
+    follow_depth: u32,
+    _max_depth: Option<u32>,
+    ast_recursion_limit: Option<usize>,
+    progress: Arc<AtomicUsize>,
+    ct: CancellationToken,
+    use_summary: bool,
+    impl_only: Option<bool>,
+    entries: &[WalkEntry],
+) -> Result<FocusedAnalysisOutput, AnalyzeError> {
     // Check if already cancelled
     if ct.is_cancelled() {
         return Err(AnalyzeError::Cancelled);
@@ -330,9 +361,7 @@ pub fn analyze_focused_with_progress(
         });
     }
 
-    // Walk the directory
-    let entries = walk_directory(root, max_depth)?;
-
+    // Use pre-walked entries (passed by caller)
     // Collect semantic analysis for all files in parallel
     let file_entries: Vec<&WalkEntry> = entries.iter().filter(|e| !e.is_dir).collect();
 
@@ -370,9 +399,9 @@ pub fn analyze_focused_with_progress(
                     for r in &mut semantic.references {
                         r.location = entry.path.display().to_string();
                     }
-                    // Extract impl-trait blocks independently (Rust only; empty for other langs)
-                    if language == "rust" {
-                        semantic.impl_traits = extract_impl_traits(&source, &entry.path);
+                    // Populate file path on impl_traits (already extracted during SemanticExtractor::extract)
+                    for trait_info in &mut semantic.impl_traits {
+                        trait_info.path = entry.path.clone();
                     }
                     progress.fetch_add(1, Ordering::Relaxed);
                     Some((entry.path.clone(), semantic))
@@ -466,18 +495,32 @@ pub fn analyze_focused_with_progress(
     let outgoing_chains = graph.find_outgoing_chains(&resolved_focus, follow_depth)?;
 
     let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
-        incoming_chains.into_iter().partition(|chain| {
+        incoming_chains.iter().cloned().partition(|chain| {
             chain
                 .chain
                 .first()
                 .is_none_or(|(name, path, _)| !is_test_file(path) && !name.starts_with("test_"))
         });
 
-    // Format output
+    // Format output with pre-computed chains
     let formatted = if use_summary {
-        format_focused_summary(&graph, &resolved_focus, follow_depth, Some(root))?
+        format_focused_summary_internal(
+            &graph,
+            &resolved_focus,
+            follow_depth,
+            Some(root),
+            Some(&incoming_chains),
+            Some(&outgoing_chains),
+        )?
     } else {
-        format_focused(&graph, &resolved_focus, follow_depth, Some(root))?
+        format_focused_internal(
+            &graph,
+            &resolved_focus,
+            follow_depth,
+            Some(root),
+            Some(&incoming_chains),
+            Some(&outgoing_chains),
+        )?
     };
 
     Ok(FocusedAnalysisOutput {
@@ -500,9 +543,10 @@ pub fn analyze_focused(
     max_depth: Option<u32>,
     ast_recursion_limit: Option<usize>,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
+    let entries = walk_directory(root, max_depth)?;
     let counter = Arc::new(AtomicUsize::new(0));
     let ct = CancellationToken::new();
-    analyze_focused_with_progress(
+    analyze_focused_with_progress_with_entries(
         root,
         focus,
         SymbolMatchMode::Exact,
@@ -513,6 +557,7 @@ pub fn analyze_focused(
         ct,
         false,
         None,
+        &entries,
     )
 }
 
@@ -960,6 +1005,53 @@ mod tests {
         assert!(
             paginated.next_cursor.is_none(),
             "no next_cursor for empty or single-page prod_chains"
+        );
+    }
+
+    #[test]
+    fn test_callers_count_matches_formatted_output() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a file with multiple callers of `target`
+        let code = r#"
+fn target() {}
+fn caller_a() { target(); }
+fn caller_b() { target(); }
+fn caller_c() { target(); }
+"#;
+        fs::write(temp_dir.path().join("lib.rs"), code).unwrap();
+
+        // Analyze the symbol
+        let output = analyze_focused(temp_dir.path(), "target", 1, None, None).unwrap();
+
+        // Extract CALLERS count from formatted output
+        let formatted = &output.formatted;
+        let callers_count_from_output = formatted
+            .lines()
+            .find(|line| line.contains("FOCUS:"))
+            .and_then(|line| {
+                line.split(',')
+                    .find(|part| part.contains("callers"))
+                    .and_then(|part| {
+                        part.trim()
+                            .split_whitespace()
+                            .next()
+                            .and_then(|s| s.parse::<usize>().ok())
+                    })
+            })
+            .expect("should find CALLERS count in formatted output");
+
+        // Compute expected count from prod_chains (unique first-caller names)
+        let expected_callers_count = output
+            .prod_chains
+            .iter()
+            .filter_map(|chain| chain.chain.first().map(|(name, _, _)| name))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+
+        assert_eq!(
+            callers_count_from_output, expected_callers_count,
+            "CALLERS count in formatted output should match unique-first-caller count in prod_chains"
         );
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -391,22 +391,37 @@ fn format_chains_as_tree(chains: &[(&str, &str)], arrow: &str, focus_symbol: &st
 
 /// Format focused symbol analysis with call graph.
 #[instrument(skip_all)]
-pub fn format_focused(
+/// Internal helper that accepts pre-computed chains.
+pub(crate) fn format_focused_internal(
     graph: &CallGraph,
     symbol: &str,
     follow_depth: u32,
     base_path: Option<&Path>,
+    incoming_chains: Option<&[InternalCallChain]>,
+    outgoing_chains: Option<&[InternalCallChain]>,
 ) -> Result<String, FormatterError> {
     let mut output = String::new();
 
     // Compute all counts BEFORE output begins
     let def_count = graph.definitions.get(symbol).map_or(0, |d| d.len());
-    let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
-    let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
+
+    // Use pre-computed chains if provided, otherwise compute them
+    let (incoming_chains_vec, outgoing_chains_vec);
+    let (incoming_chains_ref, outgoing_chains_ref) =
+        if let (Some(inc), Some(out)) = (incoming_chains, outgoing_chains) {
+            (inc, out)
+        } else {
+            incoming_chains_vec = graph.find_incoming_chains(symbol, follow_depth)?;
+            outgoing_chains_vec = graph.find_outgoing_chains(symbol, follow_depth)?;
+            (
+                incoming_chains_vec.as_slice(),
+                outgoing_chains_vec.as_slice(),
+            )
+        };
 
     // Partition incoming_chains into production and test callers
     let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
-        incoming_chains.into_iter().partition(|chain| {
+        incoming_chains_ref.iter().cloned().partition(|chain| {
             chain
                 .chain
                 .first()
@@ -421,7 +436,7 @@ pub fn format_focused(
         .len();
 
     // Count unique callees
-    let callees_count = outgoing_chains
+    let callees_count = outgoing_chains_ref
         .iter()
         .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
         .collect::<std::collections::HashSet<_>>()
@@ -503,7 +518,7 @@ pub fn format_focused(
 
     // CALLEES section - what this symbol calls
     output.push_str("CALLEES:\n");
-    let outgoing_refs: Vec<_> = outgoing_chains
+    let outgoing_refs: Vec<_> = outgoing_chains_ref
         .iter()
         .filter_map(|chain| {
             if chain.chain.len() >= 2 {
@@ -534,7 +549,7 @@ pub fn format_focused(
             files.insert(path.clone());
         }
     }
-    for chain in &outgoing_chains {
+    for chain in outgoing_chains_ref {
         for (_, path, _) in &chain.chain {
             files.insert(path.clone());
         }
@@ -579,22 +594,37 @@ pub fn format_focused(
 /// Format a compact summary of focused symbol analysis.
 /// Used when output would exceed the size threshold or when explicitly requested.
 #[instrument(skip_all)]
-pub fn format_focused_summary(
+/// Internal helper that accepts pre-computed chains.
+pub(crate) fn format_focused_summary_internal(
     graph: &CallGraph,
     symbol: &str,
     follow_depth: u32,
     base_path: Option<&Path>,
+    incoming_chains: Option<&[InternalCallChain]>,
+    outgoing_chains: Option<&[InternalCallChain]>,
 ) -> Result<String, FormatterError> {
     let mut output = String::new();
 
     // Compute all counts BEFORE output begins
     let def_count = graph.definitions.get(symbol).map_or(0, |d| d.len());
-    let incoming_chains = graph.find_incoming_chains(symbol, follow_depth)?;
-    let outgoing_chains = graph.find_outgoing_chains(symbol, follow_depth)?;
+
+    // Use pre-computed chains if provided, otherwise compute them
+    let (incoming_chains_vec, outgoing_chains_vec);
+    let (incoming_chains_ref, outgoing_chains_ref) =
+        if let (Some(inc), Some(out)) = (incoming_chains, outgoing_chains) {
+            (inc, out)
+        } else {
+            incoming_chains_vec = graph.find_incoming_chains(symbol, follow_depth)?;
+            outgoing_chains_vec = graph.find_outgoing_chains(symbol, follow_depth)?;
+            (
+                incoming_chains_vec.as_slice(),
+                outgoing_chains_vec.as_slice(),
+            )
+        };
 
     // Partition incoming_chains into production and test callers
     let (prod_chains, test_chains): (Vec<_>, Vec<_>) =
-        incoming_chains.into_iter().partition(|chain| {
+        incoming_chains_ref.iter().cloned().partition(|chain| {
             chain
                 .chain
                 .first()
@@ -609,7 +639,7 @@ pub fn format_focused_summary(
         .len();
 
     // Count unique callees
-    let callees_count = outgoing_chains
+    let callees_count = outgoing_chains_ref
         .iter()
         .filter_map(|chain| chain.chain.first().map(|(p, _, _)| p))
         .collect::<std::collections::HashSet<_>>()
@@ -688,13 +718,13 @@ pub fn format_focused_summary(
 
     // CALLEES (top 10 by frequency)
     output.push_str("CALLEES (top 10):\n");
-    if outgoing_chains.is_empty() {
+    if outgoing_chains_ref.is_empty() {
         output.push_str("  (none)\n");
     } else {
         // Collect callee names and count frequency
         let mut callee_freq: std::collections::HashMap<String, usize> =
             std::collections::HashMap::new();
-        for chain in &outgoing_chains {
+        for chain in outgoing_chains_ref {
             if let Some((name, _, _)) = chain.chain.first() {
                 *callee_freq.entry(name.clone()).or_insert(0) += 1;
             }
@@ -714,6 +744,28 @@ pub fn format_focused_summary(
     output.push_str("Use summary=false with force=true for full output\n");
 
     Ok(output)
+}
+
+/// Format focused symbol analysis with call graph.
+/// Public wrapper that computes chains if not provided.
+pub fn format_focused(
+    graph: &CallGraph,
+    symbol: &str,
+    follow_depth: u32,
+    base_path: Option<&Path>,
+) -> Result<String, FormatterError> {
+    format_focused_internal(graph, symbol, follow_depth, base_path, None, None)
+}
+
+/// Format a compact summary of focused symbol analysis.
+/// Public wrapper that computes chains if not provided.
+pub fn format_focused_summary(
+    graph: &CallGraph,
+    symbol: &str,
+    follow_depth: u32,
+    base_path: Option<&Path>,
+) -> Result<String, FormatterError> {
+    format_focused_summary_internal(graph, symbol, follow_depth, base_path, None, None)
 }
 
 /// Format a compact summary for large directory analysis results.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,16 +421,24 @@ impl CodeAnalyzer {
         let ct_clone = ct.clone();
         let impl_only = params.impl_only;
 
+        // Walk directory once at entry point
+        let entries = match walk_directory(path, max_depth) {
+            Ok(e) => e,
+            Err(e) => {
+                return Err(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to walk directory: {}", e),
+                    error_meta("resource", false, "check path permissions and availability"),
+                ));
+            }
+        };
+        let entries = std::sync::Arc::new(entries);
+
         // Validate impl_only: only valid for directories that contain Rust source files.
         if impl_only == Some(true) {
-            let has_rust = walk_directory(path, max_depth)
-                .ok()
-                .map(|entries| {
-                    entries.iter().any(|e| {
-                        !e.is_dir && e.path.extension().and_then(|x| x.to_str()) == Some("rs")
-                    })
-                })
-                .unwrap_or(false);
+            let has_rust = entries
+                .iter()
+                .any(|e| !e.is_dir && e.path.extension().and_then(|x| x.to_str()) == Some("rs"));
 
             if !has_rust {
                 return Err(ErrorData::new(
@@ -449,15 +457,13 @@ impl CodeAnalyzer {
         let use_summary_for_task = params.output_control.force != Some(true)
             && params.output_control.summary == Some(true);
 
-        // Get total file count for progress reporting
-        let total_files = match walk_directory(path, max_depth) {
-            Ok(entries) => entries.iter().filter(|e| !e.is_dir).count(),
-            Err(_) => 0,
-        };
+        // Get total file count for progress reporting from the single walk
+        let total_files = entries.iter().filter(|e| !e.is_dir).count();
 
         // Spawn blocking analysis with progress tracking
+        let entries_clone = std::sync::Arc::clone(&entries);
         let handle = tokio::task::spawn_blocking(move || {
-            analyze::analyze_focused_with_progress(
+            analyze::analyze_focused_with_progress_with_entries(
                 &path_owned,
                 &symbol_owned,
                 match_mode,
@@ -468,6 +474,7 @@ impl CodeAnalyzer {
                 ct_clone,
                 use_summary_for_task,
                 impl_only,
+                &entries_clone,
             )
         });
 
@@ -552,7 +559,7 @@ impl CodeAnalyzer {
         };
 
         // Auto-detect: if no explicit summary param and output exceeds limit,
-        // re-run analysis with use_summary=true
+        // re-run analysis with use_summary=true (reuse same entries from initial walk)
         if params.output_control.summary.is_none()
             && params.output_control.force != Some(true)
             && output.formatted.len() > SIZE_LIMIT
@@ -566,8 +573,9 @@ impl CodeAnalyzer {
             let counter2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let ct2 = ct.clone();
             let impl_only2 = impl_only;
+            let entries_clone2 = std::sync::Arc::clone(&entries);
             let summary_result = tokio::task::spawn_blocking(move || {
-                analyze::analyze_focused_with_progress(
+                analyze::analyze_focused_with_progress_with_entries(
                     &path_owned2,
                     &symbol_owned2,
                     match_mode2,
@@ -578,6 +586,7 @@ impl CodeAnalyzer {
                     ct2,
                     true, // use_summary=true
                     impl_only2,
+                    &entries_clone2,
                 )
             })
             .await;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use crate::types::{
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use thiserror::Error;
 use tracing::instrument;
@@ -520,7 +520,14 @@ impl SemanticExtractor {
         Self::extract_impl_methods(source, compiled, root, max_depth, &mut classes);
         Self::extract_references(source, compiled, root, max_depth, &mut references);
 
-        tracing::debug!(language = %language, functions = functions.len(), classes = classes.len(), imports = imports.len(), references = references.len(), calls = calls.len(), "extraction complete");
+        // Extract impl-trait blocks for Rust files (empty for other languages)
+        let impl_traits = if language == "rust" {
+            Self::extract_impl_traits_from_tree(source, compiled, root)
+        } else {
+            vec![]
+        };
+
+        tracing::debug!(language = %language, functions = functions.len(), classes = classes.len(), imports = imports.len(), references = references.len(), calls = calls.len(), impl_traits = impl_traits.len(), "extraction complete");
 
         Ok(SemanticAnalysis {
             functions,
@@ -529,7 +536,7 @@ impl SemanticExtractor {
             references,
             call_frequency,
             calls,
-            impl_traits: vec![],
+            impl_traits,
         })
     }
 
@@ -852,6 +859,57 @@ impl SemanticExtractor {
                 }
             }
         }
+    }
+
+    /// Extract impl-trait blocks from an already-parsed tree.
+    ///
+    /// Called during `extract()` for Rust files to avoid a second parse.
+    /// Returns an empty vec if the query is not available.
+    fn extract_impl_traits_from_tree(
+        source: &str,
+        compiled: &CompiledQueries,
+        root: Node<'_>,
+    ) -> Vec<ImplTraitInfo> {
+        let Some(query) = &compiled.impl_trait else {
+            return vec![];
+        };
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(query, root, source.as_bytes());
+        let mut results = Vec::new();
+
+        while let Some(mat) = matches.next() {
+            let mut trait_name = String::new();
+            let mut impl_type = String::new();
+            let mut line = 0usize;
+
+            for capture in mat.captures {
+                let capture_name = query.capture_names()[capture.index as usize];
+                let node = capture.node;
+                let text = source[node.start_byte()..node.end_byte()].to_string();
+                match capture_name {
+                    "trait_name" => {
+                        trait_name = text;
+                        line = node.start_position().row + 1;
+                    }
+                    "impl_type" => {
+                        impl_type = text;
+                    }
+                    _ => {}
+                }
+            }
+
+            if !trait_name.is_empty() && !impl_type.is_empty() {
+                results.push(ImplTraitInfo {
+                    trait_name,
+                    impl_type,
+                    path: PathBuf::new(), // Path will be set by caller
+                    line,
+                });
+            }
+        }
+
+        results
     }
 }
 


### PR DESCRIPTION
## Summary

Three pipeline-level performance fixes to the `analyze_symbol` hot path, each eliminating a category of repeated work.

**#478 - Single directory walk:** `handle_focused_mode` previously called `walk_directory` up to 4 times per request. Walk is now performed once at the entry point; the resulting `Vec<WalkEntry>` is passed through to `analyze_focused_with_progress` and reused by the auto-summary retry path.

**#479 - Single tree-sitter parse per Rust file:** `analyze_focused_with_progress` previously parsed each Rust file twice -- once via `SemanticExtractor::extract` and once via `extract_impl_traits`. The impl-trait query is now run on the already-parsed tree inside `extract()` via a new `extract_impl_traits_from_tree` private method, populating `semantic.impl_traits` in the same pass.

**#480 - Single BFS traversal:** `find_incoming_chains` and `find_outgoing_chains` were each called twice per non-summary request (once in `analyze_focused_with_progress` for pagination, once inside `format_focused`/`format_focused_summary`). Both are now computed once after the `impl_only` mutation and passed as pre-computed slices to internal formatter helpers. Public formatter signatures are unchanged. A regression test verifies CALLERS count consistency between formatted output and `FocusedAnalysisOutput` chains.

## Changes

- `src/lib.rs`
- `src/analyze.rs`
- `src/parser.rs`
- `src/languages/rust.rs`
- `src/formatter.rs`

## Test plan

- [x] All existing tests pass (`cargo test`: 229 passed)
- [x] `test_callers_count_matches_formatted_output` verifies CALLERS count consistency (mandatory for #480)
- [x] impl_only mutation ordering preserved (before BFS calls)
- [x] Public API signatures unchanged
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] `cargo deny check advisories licenses` clean

Closes #479, #478, #480