### PR TITLE
fix(ci): remove path filter from pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,6 @@ on:
       - '.github/workflows/**'
       - 'tests/**'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'clippy.toml'
-      - '.github/workflows/**'
-      - 'tests/**'
-      - 'server.json'
       - '.commitlintrc.yml'
 
 concurrency:


### PR DESCRIPTION
## Summary

The `pull_request` trigger in `ci.yml` had path filters that excluded `docs/**` and `*.md` files. Docs-only PRs never triggered CI, so the required `ci-result` status check never ran and the PR stayed permanently blocked.

The internal `changes` job already gates expensive jobs (format, lint, test, coverage, etc.) on code changes via `dorny/paths-filter`, making the outer trigger-level filter redundant.

## Changes

- `.github/workflows/ci.yml`: remove `paths:` block from `pull_request` trigger

## Test plan

- [ ] A docs-only PR (e.g. #527) should now trigger CI and have `ci-result` report green with all code jobs skipped