### PR TITLE
fix(publish): fix readme path in code-analyze-mcp Cargo.toml for crates.io

### DIFF
--- a/code-analyze-mcp/Cargo.toml
+++ b/code-analyze-mcp/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 description = "MCP server for multi-language code structure analysis"
-readme = "../../README.md"
+readme = "../README.md"
 publish = true
 
 [[bin]]


### PR DESCRIPTION
## Summary

The `readme` field in `code-analyze-mcp/Cargo.toml` pointed to `../../README.md` (relative from the workspace root), but `cargo publish` resolves paths relative to the crate directory. The correct path is `../README.md`.

## Changes
- `code-analyze-mcp/Cargo.toml`: `readme = "../../README.md"` -> `readme = "../README.md"`

## Test plan
- [ ] `cargo publish -p code-analyze-mcp --dry-run` passes locally