### PR TITLE
fix(types): gate schemars(extend) attributes behind cfg feature flag

### DIFF
--- a/crates/code-analyze-core/src/types.rs
+++ b/crates/code-analyze-core/src/types.rs
@@ -104,7 +104,7 @@ pub struct AnalyzeFileParams {
     /// Omitting this field returns all sections (current behavior).
     /// Ignored when summary=true (summary takes precedence).
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("examples" = [["functions", "classes"], ["functions"], ["imports"]]))]
+    #[cfg_attr(feature = "schemars", schemars(extend("examples" = [["functions", "classes"], ["functions"], ["imports"]])))]
     pub fields: Option<Vec<AnalyzeFileField>>,
 
     #[serde(flatten)]
@@ -147,7 +147,7 @@ pub struct AnalyzeSymbolParams {
     pub symbol: String,
 
     /// Symbol matching mode (default: exact). exact: case-sensitive exact match. insensitive: case-insensitive exact match. prefix: case-insensitive prefix match. contains: case-insensitive substring match. When exact match fails, retry with insensitive. When prefix or contains returns multiple candidates, the response lists them so you can refine.
-    #[schemars(extend("examples" = ["exact", "insensitive", "prefix", "contains"]))]
+    #[cfg_attr(feature = "schemars", schemars(extend("examples" = ["exact", "insensitive", "prefix", "contains"])))]
     pub match_mode: Option<SymbolMatchMode>,
 
     /// Call graph traversal depth for this tool (default 1). Level 1 = direct callers and callees; level 2 = one more hop, etc. Output size grows exponentially with graph branching. Warn user on levels above 2.


### PR DESCRIPTION
## Summary

The two `#[schemars(extend(...))]` attributes added in #590 on `AnalyzeFileParams.fields` and `AnalyzeSymbolParams.match_mode` were unconditional. When `cargo publish` verifies the `code-analyze-core` crate tarball without the `schemars` feature, the attribute is unknown and compilation fails.

This is the root cause of the Release workflow failure on v0.2.3.

## Changes

- `crates/code-analyze-core/src/types.rs`: wrap both `#[schemars(extend(...))]` with `#[cfg_attr(feature = "schemars", schemars(...))]`, matching the existing pattern used throughout the file.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build -p code-analyze-core --no-default-features` (simulates publish verification) must succeed