### PR TITLE
docs: update README, ARCHITECTURE, and ROADMAP for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To build with a subset of languages, disable default features and opt in:
 
 ```toml
 [dependencies]
-code-analyze-core = { version = "0.2", default-features = false, features = ["lang-rust", "lang-python"] }
+code-analyze-core = { version = "0.3", default-features = false, features = ["lang-rust", "lang-python"] }
 ```
 
 ## Installation
@@ -204,6 +204,8 @@ Builds a call graph for a named symbol across all files in a directory. Uses sen
   - `prefix`: Case-insensitive prefix match; returns an error listing candidates when multiple symbols match
   - `contains`: Case-insensitive substring match; returns an error listing candidates when multiple symbols match
   All non-exact modes return an error with candidate names when the match is ambiguous; use the listed candidates to refine to a unique match.
+
+The tool also returns `structuredContent` with typed arrays for programmatic consumption: `callers` (production callers), `test_callers` (callers from test files), and `callees` (direct callees), each as `Option<Vec<CallChainEntry>>`. A `CallChainEntry` has three fields: `symbol` (string), `file` (string), `line` (u32). These arrays represent depth-1 relationships only; `follow_depth` does not affect them.
 
 **Example output:**
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Builds a call graph for a named symbol across all files in a directory. Uses sen
   - `contains`: Case-insensitive substring match; returns an error listing candidates when multiple symbols match
   All non-exact modes return an error with candidate names when the match is ambiguous; use the listed candidates to refine to a unique match.
 
-The tool also returns `structuredContent` with typed arrays for programmatic consumption: `callers` (production callers), `test_callers` (callers from test files), and `callees` (direct callees), each as `Option<Vec<CallChainEntry>>`. A `CallChainEntry` has three fields: `symbol` (string), `file` (string), `line` (u32). These arrays represent depth-1 relationships only; `follow_depth` does not affect them.
+The tool also returns `structuredContent` with typed arrays for programmatic consumption: `callers` (production callers), `test_callers` (callers from test files), and `callees` (direct callees), each as `Option<Vec<CallChainEntry>>`. A `CallChainEntry` has three fields: `symbol` (string), `file` (string), and `line` (JSON integer; `usize` in the Rust API). These arrays represent depth-1 relationships only; `follow_depth` does not affect them.
 
 **Example output:**
 

--- a/crates/code-analyze-core/README.md
+++ b/crates/code-analyze-core/README.md
@@ -18,6 +18,7 @@ Core library for code structure analysis using tree-sitter.
 - **File analysis** - Functions, classes, and imports with signatures and line ranges
 - **Symbol call graphs** - Callers and callees across a directory with configurable depth
 - **Module index** - Lightweight function and import index (~75% smaller than full file analysis)
+- **In-memory analysis** - `analyze_str` parses source text directly without a file path; returns the same `FileAnalysisOutput` as `analyze_file`
 - **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Fortran, JavaScript, C/C++, C#
 - **Pagination** - Cursor-based pagination for large outputs
 - **Caching** - LRU cache for parsed results with mtime-based invalidation
@@ -29,13 +30,13 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-code-analyze-core = "0.2"
+code-analyze-core = "0.3"
 ```
 
 ## Example
 
 ```rust,no_run
-use code_analyze_core::{analyze_directory, analyze_file, AnalysisConfig};
+use code_analyze_core::{analyze_directory, analyze_file, analyze_str, AnalysisConfig};
 use anyhow::Result;
 
 #[tokio::main]
