### PR TITLE
chore(registry): convert server.json to static template, generate at release time

### DIFF
--- a/.github/workflows/publish-registry-manual.yml
+++ b/.github/workflows/publish-registry-manual.yml
@@ -23,6 +23,68 @@ jobs:
         with:
           ref: main
 
+      - name: Detect latest release version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(gh release list --limit 1 --json tagName --jq '.[0].tagName | ltrimstr("v")')
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Download MCPB files and compute SHA256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_TAG="v${VERSION}"
+          declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
+          declare -A shas
+
+          for target in "${targets[@]}"; do
+            MCPB_NAME="code-analyze-mcp-${VERSION}-${target}.mcpb"
+            DOWNLOAD_URL="https://github.com/clouatre-labs/code-analyze-mcp/releases/download/${RELEASE_TAG}/${MCPB_NAME}"
+            curl -fsSL "$DOWNLOAD_URL" -o "/tmp/${MCPB_NAME}"
+            sha=$(sha256sum "/tmp/${MCPB_NAME}" | cut -d' ' -f1)
+            shas["${target}"]="$sha"
+          done
+
+          echo "SHA_AARCH64_APPLE_DARWIN=${shas[aarch64-apple-darwin]}" >> "$GITHUB_ENV"
+          echo "SHA_AARCH64_LINUX_MUSL=${shas[aarch64-unknown-linux-musl]}" >> "$GITHUB_ENV"
+          echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
+
+      - name: Build server.json from template
+        run: |
+          set -euo pipefail
+
+          jq \
+            --arg version "$VERSION" \
+            --arg sha_darwin "$SHA_AARCH64_APPLE_DARWIN" \
+            --arg sha_linux_arm "$SHA_AARCH64_LINUX_MUSL" \
+            --arg sha_linux_x86 "$SHA_X86_64_LINUX_MUSL" \
+            '.version = $version |
+             .packages = [
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-apple-darwin.mcpb",
+                 "fileSha256": $sha_darwin,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_arm,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-x86_64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_x86,
+                 "transport": {"type": "stdio"}
+               }
+             ]' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+
       - name: Install mcp-publisher
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,123 +317,6 @@ jobs:
             gh release upload "${RELEASE_TAG}" "/tmp/${MCPB_NAME}" --clobber
           done
 
-  update-server-json:
-    name: Update server.json
-    needs: [create-release, generate-mcpb]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      pr_branch: ${{ steps.push.outputs.pr_branch }}
-    steps:
-      - name: Checkout repository at main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download MCPB files and compute SHA256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          
-          RELEASE_TAG="v${{ needs.create-release.outputs.version }}"
-          VERSION="${{ needs.create-release.outputs.version }}"
-          
-          declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
-          declare -A shas
-          
-          for target in "${targets[@]}"; do
-            MCPB_NAME="code-analyze-mcp-${VERSION}-${target}.mcpb"
-            DOWNLOAD_URL="https://github.com/clouatre-labs/code-analyze-mcp/releases/download/${RELEASE_TAG}/${MCPB_NAME}"
-            
-            curl -fsSL "$DOWNLOAD_URL" -o "/tmp/${MCPB_NAME}"
-            
-            sha=$(sha256sum "/tmp/${MCPB_NAME}" | cut -d' ' -f1)
-            shas["${target}"]="$sha"
-          done
-          
-          # Write to environment for next step
-          echo "SHA_AARCH64_APPLE_DARWIN=${shas[aarch64-apple-darwin]}" >> "$GITHUB_ENV"
-          echo "SHA_AARCH64_LINUX_MUSL=${shas[aarch64-unknown-linux-musl]}" >> "$GITHUB_ENV"
-          echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
-
-      - name: Update server.json with new SHAs and version
-        run: |
-          set -euo pipefail
-          
-          VERSION="${{ needs.create-release.outputs.version }}"
-          
-          jq \
-            --arg version "$VERSION" \
-            --arg sha_darwin "${{ env.SHA_AARCH64_APPLE_DARWIN }}" \
-            --arg sha_linux_arm "${{ env.SHA_AARCH64_LINUX_MUSL }}" \
-            --arg sha_linux_x86 "${{ env.SHA_X86_64_LINUX_MUSL }}" \
-            '.packages[0].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-apple-darwin.mcpb" |
-             .packages[0].fileSha256 = $sha_darwin |
-             .packages[1].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-unknown-linux-musl.mcpb" |
-             .packages[1].fileSha256 = $sha_linux_arm |
-             .packages[2].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-x86_64-unknown-linux-musl.mcpb" |
-             .packages[2].fileSha256 = $sha_linux_x86' \
-            server.json > server.json.tmp && mv server.json.tmp server.json
-
-      - name: Create feature branch and commit server.json
-        id: push
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ needs.create-release.outputs.version }}"
-          BRANCH_NAME="chore/registry-update-v${VERSION}"
-
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-
-          # Only commit and push if server.json has changed
-          if git diff --quiet -- server.json; then
-            echo "server.json unchanged; skipping PR creation"
-            echo "pr_branch=main" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git fetch origin
-          if git ls-remote --exit-code origin "$BRANCH_NAME" 2>/dev/null; then
-            echo "Stale branch $BRANCH_NAME exists, deleting..."
-            git push origin --delete "$BRANCH_NAME"
-          fi
-
-          git checkout -b "$BRANCH_NAME"
-          git add server.json
-          git commit --signoff -m "chore(registry): update server.json for v${VERSION}"
-          git push origin "$BRANCH_NAME"
-          echo "pr_branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Create pull request with auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          VERSION="${{ needs.create-release.outputs.version }}"
-          BRANCH_NAME="chore/registry-update-v${VERSION}"
-
-          # Only create PR if server.json was changed
-          if [ "${{ steps.push.outputs.pr_branch }}" = "main" ]; then
-            echo "server.json unchanged; skipping PR creation"
-            exit 0
-          fi
-
-          gh pr create \
-            --title "chore(registry): update server.json for v${VERSION}" \
-            --body "Automated server.json update with MCPB checksums for release v${VERSION}" \
-            --head "$BRANCH_NAME" \
-            --base main
-
-          # Merge immediately (single-file bot commit, no code to test)
-          gh pr merge "$BRANCH_NAME" --squash --delete-branch
-
   publish-registry:
     name: Publish to MCP Registry
     needs: [create-release, generate-mcpb]
