### PR TITLE
fix(release): commit server.json directly to main, drop PR flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,16 +317,16 @@ jobs:
             gh release upload "${RELEASE_TAG}" "/tmp/${MCPB_NAME}" --clobber
           done
 
-  update-server-json:
-    name: Update server.json
+  commit-server-json:
+    name: Commit server.json to main
     needs: [create-release, generate-mcpb]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-24.04
     permissions:
+      # github-actions[bot] is configured as a bypass actor (exempt) on the
+      # "Protect main branch" ruleset, allowing direct push without a PR.
+      # See: repo Settings > Rules > Protect main branch > Bypass list
       contents: write
-      pull-requests: write
-    outputs:
-      pr_branch: ${{ steps.push.outputs.pr_branch }}
     steps:
       - name: Checkout repository at main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -380,110 +380,35 @@ jobs:
              .packages[2].fileSha256 = $sha_linux_x86' \
             server.json > server.json.tmp && mv server.json.tmp server.json
 
-      - name: Create feature branch and commit server.json
-        id: push
+      - name: Commit and push server.json to main
         run: |
           set -euo pipefail
 
           VERSION="${{ needs.create-release.outputs.version }}"
-          BRANCH_NAME="chore/registry-update-v${VERSION}"
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
           # Only commit and push if server.json has changed
           if git diff --quiet -- server.json; then
-            echo "server.json unchanged; skipping PR creation"
-            echo "pr_branch=main" >> "$GITHUB_OUTPUT"
+            echo "No changes to server.json; skipping commit to main"
             exit 0
           fi
 
           git fetch origin
-          if git ls-remote --exit-code origin "$BRANCH_NAME" 2>/dev/null; then
-            echo "Stale branch $BRANCH_NAME exists, deleting..."
-            git push origin --delete "$BRANCH_NAME"
-          fi
-
-          git checkout -b "$BRANCH_NAME"
           git add server.json
           git commit --signoff -m "chore(registry): update server.json for v${VERSION}"
-          git push origin "$BRANCH_NAME"
-          echo "pr_branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Create pull request with auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ needs.create-release.outputs.version }}"
-          BRANCH_NAME="chore/registry-update-v${VERSION}"
-
-          # Only create PR if server.json was changed
-          if [ "${{ steps.push.outputs.pr_branch }}" = "main" ]; then
-            echo "server.json unchanged; skipping PR creation"
-            exit 0
-          fi
-
-          gh pr create \
-            --title "chore(registry): update server.json for v${VERSION}" \
-            --body "Automated server.json update with MCPB checksums for release v${VERSION}" \
-            --head "$BRANCH_NAME" \
-            --base main
-
-          # Merge immediately (single-file bot commit, no code to test)
-          gh pr merge "$BRANCH_NAME" --squash --delete-branch
+          git push origin main
 
   publish-registry:
     name: Publish to MCP Registry
-    needs: [create-release, update-server-json]
+    needs: [create-release, commit-server-json]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
-      pull-requests: read
     steps:
-      - name: Wait for server.json PR to merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          BRANCH_NAME="${{ needs.update-server-json.outputs.pr_branch }}"
-
-          # If no PR was created (server.json unchanged), skip waiting
-          if [ "$BRANCH_NAME" = "main" ]; then
-            echo "No PR created; server.json unchanged"
-            exit 0
-          fi
-
-          echo "Waiting for PR on branch $BRANCH_NAME to merge (max 5 minutes)..."
-          ELAPSED=0
-          MAX_WAIT=300
-          SLEEP_INTERVAL=30
-
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            STATE=$(gh pr view "$BRANCH_NAME" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
-            echo "PR state: $STATE"
-
-            if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged successfully"
-              exit 0
-            fi
-
-            if [ "$STATE" = "CLOSED" ]; then
-              echo "ERROR: PR was closed without merging"
-              exit 1
-            fi
-
-            sleep $SLEEP_INTERVAL
-            ELAPSED=$((ELAPSED + SLEEP_INTERVAL))
-          done
-
-          echo "ERROR: PR did not merge within 5 minutes"
-          exit 1
-
       - name: Checkout repository at main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

Eliminates the follow-up `chore/registry-update-v*` PR opened after every release. The `update-server-json` job now commits `server.json` directly to `main` using the `github-actions[bot]` bypass actor already configured in the branch ruleset (added in #522).

The release flow collapses from:
```
tag -> build -> open server.json PR -> CI -> merge -> publish
```
to:
```
tag -> build -> commit server.json to main -> publish
```

## Changes

- `.github/workflows/release.yml`: -81 lines, +3 lines (net -78)
  - `update-server-json`: replace PR creation with direct `git push origin main`
  - `update-server-json`: drop `pull-requests: write` permission
  - `update-server-json`: remove `pr_branch` output
  - `publish-registry`: remove PR polling wait loop
  - `publish-registry`: drop `pull-requests: read` permission

## Test plan

- [ ] YAML valid (verified locally)
- [ ] No remaining `pr_branch` references in target jobs (verified)
- [ ] All MUST constraints honored (git fetch, diff guard, --signoff, set -euo pipefail, dry-run condition)
- [ ] Manual release test: trigger a release and confirm `server.json` is committed directly to `main` without a follow-up PR

Fixes #523
