### PR TITLE
fix(registry): add required version field to server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.clouatre-labs/code-analyze-mcp",
+  "version": "0.1.10",
   "title": "Code Analyze MCP",
   "description": "MCP server for code structure analysis using tree-sitter.",
   "repository": {


### PR DESCRIPTION
## Summary

The MCP registry publish workflow was failing with:

```
Error: publish failed: server returned status 400: {"title":"Bad Request","status":400,"detail":"Failed to publish server","errors":[{"message":"server name and version are required"}]}
```

The `ServerDetail` schema requires a top-level `version` field alongside `name` and `description`. This field was missing from `server.json`.

## Changes

- `server.json`: added `"version": "0.1.10"`

## Note

Future releases should keep this field in sync with `Cargo.toml`. The `update-server-json` automation should be updated to set this field as well.