### PR TITLE
chore(release): bump version to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-analyze-mcp"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.94.1"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump version to 0.1.10. Tag and release will be created after merge.

## Changes since v0.1.9

**Performance**
- perf: pre-lowercase symbol index and parallel cache stat (#490)
- perf: eliminate redundant walks, parses, and BFS in analyze_symbol (#491)

**Robustness**
- fix(robustness): replace unwrap with expect/recover in hot paths (#489)
- refactor: decompose handle_focused_mode and analyze_focused_with_progress (#494)

**Registry / CI**
- feat(registry): add MCP registry server.json and CI automation (#474)
- ci(release): automate MCP registry publish via mcp-publisher (#475)
- chore(ci): add zizmor SHA-pinning enforcement (#473)
- ci: pass --profile ci to cargo test, clippy, and bench (#472)
- chore(ci): pin macos-latest to macos-15 (#468)
- chore(ci): pin GitHub runner from ubuntu-latest to ubuntu-24.04 (#467)
- chore(ci): switch crates.io publish to OIDC trusted publishing (#466)
- chore(ci): remove merge_group trigger (#471)

**Chore / docs**
- chore: supply chain hygiene and crates.io metadata (#498)
- chore: enable clippy pedantic lints (#499)
- docs: commit AGENTS.md as real file and unblock from .gitignore (#492)
- docs: record hardening track learnings in repo-standards.md (#477)
- docs: update Wave 7 direction with HTTP transport and deployment plan (#465)
- docs: remove invalid OpenSSF Scorecard badge (#500)
- docs: document squash-only merge strategy and branch deletion policy (#501)
- chore(review): add scoped Copilot review instructions (#493)
- chore(deps): group renovate updates and add weekly schedule (#469)

## Test plan
- [ ] Tests pass
- [ ] Linter clean
- [ ] cargo build succeeds at v0.1.10