### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-core"
-version = "0.4.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "criterion",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.4.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "code-analyze-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Hugues Clouatre"]

--- a/crates/code-analyze-mcp/Cargo.toml
+++ b/crates/code-analyze-mcp/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-code-analyze-core = { path = "../code-analyze-core", version = "0.4", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+code-analyze-core = { path = "../code-analyze-core", version = "0.3", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }


### PR DESCRIPTION
Corrects workspace version from 0.4.0 to 0.3.1. PR #633 contained only bug fixes and doc/dead-code cleanup with zero confirmed downstream consumers affected by the removed types, making this a patch release.

Changes: Cargo.toml 0.4.0 -> 0.3.1; crates/code-analyze-mcp/Cargo.toml dep requirement 0.4 -> 0.3