### PR TITLE
chore: bump workspace version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64",
  "criterion",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "code-analyze-core",


### PR DESCRIPTION
Bump workspace version from 0.2.3 to 0.2.4.

v0.2.3 was tagged but never successfully published to crates.io due to a compile error when building `code-analyze-core` without the `schemars` feature (unconditional `#[schemars(extend(...)]` attributes introduced in #590, fixed in #600). This release includes that fix.