### PR TITLE
fix(ci): add server.json to pull_request path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'clippy.toml'
+      - '.github/workflows/**'
+      - 'tests/**'
+      - 'server.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

CI skips entirely on PRs that only touch \`server.json\` because it is not in the \`pull_request\` path filter. This leaves \`CI Result\` in a pending state, blocking auto-merge for bot PRs created by the release and release-repair workflows.

## Changes

- Added \`server.json\` to the \`pull_request\` paths in \`ci.yml\`

## Why not other PRs?

Every other PR touched at least one file already in the filter (\`src/**\`, \`Cargo.toml\`, \`tests/**\`, \`.github/workflows/**\`). The \`update-server-json\` job in the release pipeline is the only workflow that opens PRs touching only \`server.json\`.