@@ -446,10 +329,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # Generate server.json in-place from MCPB SHAs. Intentionally duplicates
-      # the logic from update-server-json so publish-registry does not need to
-      # wait for that job's PR to merge. update-server-json still persists the
-      # file to the repo as a fire-and-forget follow-up.
       - name: Download MCPB files and compute SHA256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -477,23 +356,38 @@ jobs:
           echo "SHA_AARCH64_LINUX_MUSL=${shas[aarch64-unknown-linux-musl]}" >> "$GITHUB_ENV"
           echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
 
-      - name: Update server.json with new SHAs and version
+      - name: Build server.json from template
         run: |
           set -euo pipefail
-          
+
           VERSION="${{ needs.create-release.outputs.version }}"
-          
+
           jq \
             --arg version "$VERSION" \
-            --arg sha_darwin "${{ env.SHA_AARCH64_APPLE_DARWIN }}" \
-            --arg sha_linux_arm "${{ env.SHA_AARCH64_LINUX_MUSL }}" \
-            --arg sha_linux_x86 "${{ env.SHA_X86_64_LINUX_MUSL }}" \
-            '.packages[0].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-apple-darwin.mcpb" |
-             .packages[0].fileSha256 = $sha_darwin |
-             .packages[1].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-unknown-linux-musl.mcpb" |
-             .packages[1].fileSha256 = $sha_linux_arm |
-             .packages[2].identifier = "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-x86_64-unknown-linux-musl.mcpb" |
-             .packages[2].fileSha256 = $sha_linux_x86' \
+            --arg sha_darwin "$SHA_AARCH64_APPLE_DARWIN" \
+            --arg sha_linux_arm "$SHA_AARCH64_LINUX_MUSL" \
+            --arg sha_linux_x86 "$SHA_X86_64_LINUX_MUSL" \
+            '.version = $version |
+             .packages = [
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-apple-darwin.mcpb",
+                 "fileSha256": $sha_darwin,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-aarch64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_arm,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v\($version)/code-analyze-mcp-\($version)-x86_64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_x86,
+                 "transport": {"type": "stdio"}
+               }
+             ]' \
             server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install mcp-publisher

--- a/server.json
+++ b/server.json
@@ -1,37 +1,11 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.clouatre-labs/code-analyze-mcp",
-  "version": "0.1.11",
   "title": "Code Analyze MCP",
   "description": "MCP server for code structure analysis using tree-sitter.",
   "repository": {
     "url": "https://github.com/clouatre-labs/code-analyze-mcp",
     "source": "github"
   },
-  "packages": [
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.2.1/code-analyze-mcp-0.2.1-aarch64-apple-darwin.mcpb",
-      "fileSha256": "0422bbad43de8f7d08677797035ba9908527e72281fc279b0394dc2b3e7bebe3",
-      "transport": {
-        "type": "stdio"
-      }
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.2.1/code-analyze-mcp-0.2.1-aarch64-unknown-linux-musl.mcpb",
-      "fileSha256": "5eb7056f305531091e487a7621059e74a9a10bd80a0d7780196976fd98c4b077",
-      "transport": {
-        "type": "stdio"
-      }
-    },
-    {
-      "registryType": "mcpb",
-      "identifier": "https://github.com/clouatre-labs/code-analyze-mcp/releases/download/v0.2.1/code-analyze-mcp-0.2.1-x86_64-unknown-linux-musl.mcpb",
-      "fileSha256": "c31a1e31baf1af2a95d6ffb0bb47147fe715ad69e832a25338700d7e65bb2c6c",
-      "transport": {
-        "type": "stdio"
-      }
-    }
-  ]
+  "packages": []
 }


### PR DESCRIPTION
## Summary

`server.json` previously embedded the version string, package download URLs, and `fileSha256` hashes for each release artifact. These values can only be known after the MCPB bundles are built and uploaded, which made the committed file always one release stale and required a post-release auto-PR on every tag to patch it.

## Changes

- **`server.json`** -- stripped to static metadata only (name, title, description, repository). No version, no packages, no SHAs.
- **`release.yml`** -- removed the `update-server-json` job (120 lines of post-release PR machinery). Added a "Build server.json from template" step to `publish-registry` that constructs the full file from the MCPB SHAs computed in the prior step.
- **`publish-registry-manual.yml`** -- rewritten to detect the latest release tag via `gh release list`, download its MCPB artifacts, compute SHAs, and build `server.json` before publishing. Matches the release job pattern exactly.

## Why

`fileSha256` is required by the registry schema and must be computed from the actual artifact binary. There is no way to know it before the build. Committing it post-release via an automated PR was purely overhead with no benefit -- the `publish-registry` job already computed and used the correct values independently.