### PR TITLE
fix: suppress dead_code warning on tool_router field

### DIFF
--- a/crates/code-analyze-mcp/src/lib.rs
+++ b/crates/code-analyze-mcp/src/lib.rs
@@ -155,6 +155,9 @@ fn paginate_focus_chains(
 /// log event channel, metrics sender, and per-session sequence tracking.
 #[derive(Clone)]
 pub struct CodeAnalyzer {
+    // Accessed by the `#[tool_handler]` macro-generated dispatch; rustc lint cannot trace
+    // through proc-macro expansions and incorrectly reports this field as never read.
+    #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     cache: AnalysisCache,
     peer: Arc<TokioMutex<Option<Peer<RoleServer>>>>,

--- a/crates/code-analyze-mcp/src/lib.rs
+++ b/crates/code-analyze-mcp/src/lib.rs
@@ -155,8 +155,8 @@ fn paginate_focus_chains(
 /// log event channel, metrics sender, and per-session sequence tracking.
 #[derive(Clone)]
 pub struct CodeAnalyzer {
-    // Accessed by the `#[tool_handler]` macro-generated dispatch; rustc lint cannot trace
-    // through proc-macro expansions and incorrectly reports this field as never read.
+    // Accessed by rmcp macro-generated tool dispatch, but this field still triggers
+    // `dead_code` in this crate, so keep the targeted suppression.
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     cache: AnalysisCache,


### PR DESCRIPTION
## Summary

Suppresses the dead_code warning on the tool_router field in CodeAnalyzer, a regression from #633. The field is accessed by the #[tool_handler] macro-generated dispatch code; rustc lint cannot trace through proc-macro expansions and incorrectly reports it as never read.

## Changes

- crates/code-analyze-mcp/src/lib.rs: add #[allow(dead_code)] and an explanatory comment on the tool_router field

## Test plan

- [x] cargo build clean (no warnings)
- [x] cargo install --path crates/code-analyze-mcp clean (warning absent)
- [x] cargo clippy -- -D warnings clean
- [x] cargo fmt --check clean
- [x] cargo test -- 324 tests pass, 0 failures