### PR TITLE
docs: annotate build-and-attest.yml with SLSA v1.0 Build Level 3 rationale

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -1,3 +1,7 @@
+# SLSA v1.0 Build Level 3: this workflow is a reusable workflow (workflow_call).
+# The reusable workflow boundary isolates the build and attestation steps from the
+# caller, satisfying the Level 3 isolation requirement per GitHub's documentation:
+# https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
 name: Build and Attest
 
 on:


### PR DESCRIPTION
## Summary

`build-and-attest.yml` is a reusable workflow (`workflow_call`). The reusable workflow boundary isolates build and attestation steps from the caller, satisfying SLSA v1.0 Build Level 3. Without an explicit comment, the file is easy to misread as Level 2 -- as noted in a recent audit report.

This mirrors the change made in clouatre-labs/aptu#1053.

Reference: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3

## Changes

- `.github/workflows/build-and-attest.yml`: four-line comment added at the top citing the GitHub docs URL and explaining the Level 3 basis

## Test plan

- [ ] No functional changes; comment only