@@ -46,6 +47,11 @@ async fn main() -> Result<()> {
 
     // Analyze a single file
     let output = analyze_file("src/lib.rs", false, None, None, false, false, None, None).await?;
+    println!("{}", output.formatted);
+
+    // Analyze source text in memory (no file path required)
+    let source = std::fs::read_to_string("src/lib.rs")?;
+    let output = analyze_str(&source, "rs", None).await?;
     println!("{}", output.formatted);
 
     Ok(())
@@ -76,7 +82,7 @@ use code_analyze_core::AnalysisConfig;
 
 let config = AnalysisConfig {
     max_file_bytes: Some(1_000_000), // skip files > 1 MB
-    parse_timeout_micros: None,      // reserved, no-op in 0.2
+    parse_timeout_micros: None,      // reserved, no-op in 0.3
     cache_capacity: None,            // use default LRU capacity
 };
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,24 +20,25 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 
 | Module | File | Responsibility |
 |--------|------|-----------------|
-| `main` | `src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
-| `lib` | `src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` |
-| `analyze` | `src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
-| `parser` | `src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
-| `formatter` | `src/formatter.rs` | Output formatting for all four tools |
-| `traversal` | `src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
-| `types` | `src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
-| `lang` | `src/lang.rs` | Extension-to-language mapping |
-| `languages/mod` | `src/languages/mod.rs` | LanguageInfo registry and handler function types |
-| `languages/rust` | `src/languages/rust.rs` | Rust-specific queries and semantic handlers |
-| `cache` | `src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
-| `completion` | `src/completion.rs` | Path completion support respecting .gitignore |
-| `logging` | `src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
-| `schema_helpers` | `src/schema_helpers.rs` | JSON Schema helpers for integer and page_size field validation |
-| `test_detection` | `src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |
-| `pagination` | `src/pagination.rs` | Cursor-based pagination with CursorData and PaginationMode (Default, Callers, Callees) |
-| `graph` | `src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
-| `metrics` | `src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
+| `main` | `crates/code-analyze-mcp/src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
+| `lib` | `crates/code-analyze-mcp/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` |
+| `logging` | `crates/code-analyze-mcp/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
+| `schema_helpers` | `crates/code-analyze-mcp/src/schema_helpers.rs` | JSON Schema helpers for integer and page_size field validation |
+| `metrics` | `crates/code-analyze-mcp/src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
+| `analyze` | `crates/code-analyze-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
+| `analyze_str` | `crates/code-analyze-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
+| `parser` | `crates/code-analyze-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
+| `formatter` | `crates/code-analyze-core/src/formatter.rs` | Output formatting for all four tools |
+| `traversal` | `crates/code-analyze-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
+| `types` | `crates/code-analyze-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
+| `lang` | `crates/code-analyze-core/src/lang.rs` | Extension-to-language mapping |
+| `languages/mod` | `crates/code-analyze-core/src/languages/mod.rs` | LanguageInfo registry and handler function types |
+| `languages/rust` | `crates/code-analyze-core/src/languages/rust.rs` | Rust-specific queries and semantic handlers |
+| `cache` | `crates/code-analyze-core/src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
+| `completion` | `crates/code-analyze-core/src/completion.rs` | Path completion support respecting .gitignore |
+| `test_detection` | `crates/code-analyze-core/src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |
+| `pagination` | `crates/code-analyze-core/src/pagination.rs` | Cursor-based pagination with CursorData and PaginationMode (Default, Callers, Callees) |
+| `graph` | `crates/code-analyze-core/src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
 
 ## Data Flow
 
@@ -89,6 +90,15 @@ graph TD
 3. Returns a minimal fixed schema: `name`, `line_count`, `language`, `functions[{name, line}]`, `imports[{module, items}]`
 4. No call graph, no type references, no field accesses -- output is ~75% smaller than `analyze_file`
 
+### analyze_str (In-Memory Parsing)
+
+1. Accept `source: &str`, `language: &str`, and `ast_recursion_limit: Option<u32>` -- no filesystem I/O
+2. Resolve language string to a `LanguageInfo` entry; return `Err(AnalyzeError::UnsupportedLanguage(language.to_string()))` if not found
+3. Run `SemanticExtractor` on the source bytes directly
+4. Return `Ok(FileAnalysisOutput)` on success
+
+Exported from `code_analyze_core` as a public API for library consumers that hold source text in memory (e.g. language servers, test harnesses) without a corresponding on-disk path. Eliminates the TOCTOU race and I/O overhead of writing a temp file first.
+
 ### analyze_symbol (Symbol Call Graph)
 
 1. Walk entire directory to build symbol index
@@ -96,6 +106,13 @@ graph TD
 3. Sentinel values: `<module>` for top-level calls, `<reference>` for type references
 4. Symbols called >3x marked with `•N`
 5. Format as FOCUS/DEPTH/DEFINED/CALLERS/CALLEES sections
+
+**Structured output:** In addition to formatted text, `analyze_symbol` populates three fields on `FocusedAnalysisOutput` for programmatic consumption:
+- `callers: Option<Vec<CallChainEntry>>` -- depth-1 production callers
+- `test_callers: Option<Vec<CallChainEntry>>` -- depth-1 callers from test files
+- `callees: Option<Vec<CallChainEntry>>` -- depth-1 callees
+
+`CallChainEntry` is a stable public type (exported from `code_analyze_core`) with fields `symbol: String`, `file: String`, `line: u32`. Conversion from the internal `InternalCallChain` (which is non-serializable and stays internal) happens at the output boundary via the private `chains_to_entries` helper. The `follow_depth` parameter does not affect these arrays; they always represent depth-1 relationships.
 
 ## Language Handler System
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `main` | `crates/code-analyze-mcp/src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
 | `lib` | `crates/code-analyze-mcp/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` |
 | `logging` | `crates/code-analyze-mcp/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
-| `schema_helpers` | `crates/code-analyze-mcp/src/schema_helpers.rs` | JSON Schema helpers for integer and page_size field validation |
+| `schema_helpers` | `crates/code-analyze-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
 | `metrics` | `crates/code-analyze-mcp/src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
 | `analyze` | `crates/code-analyze-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/code-analyze-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
@@ -92,7 +92,7 @@ graph TD
 
 ### analyze_str (In-Memory Parsing)
 
-1. Accept `source: &str`, `language: &str`, and `ast_recursion_limit: Option<u32>` -- no filesystem I/O
+1. Accept `source: &str`, `language: &str`, and `ast_recursion_limit: Option<usize>` -- no filesystem I/O
 2. Resolve language string to a `LanguageInfo` entry; return `Err(AnalyzeError::UnsupportedLanguage(language.to_string()))` if not found
 3. Run `SemanticExtractor` on the source bytes directly
 4. Return `Ok(FileAnalysisOutput)` on success
@@ -112,7 +112,7 @@ Exported from `code_analyze_core` as a public API for library consumers that hol
 - `test_callers: Option<Vec<CallChainEntry>>` -- depth-1 callers from test files
 - `callees: Option<Vec<CallChainEntry>>` -- depth-1 callees
 
-`CallChainEntry` is a stable public type (exported from `code_analyze_core`) with fields `symbol: String`, `file: String`, `line: u32`. Conversion from the internal `InternalCallChain` (which is non-serializable and stays internal) happens at the output boundary via the private `chains_to_entries` helper. The `follow_depth` parameter does not affect these arrays; they always represent depth-1 relationships.
+`CallChainEntry` is a stable public type (exported from `code_analyze_core`) with fields `symbol: String`, `file: String`, `line: usize`. Conversion from the internal `InternalCallChain` (which is non-serializable and stays internal) happens at the output boundary via the private `chains_to_entries` helper. The `follow_depth` parameter does not affect these arrays; they always represent depth-1 relationships.
 
 ## Language Handler System
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,17 @@ Key changes:
 - #356: Idempotency audit and cross-client compatibility verification
 - #357: ROADMAP.md and OBSERVABILITY.md documentation
 
+### [Complete] 0.3.0 Library API
+
+Issues: #623, #624, #625.
+
+Extends `code-analyze-core` with a stable public library API and structured output for programmatic consumption.
+
+Key changes:
+- #623: `analyze_str(source, language, ast_recursion_limit)` -- public in-memory parsing API; eliminates TOCTOU race for consumers holding source text without an on-disk path; adds `AnalyzeError::UnsupportedLanguage` variant
+- #624: `CallChainEntry { symbol, file, line }` public type; `callers`, `test_callers`, `callees` fields on `FocusedAnalysisOutput`; MCP clients can now consume caller/callee relationships from `structured_content` without text parsing
+- #625: `analyze_symbol` tool description updated to accurately reflect `FocusedAnalysisOutput` schema
+
 ### [Benchmarking] Wave 7: OpenFAST Fortran Analysis (v13)
 
 2x2 factorial design (model x tool_set) on Fortran scientific HPC code (OpenFAST). See [v13 methodology](docs/benchmarks/v13/methodology.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ Issues: #623, #624, #625.
 
 Key changes:
 - #623: `analyze_str(source, language, ast_recursion_limit)` -- public in-memory parsing API; eliminates TOCTOU race for consumers holding source text without an on-disk path; adds `AnalyzeError::UnsupportedLanguage` variant
-- #624: `CallChainEntry { symbol, file, line }` public type; `callers`, `test_callers`, `callees` fields on `FocusedAnalysisOutput`; MCP clients can now consume caller/callee relationships from `structured_content` without text parsing
+- #624: `CallChainEntry { symbol, file, line }` public type; `callers`, `test_callers`, `callees` fields on `FocusedAnalysisOutput`; MCP clients can now consume caller/callee relationships from `structuredContent` without text parsing
 - #625: `analyze_symbol` tool description updated to accurately reflect `FocusedAnalysisOutput` schema
 
 ### [Benchmarking] Wave 7: OpenFAST Fortran Analysis (v13)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,9 +32,9 @@ Key changes:
 
 ### [Complete] 0.3.0 Library API
 
-Issues: #623, #624, #625.
+Promotes `code-analyze-core` to a stable public library API and adds structured output fields for programmatic consumption without text parsing.
 
-Extends `code-analyze-core` with a stable public library API and structured output for programmatic consumption.
+Issues: #623, #624, #625.
 
 Key changes:
 - #623: `analyze_str(source, language, ast_recursion_limit)` -- public in-memory parsing API; eliminates TOCTOU race for consumers holding source text without an on-disk path; adds `AnalyzeError::UnsupportedLanguage` variant


### PR DESCRIPTION
## Summary

Documentation-only update to reflect features shipped in 0.3.0 (PRs #626, #627, #628). No source code changes.

## Changes

- **README.md**: bump dependency version example from `"0.2"` to `"0.3"`; add `structuredContent` paragraph under `analyze_symbol` documenting `callers`, `test_callers`, `callees` arrays and the `CallChainEntry` type
- **docs/ARCHITECTURE.md**: fix module map paths to reflect two-crate workspace layout (`crates/code-analyze-core/src/` and `crates/code-analyze-mcp/src/`); add `analyze_str` row to module map; add `analyze_str` Analysis Mode section documenting the public in-memory API and `AnalyzeError::UnsupportedLanguage`; document `CallChainEntry` public type and three new fields on `FocusedAnalysisOutput` under the `analyze_symbol` section
- **docs/ROADMAP.md**: insert `[Complete] 0.3.0 Library API` wave block between Wave 6 and Wave 7, listing issues #623, #624, #625 with one-line descriptions

## Test plan

- [x] Zero `.rs` files modified
- [x] All existing content preserved; only targeted additions and corrections made
- [x] Markdown well-formed (no broken tables or unclosed fences)