### PR TITLE
docs: consolidate OpenSSF badge to single entry per readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   <a href="https://api.reuse.software/info/github.com/clouatre-labs/code-analyze-mcp"><img alt="REUSE" src="https://api.reuse.software/badge/github.com/clouatre-labs/code-analyze-mcp" height="20"></a>
   <a href="https://slsa.dev"><img alt="SLSA Level 3" src="https://slsa.dev/images/gh-badge-level3.svg" height="20"></a>
   <a href="https://www.bestpractices.dev/projects/12275"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/12275/badge" height="20"></a>
-  <a href="https://www.bestpractices.dev/projects/12275/silver"><img alt="OpenSSF Silver" src="https://www.bestpractices.dev/projects/12275/badge?level=silver" height="20"></a>
 </p>
 
 <p align="center">Standalone MCP server for code structure analysis using tree-sitter.</p>

--- a/code-analyze-core/README.md
+++ b/code-analyze-core/README.md
@@ -9,7 +9,6 @@ Core library for code structure analysis using tree-sitter.
 [![MCP server](https://img.shields.io/badge/MCP-code--analyze--mcp-fc8d62?style=flat-square&labelColor=555555&logo=rust)](https://crates.io/crates/code-analyze-mcp)
 [![REUSE](https://api.reuse.software/badge/github.com/clouatre-labs/code-analyze-mcp)](https://api.reuse.software/info/github.com/clouatre-labs/code-analyze-mcp)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12275/badge)](https://www.bestpractices.dev/projects/12275)
-[![OpenSSF Silver](https://www.bestpractices.dev/projects/12275/badge?level=silver)](https://www.bestpractices.dev/projects/12275/silver)
 
 ## Features
 


### PR DESCRIPTION
Remove duplicate Silver badge from README.md and code-analyze-core/README.md. The base https://www.bestpractices.dev/projects/12275 badge already displays the highest achieved level (Silver).