### PR TITLE
ci: merge format into lint, drop redundant test job, add explicit CodeQL workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,23 +81,6 @@ jobs:
           fi
           echo "Branch is up to date with main."
 
-  format:
-    name: Check Format
-    runs-on: ubuntu-24.04
-    needs: changes
-    if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
-          components: rustfmt
-      - name: Check formatting
-        run: cargo fmt --check
-
   lint:
     name: Lint
     runs-on: ubuntu-24.04
@@ -111,33 +94,15 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable
-          components: clippy
+          components: rustfmt, clippy
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Check formatting
+        run: cargo fmt --check
       - name: Run Clippy lints
         run: cargo clippy --profile ci -- -D warnings -W clippy::cognitive_complexity
-
-  test:
-    name: Test
-    runs-on: ubuntu-24.04
-    needs: changes
-    if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
-        with:
-          toolchain: stable
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Run tests
-        run: cargo test
 
   coverage:
     name: Coverage
@@ -257,7 +222,7 @@ jobs:
     name: CI Result
     runs-on: ubuntu-24.04
     if: always()
-    needs: [changes, commitlint, check-base, format, lint, test, coverage, deny, msrv, renovate-check, zizmor]
+    needs: [changes, commitlint, check-base, lint, coverage, deny, msrv, renovate-check, zizmor]
     steps:
       - name: Verify all jobs passed or were skipped
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, rust]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Three CI improvements: two speed wins and the Node.js 24 fix.

## Changes

**Add `.github/workflows/codeql.yml`**
The Node.js 20 deprecation warning came from GitHub's Default Setup CodeQL
scan, which internally uses `actions/checkout@v4` (node20). Default Setup is
`not-configured` in this repo, meaning past analyses ran via a now-removed
configuration. Adding an explicit `codeql.yml` takes full ownership:

- `actions/checkout@de0fac2e...` (v6, node24) -- same SHA already in `ci.yml`
- `actions/setup-node@53b83947...` (v6.3.0) with `node-version: '24'` -- uses
  the pre-installed Node 24 from the ubuntu-24.04 image cache, no download
- `github/codeql-action` init and analyze pinned to `5c8a8a64...` (v3.35.1)
- Analyzes `rust` and `actions` languages on push, PR, and weekly schedule
- All SHAs, no tags

**Merge `format` job into `lint`**
Both jobs installed the same Rust toolchain. Moving `cargo fmt --check` as the
first step of `lint` (which already has rust-cache) eliminates one full runner
startup and toolchain download (~23s compute). Components list becomes
`rustfmt, clippy`.

**Drop `test` job**
The `coverage` job runs `cargo llvm-cov` with every test binary listed
explicitly -- the full test suite. The standalone `cargo test` was 100%
redundant. Removing it saves ~53s of compute per run.

## Compute savings

~2 runner-minutes per push/PR. Wall-clock time is unchanged (parallel jobs);
billed compute drops.

## Test plan

- [ ] CI Result passes on this PR
- [ ] Coverage job still enforces the 80% gate
- [ ] Lint job runs both `cargo fmt --check` and `cargo clippy`
- [ ] CodeQL workflow runs clean (analyze rust + actions)
