### PR TITLE
ci: add aptu PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,32 @@
+name: Triage Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  review:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Review PR
+        uses: clouatre-labs/aptu@5f42e4cc76b092579db59a3c41eb5a9eaddcfb06 # v0.2.22
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          provider: gemini
+          model: gemini-3.1-flash-lite-preview
+          skip-labeled: 'false'
+          fallback-provider: 'openrouter'
+          fallback-model: 'inception/mercury-2'


### PR DESCRIPTION
## Summary

Adds the aptu AI-powered PR review workflow, mirroring the setup in clouatre-labs/aptu.

## Changes

- `.github/workflows/pr-review.yml` -- triggers on PR open/synchronize; uses `clouatre-labs/aptu@5f42e4cc` (v0.2.22); Gemini primary, OpenRouter fallback; `continue-on-error: true` (advisory only)

## Prerequisites

- `GEMINI_API_KEY` secret added to repo
- `OPENROUTER_API_KEY` secret added to repo

## Test plan

- [ ] Open a PR after merge; confirm aptu posts a review comment