### PR TITLE
chore: add glama.json to claim server listing on glama.ai

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["clouatre"]
+}


### PR DESCRIPTION
Adds `glama.json` to the repo root to claim ownership of the server listing on [glama.ai](https://glama.ai/mcp/servers), the largest MCP directory (17,000+ servers).

## Changes

- `glama.json` -- maintainer claim file for glama.ai, org repos require this file for ownership verification

## After merge

Go through the Claim ownership flow on glama.ai to trigger discovery and associate the listing with the `clouatre-labs` org.