### PR TITLE
test(annotations): assert description completeness, flatten propagation, and schema examples

### DIFF
--- a/crates/code-analyze-core/src/types.rs
+++ b/crates/code-analyze-core/src/types.rs
@@ -103,6 +103,7 @@ pub struct AnalyzeFileParams {
     /// Omitting this field returns all sections (current behavior).
     /// Ignored when summary=true (summary takes precedence).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("examples" = [["functions", "classes"], ["functions"], ["imports"]]))]
     pub fields: Option<Vec<AnalyzeFileField>>,
 
     #[serde(flatten)]
@@ -145,6 +146,7 @@ pub struct AnalyzeSymbolParams {
     pub symbol: String,
 
     /// Symbol matching mode (default: exact). exact: case-sensitive exact match. insensitive: case-insensitive exact match. prefix: case-insensitive prefix match. contains: case-insensitive substring match. When exact match fails, retry with insensitive. When prefix or contains returns multiple candidates, the response lists them so you can refine.
+    #[schemars(extend("examples" = ["exact", "insensitive", "prefix", "contains"]))]
     pub match_mode: Option<SymbolMatchMode>,
 
     /// Call graph traversal depth for this tool (default 1). Level 1 = direct callers and callees; level 2 = one more hop, etc. Output size grows exponentially with graph branching. Warn user on levels above 2.

--- a/crates/code-analyze-mcp/src/metrics.rs
+++ b/crates/code-analyze-mcp/src/metrics.rs
@@ -329,24 +329,19 @@ mod tests {
     async fn test_cleanup_old_files_deletes_old_keeps_recent() {
         use tempfile::TempDir;
 
-        // Today = 2026-03-28 (hard-coded to match plan; adjust if re-run later)
-        // 31 days ago = 2026-02-25; 29 days ago = 2026-02-27
+        // Create a file with a date far in the past (1970-01-01) which should be deleted,
+        // and a file with today's date which should be kept.
         let dir = TempDir::new().unwrap();
-        let old_file = dir.path().join("metrics-2026-02-25.jsonl");
-        let recent_file = dir.path().join("metrics-2026-02-27.jsonl");
+        let old_file = dir.path().join("metrics-1970-01-01.jsonl");
+        let today = current_date_str();
+        let recent_file = dir.path().join(format!("metrics-{}.jsonl", today));
         std::fs::write(&old_file, "old\n").unwrap();
         std::fs::write(&recent_file, "recent\n").unwrap();
 
         cleanup_old_files(dir.path()).await;
 
-        assert!(
-            !old_file.exists(),
-            "31-day-old file should have been deleted"
-        );
-        assert!(
-            recent_file.exists(),
-            "29-day-old file should have been kept"
-        );
+        assert!(!old_file.exists(), "old file should have been deleted");
+        assert!(recent_file.exists(), "today's file should have been kept");
     }
 
     #[test]

--- a/crates/code-analyze-mcp/tests/annotations.rs
+++ b/crates/code-analyze-mcp/tests/annotations.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 code-analyze-mcp contributors
 // SPDX-License-Identifier: Apache-2.0
 use code_analyze_mcp::CodeAnalyzer;
+use serde_json::Value;
 
 #[test]
 fn test_all_tools_have_correct_annotations() {
@@ -51,6 +52,106 @@ fn test_all_tools_have_correct_annotations() {
             Some(false),
             "tool {} must have open_world_hint=false",
             name
+        );
+    }
+}
+
+#[test]
+fn test_all_tools_have_non_empty_descriptions() {
+    let tools = CodeAnalyzer::list_tools();
+    for tool in &tools {
+        let name = tool.name.as_ref();
+        let desc = tool.description.as_deref().unwrap_or("");
+        assert!(
+            !desc.is_empty(),
+            "tool '{}' has an empty or missing description",
+            name
+        );
+    }
+}
+
+#[test]
+fn test_all_tool_parameters_have_descriptions() {
+    let tools = CodeAnalyzer::list_tools();
+    for tool in &tools {
+        let tool_name = tool.name.as_ref();
+        let schema = &tool.input_schema;
+        let properties = match schema.get("properties").and_then(Value::as_object) {
+            Some(p) => p,
+            None => continue,
+        };
+        for (param_name, param_schema) in properties.iter() {
+            let desc = param_schema
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            assert!(
+                !desc.is_empty(),
+                "tool '{}' parameter '{}' has an empty or missing description in inputSchema",
+                tool_name,
+                param_name
+            );
+        }
+    }
+}
+
+#[test]
+fn test_flatten_fields_have_descriptions() {
+    let tools = CodeAnalyzer::list_tools();
+    let flatten_fields = ["cursor", "page_size", "summary", "force", "verbose"];
+    for tool in &tools {
+        let tool_name = tool.name.as_ref();
+        if tool_name == "analyze_module" {
+            continue;
+        }
+        let properties = match tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+        {
+            Some(p) => p,
+            None => continue,
+        };
+        for field in &flatten_fields {
+            if let Some(param_schema) = properties.get(*field) {
+                let desc = param_schema
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                assert!(
+                    !desc.is_empty(),
+                    "tool '{}' flattened field '{}' is missing a description in inputSchema",
+                    tool_name,
+                    field
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_complex_params_have_examples() {
+    let tools = CodeAnalyzer::list_tools();
+    let checks: &[(&str, &str)] = &[("analyze_file", "fields"), ("analyze_symbol", "match_mode")];
+    for (tool_name, param_name) in checks {
+        let tool = tools
+            .iter()
+            .find(|t| t.name.as_ref() == *tool_name)
+            .unwrap_or_else(|| panic!("tool '{}' not found", tool_name));
+        let properties = tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("tool '{}' has no properties", tool_name));
+        let param = properties
+            .get(*param_name)
+            .unwrap_or_else(|| panic!("tool '{}' has no parameter '{}'", tool_name, param_name));
+        let examples = param.get("examples").and_then(Value::as_array);
+        assert!(
+            examples.map_or(false, |arr| !arr.is_empty()),
+            "tool '{}' parameter '{}' is missing a JSON Schema 'examples' array",
+            tool_name,
+            param_name
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds four Rust tests to `crates/code-analyze-mcp/tests/annotations.rs` that catch annotation quality regressions at compile/test time, since no ecosystem-level MCP linting tooling exists for this. Adds `examples` arrays to two complex parameters to improve LLM sampling accuracy.

## Changes

- `crates/code-analyze-mcp/tests/annotations.rs`: four new tests (see below)
- `crates/code-analyze-core/src/types.rs`: `#[schemars(extend("examples" = [...]))]` on `AnalyzeFileParams.fields` and `AnalyzeSymbolParams.match_mode`
- `crates/code-analyze-mcp/src/metrics.rs`: fix fragile cleanup test that hardcoded a 2026-03-28 date string

## New tests

| Test | What it catches |
|---|---|
| `test_all_tools_have_non_empty_descriptions` | Tool with empty or missing `description` string |
| `test_all_tool_parameters_have_descriptions` | Parameter added without a `///` doc comment (schemars emits empty `description`) |
| `test_flatten_fields_have_descriptions` | schemars version bump silently dropping descriptions through `#[serde(flatten)]` |
| `test_complex_params_have_examples` | `Vec<enum>` or multi-variant enum param missing a JSON Schema `examples` array |

## CI impact

None. All four tests run as part of `cargo test` (already in CI). No new dependencies, no new CI jobs, no Node.js.

## Test plan
- [x] `cargo test` -- 30 passed, 0 failed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo deny check advisories licenses` -- clean