### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "criterion",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "code-analyze-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version from 0.2.1 to 0.2.2 in preparation for release.

## Changes
- `Cargo.toml`: version 0.2.1 -> 0.2.2
- `Cargo.lock`: updated workspace crate entries