### PR TITLE
ci: add manual publish-registry workflow for MCP registry

### DIFF
--- a/.github/workflows/publish-registry-manual.yml
+++ b/.github/workflows/publish-registry-manual.yml
@@ -1,0 +1,44 @@
+name: Publish to MCP Registry (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-registry-manual
+  cancel-in-progress: false
+
+jobs:
+  publish-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz" \
+            -o /tmp/mcp-publisher.tar.gz
+          echo "79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5  /tmp/mcp-publisher.tar.gz" | sha256sum --check
+          tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
+          test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }
+          sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher
+          rm -f /tmp/mcp-publisher.tar.gz
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Login via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish


### PR DESCRIPTION
Adds a `workflow_dispatch`-only workflow that publishes the current `server.json` to the MCP registry.

- Useful for recovering from failed release runs (e.g. 0.1.10)
- Serves as an isolated test of the `mcp-publisher` OIDC flow before each release
- Exact same steps as the `publish-registry` job in `release.yml`; no new logic

Closes the 0.1.10 MCP registry publish gap.