### PR TITLE
fix(graph): improve analyze_symbol error messages with actionable match_mode suggestions

### DIFF
--- a/crates/code-analyze-core/src/analyze.rs
+++ b/crates/code-analyze-core/src/analyze.rs
@@ -475,7 +475,7 @@ fn resolve_symbol(
         } else {
             return Err(crate::graph::GraphError::SymbolNotFound {
                 symbol: params.focus.clone(),
-                hint: "Try match_mode=insensitive for a case-insensitive search.".to_string(),
+                hint: "Try match_mode=insensitive for a case-insensitive search, or match_mode=prefix to list symbols starting with this name.".to_string(),
             }
             .into());
         }

--- a/crates/code-analyze-core/src/graph.rs
+++ b/crates/code-analyze-core/src/graph.rs
@@ -32,7 +32,7 @@ pub enum GraphError {
     #[error("Symbol not found: '{symbol}'. {hint}")]
     SymbolNotFound { symbol: String, hint: String },
     #[error(
-        "Multiple candidates matched '{query}': {candidates_display}. Refine the symbol name or use a stricter match_mode.",
+        "Multiple candidates matched '{query}': {candidates_display}. Use match_mode=exact to target one of the candidates listed above, or refine the symbol name.",
         candidates_display = format_candidates(.candidates)
     )]
     MultipleCandidates {
@@ -83,7 +83,7 @@ pub fn resolve_symbol<'a>(
         0 => {
             let hint = match mode {
                 SymbolMatchMode::Exact => {
-                    "Try match_mode=insensitive for a case-insensitive search.".to_string()
+                    "Try match_mode=insensitive for a case-insensitive search, or match_mode=prefix to list symbols starting with this name.".to_string()
                 }
                 _ => "No symbols matched; try a shorter query or match_mode=contains.".to_string(),
             };
@@ -118,7 +118,7 @@ impl CallGraph {
             }
             return Err(GraphError::SymbolNotFound {
                 symbol: query.to_string(),
-                hint: "Try match_mode=insensitive for a case-insensitive search.".to_string(),
+                hint: "Try match_mode=insensitive for a case-insensitive search, or match_mode=prefix to list symbols starting with this name.".to_string(),
             });
         }
 


### PR DESCRIPTION
## Summary

Closes #560.

Improves `analyze_symbol` error messages so small models in a failure state receive explicit, actionable recovery guidance rather than vague hints.

## Changes

- `crates/code-analyze-core/src/graph.rs`: `SymbolNotFound` exact-mode hint now mentions both `match_mode=insensitive` and `match_mode=prefix`; `MultipleCandidates` sentence now names `match_mode=exact` and references the candidates list
- `crates/code-analyze-core/src/analyze.rs`: same `SymbolNotFound` exact-mode hint update

## Test plan

- [x] All tests pass: `cargo test`
- [x] No clippy warnings: `cargo clippy -- -D warnings`
- [x] Formatted: `cargo fmt --check`
- [x] No secrets: gitleaks clean
- [x] String-only changes; no logic, schema, or variant structure modified