### PR TITLE
docs: add per-crate READMEs for 0.2.0 publication

### DIFF
--- a/code-analyze-core/Cargo.toml
+++ b/code-analyze-core/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 description = "Multi-language AST analysis library using tree-sitter"
+readme = "README.md"
 publish = true
 
 [package.metadata.docs.rs]

--- a/code-analyze-core/README.md
+++ b/code-analyze-core/README.md
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 code-analyze-mcp Contributors -->
+
+# code-analyze-core
+
+Core library for code structure analysis using tree-sitter.
+
+[![docs.rs](https://img.shields.io/badge/docs.rs-code--analyze--core-66c2a5?style=flat-square&labelColor=555555&logo=docs.rs)](https://docs.rs/code-analyze-core)
+[![MCP server](https://img.shields.io/badge/MCP-code--analyze--mcp-fc8d62?style=flat-square&labelColor=555555&logo=rust)](https://crates.io/crates/code-analyze-mcp)
+[![REUSE](https://api.reuse.software/badge/github.com/clouatre-labs/code-analyze-mcp)](https://api.reuse.software/info/github.com/clouatre-labs/code-analyze-mcp)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12275/badge)](https://www.bestpractices.dev/projects/12275)
+[![OpenSSF Silver](https://www.bestpractices.dev/projects/12275/badge?level=silver)](https://www.bestpractices.dev/projects/12275/silver)
+
+## Features
+
+- **Directory analysis** - File tree with LOC, function, and class counts
+- **File analysis** - Functions, classes, and imports with signatures and line ranges
+- **Symbol call graphs** - Callers and callees across a directory with configurable depth
+- **Module index** - Lightweight function and import index (~75% smaller than full file analysis)
+- **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Fortran
+- **Pagination** - Cursor-based pagination for large outputs
+- **Caching** - LRU cache for parsed results with mtime-based invalidation
+- **Parallel** - Rayon-based parallel file analysis
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+code-analyze-core = "0.2"
+```
+
+## Example
+
+```rust,no_run
+use code_analyze_core::{analyze_directory, analyze_file, AnalysisConfig};
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Analyze a directory (depth 2, compact summary)
+    let output = analyze_directory("src/", Some(2), true, None, None, false, false).await?;
+    println!("{}", output.formatted);
+
+    // Analyze a single file
+    let output = analyze_file("src/lib.rs", false, None, None, false, false, None, None).await?;
+    println!("{}", output.formatted);
+
+    Ok(())
+}
+```
+
+## Supported Languages
+
+| Language | Extensions |
+|----------|-----------|
+| Rust | `.rs` |
+| Python | `.py` |
+| TypeScript | `.ts`, `.tsx` |
+| Go | `.go` |
+| Java | `.java` |
+| Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` |
+
+## Configuration
+
+`AnalysisConfig` provides resource limits for library consumers:
+
+```rust
+use code_analyze_core::AnalysisConfig;
+
+let config = AnalysisConfig {
+    max_file_bytes: Some(1_000_000), // skip files > 1 MB
+    parse_timeout_micros: None,      // reserved, no-op in 0.2
+    cache_capacity: None,            // use default LRU capacity
+};
+```
+
+## Support
+
+For questions and support, visit [clouatre.ca](https://clouatre.ca/about/).
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/clouatre-labs/code-analyze-mcp/blob/main/LICENSE).

--- a/code-analyze-mcp/Cargo.toml
+++ b/code-analyze-mcp/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 description = "MCP server for multi-language code structure analysis"
+readme = "../../README.md"
 publish = true
 
 [[bin]]


### PR DESCRIPTION
## Summary

- Add \`code-analyze-core/README.md\`: library-focused, aligned with aptu-core structure; includes badges (docs.rs, MCP crate, REUSE, OpenSSF passing + silver), features, installation, example, supported languages, and AnalysisConfig usage.
- Add \`code-analyze-mcp/README.md\`: thin redirect to the main README to avoid content drift.

## Why

Neither crate had a \`README.md\`. Without one, Cargo auto-discovers the workspace root \`README.md\` for both crates on crates.io -- wrong for the library crate whose audience is different.

## Checklist

- [x] code-analyze-core README reviewed
- [x] code-analyze-mcp README reviewed