### PR TITLE
fix(registry): truncate server.json description to 100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.clouatre-labs/code-analyze-mcp",
   "title": "Code Analyze MCP",
-  "description": "MCP server for code structure analysis using tree-sitter. Provides directory overview, file semantic details, symbol call graphs, and lightweight module indexing for Rust, Go, Java, Python, TypeScript, and TSX.",
+  "description": "MCP server for code structure analysis using tree-sitter.",
   "repository": {
     "url": "https://github.com/clouatre-labs/code-analyze-mcp",
     "source": "github"


### PR DESCRIPTION
MCP registry validation rejects descriptions >100 chars. Truncated to the short form.