### PR TITLE
chore(deps): lock file maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,9 +858,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
## Summary

Manual lock file maintenance replacing Renovate PR #417.

## Changes

- `itoa`: 1.0.17 -> 1.0.18
- `tree-sitter-rust`: 0.24.0 -> 0.24.1
- `zerocopy` / `zerocopy-derive`: 0.8.42 -> 0.8.47
- `rmcp` / `rmcp-macros`: 1.2.0 -> 1.3.0

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` all pass
- [x] `cargo clippy -- -D warnings` clean

Closes #417