### PR TITLE
chore: bump workspace version to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version from 0.2.3 to 0.2.4.

v0.2.3 was never published to crates.io due to a compile error (#600) discovered after the tag was cut. v0.2.4 includes the fix and is the first version that will successfully publish both crates.

## Changes
- `Cargo.toml`: workspace version 0.2.3 → 0.2.4