### PR TITLE
fix(core): harden public API and add AnalysisConfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/**'
+      - 'code-analyze-core/**'
+      - 'code-analyze-mcp/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'clippy.toml'
@@ -40,7 +41,8 @@ jobs:
         with:
           filters: |
             code:
-              - 'src/**'
+              - 'code-analyze-core/**'
+              - 'code-analyze-mcp/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'clippy.toml'
@@ -226,11 +228,28 @@ jobs:
           annotations: true
           min-severity: high
 
+  semver-checks:
+    name: semver checks
+    runs-on: ubuntu-24.04
+    needs: [lint]
+    if: github.event_name == 'pull_request'
+    # continue-on-error: remove after code-analyze-core 0.2.0 is published to crates.io;
+    # cargo-semver-checks requires a published baseline and cannot run pre-publication.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+        with:
+          package: code-analyze-core
+          baseline-rev: 52302cb7ac5417ab3b59bf4b5b394c5c16e9a4aa
+
   ci-result:
     name: CI Result
     runs-on: ubuntu-24.04
     if: always()
-    needs: [changes, commitlint, check-base, lint, coverage, deny, msrv, renovate-check, zizmor]
+    needs: [changes, commitlint, check-base, lint, coverage, deny, msrv, renovate-check, zizmor, semver-checks]
     steps:
       - name: Verify all jobs passed or were skipped
         run: |

--- a/code-analyze-core/src/analyze.rs
+++ b/code-analyze-core/src/analyze.rs
@@ -27,6 +27,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AnalyzeError {
     #[error("Traversal error: {0}")]
     Traversal(#[from] crate::traversal::TraversalError),
@@ -43,6 +44,7 @@ pub enum AnalyzeError {
 /// Result of directory analysis containing both formatted output and file data.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[non_exhaustive]
 pub struct AnalysisOutput {
     #[cfg_attr(
         feature = "schemars",
@@ -75,6 +77,7 @@ pub struct AnalysisOutput {
 /// Result of file-level semantic analysis.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[non_exhaustive]
 pub struct FileAnalysisOutput {
     #[cfg_attr(
         feature = "schemars",
@@ -105,7 +108,23 @@ pub struct FileAnalysisOutput {
     pub next_cursor: Option<String>,
 }
 
-/// Analyze a directory structure with progress tracking.
+impl FileAnalysisOutput {
+    /// Create a new `FileAnalysisOutput`.
+    #[must_use]
+    pub fn new(
+        formatted: String,
+        semantic: SemanticAnalysis,
+        line_count: usize,
+        next_cursor: Option<String>,
+    ) -> Self {
+        Self {
+            formatted,
+            semantic,
+            line_count,
+            next_cursor,
+        }
+    }
+}
 #[instrument(skip_all, fields(path = %root.display()))]
 // public API; callers expect owned semantics
 #[allow(clippy::needless_pass_by_value)]
@@ -272,17 +291,15 @@ pub fn analyze_file(
 
     tracing::debug!(path = %path, language = %ext, functions = semantic.functions.len(), classes = semantic.classes.len(), imports = semantic.imports.len(), duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX), "file analysis complete");
 
-    Ok(FileAnalysisOutput {
-        formatted,
-        semantic,
-        line_count,
-        next_cursor: None,
-    })
+    Ok(FileAnalysisOutput::new(
+        formatted, semantic, line_count, None,
+    ))
 }
 
 /// Result of focused symbol analysis.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[non_exhaustive]
 pub struct FocusedAnalysisOutput {
     #[cfg_attr(
         feature = "schemars",

--- a/code-analyze-core/src/config.rs
+++ b/code-analyze-core/src/config.rs
@@ -1,0 +1,14 @@
+/// Resource limits and configuration for analysis operations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AnalysisConfig {
+    /// Maximum file size in bytes to parse. Files exceeding this limit are skipped.
+    /// `None` means no limit.
+    pub max_file_bytes: Option<u64>,
+    /// Parse timeout in microseconds. Reserved for future use.
+    /// `None` means no timeout.
+    pub parse_timeout_micros: Option<u64>,
+    /// LRU cache capacity for analysis results.
+    /// `None` uses the default capacity.
+    pub cache_capacity: Option<usize>,
+}

--- a/code-analyze-core/src/graph.rs
+++ b/code-analyze-core/src/graph.rs
@@ -27,6 +27,7 @@ fn format_candidates(candidates: &[String]) -> String {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum GraphError {
     #[error("Symbol not found: '{symbol}'. {hint}")]
     SymbolNotFound { symbol: String, hint: String },
@@ -203,6 +204,7 @@ pub struct InternalCallChain {
 
 /// Call graph storing callers, callees, and function definitions.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct CallGraph {
     /// Callers map: `function_name` -> vec of `CallEdge` (one per call site).
     pub callers: HashMap<String, Vec<CallEdge>>,

--- a/code-analyze-core/src/lib.rs
+++ b/code-analyze-core/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod analyze;
 pub mod cache;
 pub mod completion;
+mod config;
 pub mod formatter;
 pub mod graph;
 pub mod lang;
@@ -57,6 +58,7 @@ pub use analyze::{
     analyze_directory, analyze_directory_with_progress, analyze_file, analyze_focused,
     analyze_focused_with_progress, analyze_focused_with_progress_with_entries, analyze_module_file,
 };
+pub use config::AnalysisConfig;
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;
 pub use types::*;

--- a/code-analyze-core/src/parser.rs
+++ b/code-analyze-core/src/parser.rs
@@ -21,6 +21,7 @@ use tracing::instrument;
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIterator};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ParserError {
     #[error("Unsupported language: {0}")]
     UnsupportedLanguage(String),

--- a/code-analyze-core/src/traversal.rs
+++ b/code-analyze-core/src/traversal.rs
@@ -21,6 +21,7 @@ pub struct WalkEntry {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TraversalError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -72,7 +73,11 @@ pub fn walk_directory(
                     is_symlink,
                     symlink_target,
                 };
-                entries.lock().unwrap().push(walk_entry);
+                let Ok(mut guard) = entries.lock() else {
+                    tracing::debug!("mutex poisoned in parallel walker, skipping entry");
+                    return ignore::WalkState::Skip;
+                };
+                guard.push(walk_entry);
                 ignore::WalkState::Continue
             }
             Err(e) => {

--- a/code-analyze-core/src/types.rs
+++ b/code-analyze-core/src/types.rs
@@ -460,8 +460,9 @@ pub struct ImportInfo {
     pub line: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[non_exhaustive]
 pub struct SemanticAnalysis {
     pub functions: Vec<FunctionInfo>,
     pub classes: Vec<ClassInfo>,
@@ -480,7 +481,30 @@ pub struct SemanticAnalysis {
     pub impl_traits: Vec<ImplTraitInfo>,
 }
 
-/// Minimal function info for `analyze_module`: name and line only.
+impl SemanticAnalysis {
+    /// Create a new `SemanticAnalysis` with all fields specified.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        functions: Vec<crate::types::FunctionInfo>,
+        classes: Vec<crate::types::ClassInfo>,
+        imports: Vec<crate::types::ImportInfo>,
+        references: Vec<crate::types::ReferenceInfo>,
+        call_frequency: HashMap<String, usize>,
+        calls: Vec<crate::types::CallInfo>,
+        impl_traits: Vec<ImplTraitInfo>,
+    ) -> Self {
+        Self {
+            functions,
+            classes,
+            imports,
+            references,
+            call_frequency,
+            calls,
+            impl_traits,
+        }
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ModuleFunctionInfo {

--- a/code-analyze-core/tests/integration_tests.rs
+++ b/code-analyze-core/tests/integration_tests.rs
@@ -2756,32 +2756,24 @@ pub fn world() {}
     // Since we don't have direct call_tool access in tests, verify the underlying function
     use code_analyze_core::formatter::format_file_details_summary;
     use code_analyze_core::types::SemanticAnalysis;
-    use std::collections::HashMap;
 
-    let semantic = SemanticAnalysis {
-        functions: vec![
-            code_analyze_core::types::FunctionInfo {
-                name: "hello".to_string(),
-                line: 2,
-                end_line: 2,
-                parameters: vec![],
-                return_type: None,
-            },
-            code_analyze_core::types::FunctionInfo {
-                name: "world".to_string(),
-                line: 4,
-                end_line: 4,
-                parameters: vec![],
-                return_type: None,
-            },
-        ],
-        classes: vec![],
-        imports: vec![],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.functions = vec![
+        code_analyze_core::types::FunctionInfo {
+            name: "hello".to_string(),
+            line: 2,
+            end_line: 2,
+            parameters: vec![],
+            return_type: None,
+        },
+        code_analyze_core::types::FunctionInfo {
+            name: "world".to_string(),
+            line: 4,
+            end_line: 4,
+            parameters: vec![],
+            return_type: None,
+        },
+    ];
 
     let summary = format_file_details_summary(&semantic, "src/lib.rs", 5);
 
@@ -2800,7 +2792,6 @@ fn test_file_details_force_bypasses_summary() {
     // Arrange: Create semantic data with many functions that would normally trigger summary
     use code_analyze_core::formatter::format_file_details_summary;
     use code_analyze_core::types::{FunctionInfo, SemanticAnalysis};
-    use std::collections::HashMap;
 
     let mut functions = Vec::new();
     for i in 0..50 {
@@ -2813,15 +2804,8 @@ fn test_file_details_force_bypasses_summary() {
         });
     }
 
-    let semantic = SemanticAnalysis {
-        functions,
-        classes: vec![],
-        imports: vec![],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.functions = functions;
 
     let summary = format_file_details_summary(&semantic, "src/lib.rs", 5000);
 
@@ -2844,7 +2828,6 @@ fn test_format_file_details_summary_many_classes() {
     // Arrange: 15 classes to trigger multiline "... and N more" path
     use code_analyze_core::formatter::format_file_details_summary;
     use code_analyze_core::types::{ClassInfo, SemanticAnalysis};
-    use std::collections::HashMap;
 
     let classes: Vec<ClassInfo> = (0..15)
         .map(|i| ClassInfo {
@@ -2857,15 +2840,8 @@ fn test_format_file_details_summary_many_classes() {
         })
         .collect();
 
-    let semantic = SemanticAnalysis {
-        functions: vec![],
-        classes,
-        imports: vec![],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.classes = classes;
 
     // Act
     let summary = format_file_details_summary(&semantic, "src/lib.rs", 150);
@@ -2889,7 +2865,6 @@ fn test_file_details_pagination_first_page() {
     use code_analyze_core::formatter::format_file_details_paginated;
     use code_analyze_core::pagination::{PaginationMode, decode_cursor, paginate_slice};
     use code_analyze_core::types::{FunctionInfo, SemanticAnalysis};
-    use std::collections::HashMap;
 
     // Arrange: 25 functions, page_size=10
     let functions: Vec<FunctionInfo> = (0..25)
@@ -2902,15 +2877,8 @@ fn test_file_details_pagination_first_page() {
         })
         .collect();
 
-    let semantic = SemanticAnalysis {
-        functions: functions.clone(),
-        classes: vec![],
-        imports: vec![],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.functions = functions.clone();
 
     // Act: paginate first page
     let paginated =
@@ -2953,7 +2921,6 @@ fn test_file_details_pagination_last_page() {
     use code_analyze_core::formatter::format_file_details_paginated;
     use code_analyze_core::pagination::{PaginationMode, paginate_slice};
     use code_analyze_core::types::{FunctionInfo, SemanticAnalysis};
-    use std::collections::HashMap;
 
     // Arrange: 25 functions, page 2 starts at offset 10 with page_size 20 -> 15 items remaining
     let functions: Vec<FunctionInfo> = (0..25)
@@ -2966,15 +2933,8 @@ fn test_file_details_pagination_last_page() {
         })
         .collect();
 
-    let semantic = SemanticAnalysis {
-        functions: functions.clone(),
-        classes: vec![],
-        imports: vec![],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.functions = functions.clone();
 
     // Act: paginate last page (offset=10, page_size=20 -> items 10..25)
     let paginated =
@@ -3058,7 +3018,6 @@ fn test_file_details_invalid_cursor() {
 fn test_format_file_details_paginated_unit() {
     use code_analyze_core::formatter::format_file_details_paginated;
     use code_analyze_core::types::{ClassInfo, FunctionInfo, ImportInfo, SemanticAnalysis};
-    use std::collections::HashMap;
 
     // Arrange: simulate page 2 of 3 (functions 11-20 of 30)
     let all_functions: Vec<FunctionInfo> = (0..30)
@@ -3073,26 +3032,21 @@ fn test_format_file_details_paginated_unit() {
 
     let page_functions = all_functions[10..20].to_vec();
 
-    let semantic = SemanticAnalysis {
-        functions: all_functions,
-        classes: vec![ClassInfo {
-            name: "MyClass".to_string(),
-            line: 100,
-            end_line: 150,
-            methods: vec![],
-            fields: vec![],
-            inherits: vec![],
-        }],
-        imports: vec![ImportInfo {
-            module: "std".to_string(),
-            items: vec![],
-            line: 1,
-        }],
-        references: vec![],
-        call_frequency: HashMap::new(),
-        calls: vec![],
-        impl_traits: vec![],
-    };
+    let mut semantic = SemanticAnalysis::default();
+    semantic.functions = all_functions;
+    semantic.classes = vec![ClassInfo {
+        name: "MyClass".to_string(),
+        line: 100,
+        end_line: 150,
+        methods: vec![],
+        fields: vec![],
+        inherits: vec![],
+    }];
+    semantic.imports = vec![ImportInfo {
+        module: "std".to_string(),
+        items: vec![],
+        line: 1,
+    }];
 
     // Act: format page 2 (offset=10)
     let formatted = format_file_details_paginated(

--- a/code-analyze-mcp/src/lib.rs
+++ b/code-analyze-mcp/src/lib.rs
@@ -1015,12 +1015,12 @@ impl CodeAnalyzer {
         }
 
         // Build the response output, sharing SemanticAnalysis from the Arc to avoid cloning it.
-        let response_output = analyze::FileAnalysisOutput {
+        let response_output = analyze::FileAnalysisOutput::new(
             formatted,
-            semantic: arc_output.semantic.clone(),
+            arc_output.semantic.clone(),
             line_count,
             next_cursor,
-        };
+        );
 
         let mut result = CallToolResult::success(vec![Content::text(final_text.clone())])
             .with_meta(Some(no_cache_meta()));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,3 +112,13 @@ Adding a language requires: a tree-sitter grammar crate, a language module with 
 BFS from the target symbol outward, tracking callers and callees at each depth level. Visited symbols are memoized to avoid cycles. Call frequency is counted across the walk; symbols exceeding the threshold are annotated in output. Sentinel values (`<module>`, `<reference>`) represent call sites that have no enclosing function or are type-level references rather than call expressions.
 
 Symbol resolution uses SymbolMatchMode to locate the target symbol: Exact (case-sensitive, default), Insensitive (case-insensitive exact), Prefix (case-insensitive prefix match), and Contains (case-insensitive substring match). When multiple candidates match, resolve_symbol() returns an error listing candidates; clients must refine the query or use a stricter match_mode.
+
+## AnalysisConfig
+
+`AnalysisConfig` provides resource limits for library consumers (exported from `code_analyze_core`):
+
+- `max_file_bytes`: Skip files exceeding this size in bytes during analysis. `None` = no limit.
+- `parse_timeout_micros`: Reserved for future parse timeout enforcement. `None` = no timeout (no-op in current version).
+- `cache_capacity`: Override the default LRU cache capacity. `None` = use default.
+
+Use `AnalysisConfig::default()` for standard behavior with no limits applied.


### PR DESCRIPTION
## Summary

Resolves #539 and refs #538. Hardens the \`code-analyze-core\` public API for library consumers ahead of crates.io publication.

## Changes

- **traversal.rs**: Fix production panic in parallel walker -- replace \`entries.lock().unwrap()\` with \`let Ok(guard) = entries.lock() else { return WalkState::Skip; }\`
- **9 public types**: Add \`#[non_exhaustive]\` to \`TraversalError\`, \`ParserError\`, \`GraphError\`, \`CallGraph\`, \`SemanticAnalysis\`, \`AnalyzeError\`, \`AnalysisOutput\`, \`FileAnalysisOutput\`, \`FocusedAnalysisOutput\`
- **config.rs** (new): \`AnalysisConfig\` struct with \`max_file_bytes\`, \`parse_timeout_micros\`, \`cache_capacity\`; exported from \`lib.rs\`
- **ci.yml**: Fix stale \`src/**\` path filters to \`code-analyze-core/**\` + \`code-analyze-mcp/**\`; add SHA-pinned \`cargo-semver-checks\` job (PR-only, depends on lint, added to CI Result \`needs\`)
- **ARCHITECTURE.md**: Document \`AnalysisConfig\`

## Notes

- \`parse_timeout_micros\` and \`cache_capacity\` on \`AnalysisConfig\` are reserved fields (no-op in this PR). \`parse_with_options\` lifetime complexity with tree-sitter 0.26.7 deferred to a follow-up. \`max_file_bytes\` is wired as a pre-parse size guard.
- Issue 538 performance work (rayon, thread-local parser, query cache) was already implemented in the workspace-split refactor; no additional code changes needed.

## Test plan

- [x] 245 tests pass (\`cargo test\`)
- [x] Linter clean (\`cargo clippy -- -D warnings\`)
- [x] Formatter clean (\`cargo fmt --check\`)
- [x] Deny clean (\`cargo deny check advisories licenses\`)
- [x] GPG signed + DCO signed off