### PR TITLE
docs(agents): keep DISABLE_PROMPT_CACHING=1 in server instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,5 @@ Canonical parameter lists live in the `types` module (`crates/code-analyze-core/
 - Modify files outside the scope of the assigned issue
 - Assume any API exists based on training data; verify against installed crate versions
 - Reference host-specific tools or clients in tool descriptions or server instructions (e.g. Claude Code's Grep, Glob, Read)
+- Keep `DISABLE_PROMPT_CACHING=1` in server instructions; caching data never read again is detrimental
 - Use `gh release create` to tag releases; always create a GPG-signed annotated tag and push it to trigger the release workflow


### PR DESCRIPTION
## Summary

Add a clarifying bullet to AGENTS.md explicitly preserving `DISABLE_PROMPT_CACHING=1` in server instructions.

The existing rule against referencing host-specific tools was ambiguous -- it could be read as banning any client-specific string in server instructions, which is incorrect. `DISABLE_PROMPT_CACHING=1` is a necessary MCP subagent directive: caching data that is never read again is detrimental.

References: modelcontextprotocol/modelcontextprotocol#2419, anthropics/claude-code#34334

## Changes

- `AGENTS.md`: one bullet added to the "Do not" list

## Test plan

- [ ] No code changes; documentation only