### PR TITLE
fix(ci): add crates-io-auth-action for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,6 +449,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
       - name: Publish to crates.io
         run: |
           VERSION="${{ needs.create-release.outputs.version }}"
@@ -457,3 +461,5 @@ jobs:
             exit 0
           fi
           cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Problem

The `publish` job in the release workflow calls `cargo publish` with no token, resulting in:
```
error: no token found, please run `cargo login` or use environment variable CARGO_REGISTRY_TOKEN
```

The workflow has `id-token: write` permission (correct for OIDC trusted publishing) but was missing the token exchange step.

## Solution

Added the `rust-lang/crates-io-auth-action` step before `cargo publish`, pinned to SHA `bbd81622f20ce9e2dd9622e3218b975523e45bbe` (v1.0.4).

The authentication step exchanges the GitHub OIDC token for a crates.io token and outputs it as `steps.auth.outputs.token`, which is then passed to `cargo publish` via the `CARGO_REGISTRY_TOKEN` environment variable.

This follows the official crates.io OIDC trusted publishing pattern.