### PR TITLE
docs: document squash-only merge strategy and branch deletion policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ The `-S` flag GPG-signs the commit (required by branch protection).
 
 ## Branch Protection
 
-See [docs/repo-standards.md](docs/repo-standards.md) for ruleset configuration, required status checks, signed-commit enforcement, and branch protection rationale.
+See [docs/repo-standards.md](docs/repo-standards.md) for ruleset configuration, required status checks, signed-commit enforcement, branch protection rationale, and the repo merge strategy.
 
 ## License
 

--- a/docs/repo-standards.md
+++ b/docs/repo-standards.md
@@ -41,6 +41,10 @@ This document maps every repo-level artifact to its purpose and the rationale be
 
 **Permissions-first sequencing.** The org default GITHUB_TOKEN permission was flipped to `read` on 2026-03-25. New repos work without per-workflow blocks, but explicit blocks are still required as defence in depth and should be placed before the first `jobs:` key by convention for readability.
 
+## Merge Strategy
+
+**Squash merge only.** The repository is configured with `allow_squash_merge: true`, `delete_branch_on_merge: true`, and merge commits and rebase merges disabled. Squash merging linearizes the commit history and prevents feature branches from adding noise; automatic branch deletion keeps the repository clean.
+
 ## Applying to a New Repo
 
 1. **GitHub metadata:** Set topics, copy the 11-label taxonomy (names, colors, descriptions), create the two rulesets.


### PR DESCRIPTION
## Summary

- Add a Merge Strategy section to `docs/repo-standards.md` documenting squash-only merges, disabled merge commits and rebase merges, and automatic branch deletion on merge
- Add a reference to the merge strategy in `CONTRIBUTING.md`

## Changes

- `docs/repo-standards.md`: new Merge Strategy section
- `CONTRIBUTING.md`: reference to merge strategy in Branch Protection section