### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["code-analyze-core", "code-analyze-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bumps workspace version from 0.2.0 to 0.2.1 to avoid reusing the existing v0.2.0 tag.

## Changes

- `Cargo.toml`: version 0.2.0 -> 0.2.1

## Context

v0.2.0 tag already exists at commit b228dc3 (pre-fix). PR #552 (merged) fixed the crates.io publish pipeline. This version bump allows tagging v0.2.1 without force-pushing the existing tag.