### PR TITLE
fix(ci): decouple publish-registry from server.json PR flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,59 +436,65 @@ jobs:
 
   publish-registry:
     name: Publish to MCP Registry
-    needs: [create-release, update-server-json]
+    needs: [create-release, generate-mcpb]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
-      pull-requests: read
     steps:
-      - name: Wait for server.json PR to merge
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Generate server.json in-place from MCPB SHAs. Intentionally duplicates
+      # the logic from update-server-json so publish-registry does not need to
+      # wait for that job's PR to merge. update-server-json still persists the
+      # file to the repo as a fire-and-forget follow-up.
+      - name: Download MCPB files and compute SHA256
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-
-          BRANCH_NAME="${{ needs.update-server-json.outputs.pr_branch }}"
-
-          # If no PR was created (server.json unchanged), skip waiting
-          if [ "$BRANCH_NAME" = "main" ]; then
-            echo "No PR created; server.json unchanged"
-            exit 0
-          fi
-
-          echo "Waiting for PR on branch $BRANCH_NAME to merge (max 5 minutes)..."
-          ELAPSED=0
-          MAX_WAIT=300
-          SLEEP_INTERVAL=30
-
-          while [ $ELAPSED -lt $MAX_WAIT ]; do
-            STATE=$(gh pr view "$BRANCH_NAME" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
-            echo "PR state: $STATE"
-
-            if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged successfully"
-              exit 0
-            fi
-
-            if [ "$STATE" = "CLOSED" ]; then
-              echo "ERROR: PR was closed without merging"
-              exit 1
-            fi
-
-            sleep $SLEEP_INTERVAL
-            ELAPSED=$((ELAPSED + SLEEP_INTERVAL))
+          
+          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
+          VERSION="${{ needs.create-release.outputs.version }}"
+          
+          declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
+          declare -A shas
+          
+          for target in "${targets[@]}"; do
+            MCPB_NAME="code-analyze-mcp-${VERSION}-${target}.mcpb"
+            DOWNLOAD_URL="https://github.com/clouatre-labs/code-analyze-mcp/releases/download/${RELEASE_TAG}/${MCPB_NAME}"
+            
+            curl -fsSL "$DOWNLOAD_URL" -o "/tmp/${MCPB_NAME}"
+            
+            sha=$(sha256sum "/tmp/${MCPB_NAME}" | cut -d' ' -f1)
+            shas["${target}"]="$sha"
           done
+          
+          # Write to environment for next step
+          echo "SHA_AARCH64_APPLE_DARWIN=${shas[aarch64-apple-darwin]}" >> "$GITHUB_ENV"
+          echo "SHA_AARCH64_LINUX_MUSL=${shas[aarch64-unknown-linux-musl]}" >> "$GITHUB_ENV"
+          echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
 
-          echo "ERROR: PR did not merge within 5 minutes"
-          exit 1
-
-      - name: Checkout repository at main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update server.json with new SHAs and version
+        run: |
+          set -euo pipefail
+          
+          VERSION="${{ needs.create-release.outputs.version }}"
+          
+          jq \
+            --arg version "$VERSION" \
+            --arg sha_darwin "${{ env.SHA_AARCH64_APPLE_DARWIN }}" \
+            --arg sha_linux_arm "${{ env.SHA_AARCH64_LINUX_MUSL }}" \
+            --arg sha_linux_x86 "${{ env.SHA_X86_64_LINUX_MUSL }}" \
+            '.packages[0].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-apple-darwin.mcpb" |
+             .packages[0].fileSha256 = $sha_darwin |
+             .packages[1].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-unknown-linux-musl.mcpb" |
+             .packages[1].fileSha256 = $sha_linux_arm |
+             .packages[2].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-x86_64-unknown-linux-musl.mcpb" |
+             .packages[2].fileSha256 = $sha_linux_x86' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install mcp-publisher
         run: |


### PR DESCRIPTION
## Summary

Fixes #523.

publish-registry now generates server.json in-place from MCPB SHAs (same jq logic as update-server-json) and publishes to the registry immediately, without waiting for a PR to merge. update-server-json continues to run as a fire-and-forget job to persist server.json to the repository.

Also removes the github-actions[bot] bypass actor (actor_id 1143301) added in #522 from the Protect main branch ruleset -- it is no longer needed.

## Changes

- `.github/workflows/release.yml`
  - `publish-registry` needs: `[create-release, update-server-json]` -> `[create-release, generate-mcpb]`
  - Removed "Wait for server.json PR to merge" polling step
  - Removed "Checkout repository at main" step (default checkout at tag ref retained)
  - Added "Download MCPB files and compute SHA256" step (copied from update-server-json)
  - Added "Update server.json with new SHAs and version" jq step (copied from update-server-json)
  - Removed `pull-requests: read` permission (no longer needed)
  - `update-server-json` job: unchanged (runs as fire-and-forget)

## Test plan

- [ ] YAML valid (verified locally with python3 yaml.safe_load)
- [ ] actionlint clean (pre-existing SC2129 warnings in unrelated steps only)
- [ ] needs chain verified: publish-registry no longer lists update-server-json
- [ ] polling step absent
- [ ] jq logic identical to update-server-json
- [ ] bypass actor (1143301) removed from ruleset (verified via gh api)
- [ ] Security scan clean: no secrets or credentials introduced