### PR TITLE
ci: lean CI -- gate zizmor on workflow changes, Rust CodeQL main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -45,6 +46,8 @@ jobs:
               - 'clippy.toml'
               - '.github/workflows/**'
               - 'tests/**'
+            workflows:
+              - '.github/workflows/**'
 
   commitlint:
     name: Lint Commits
@@ -207,7 +210,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: changes
     timeout-minutes: 10
-    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    if: needs.changes.outputs.workflows == 'true' || github.event_name != 'pull_request'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,17 +20,13 @@ permissions:
   contents: read
 
 jobs:
-  analyze:
-    name: Analyze (${{ matrix.language }})
+  analyze-actions:
+    name: Analyze (actions)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [actions, rust]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,10 +39,38 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
-          languages: ${{ matrix.language }}
+          languages: actions
           build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
-          category: /language:${{ matrix.language }}
+          category: /language:actions
+
+  analyze-rust:
+    name: Analyze (rust)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          category: /language:rust


### PR DESCRIPTION
## Summary

Ports the CI simplifications from clouatre-labs/aptu#986 that are applicable to this repo.

## Changes

- `ci.yml`: add a dedicated `workflows` paths-filter output; gate `zizmor` on it instead of `code`, so zizmor only runs on PRs that touch `.github/workflows/**`
- `codeql.yml`: split the `analyze` matrix job into `analyze-actions` (all triggers, 10 min) and `analyze-rust` (main/schedule only, 30 min); avoids the expensive Rust CodeQL build on every PR

## What was not ported

The `build-release` / `integration` fold does not apply -- this repo has no integration test suite.