### PR TITLE
docs: update READMEs for v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ analyze_directory path: /project summary: false
 
 In single-pass subagent sessions, prompt caches are written but never reused. Benchmarks showed MCP responses writing ~2x more to cache than native-only workflows, adding cost with no quality gain. Set `DISABLE_PROMPT_CACHING=1` (or `DISABLE_PROMPT_CACHING_HAIKU=1` for Haiku-specific pipelines) to avoid this overhead.
 
-The server's own instructions expose a 4-step recommended workflow for unknown repositories: survey the repo root with `analyze_directory` at `max_depth=2`, drill into the source package, run `analyze_file` on key files, then use `analyze_symbol` to trace call graphs. MCP clients that surface server instructions will present this workflow automatically to the agent.
+The server's own instructions expose a 4-step recommended workflow for unknown repositories: survey the repo root with `analyze_directory` at `max_depth=2`, drill into the source package, run `analyze_module` on key files for a function/import index (or `analyze_file` when signatures and types are needed), then use `analyze_symbol` to trace call graphs. MCP clients that surface server instructions will present this workflow automatically to the agent.
 
 ## Observability
 

--- a/crates/code-analyze-core/README.md
+++ b/crates/code-analyze-core/README.md
@@ -30,28 +30,27 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-code-analyze-core = "0.3"
+code-analyze-core = "0.4"
 ```
 
 ## Example
 
 ```rust,no_run
-use code_analyze_core::{analyze_directory, analyze_file, analyze_str, AnalysisConfig};
-use anyhow::Result;
+use code_analyze_core::{analyze_directory, analyze_file, analyze_str};
+use std::path::Path;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Analyze a directory (depth 2, compact summary)
-    let output = analyze_directory("src/", Some(2), true, None, None, false, false).await?;
-    println!("{}", output.formatted);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Analyze a directory
+    let output = analyze_directory(Path::new("src/"), None)?;
+    println!("{} files", output.files.len());
 
     // Analyze a single file
-    let output = analyze_file("src/lib.rs", false, None, None, false, false, None, None).await?;
+    let output = analyze_file("src/lib.rs", None)?;
     println!("{}", output.formatted);
 
     // Analyze source text in memory (no file path required)
     let source = std::fs::read_to_string("src/lib.rs")?;
-    let output = analyze_str(&source, "rs", None).await?;
+    let output = analyze_str(&source, "rs", None)?;
     println!("{}", output.formatted);
 
     Ok(())
@@ -82,7 +81,7 @@ use code_analyze_core::AnalysisConfig;
 
 let config = AnalysisConfig {
     max_file_bytes: Some(1_000_000), // skip files > 1 MB
-    parse_timeout_micros: None,      // reserved, no-op in 0.3
+    parse_timeout_micros: None,      // reserved, no-op in 0.4
     cache_capacity: None,            // use default LRU capacity
 };
 ```


### PR DESCRIPTION
## Summary

Audit and correct both READMEs ahead of the v0.4.1 release.

## Changes

- **README.md**: fix `analyze_module` workflow hint -- clarify it is preferred for function/import index, with `analyze_file` for signatures and types
- **crates/code-analyze-core/README.md**:
  - Bump dependency snippet version from `0.3` to `0.4`
  - Correct `analyze_directory`, `analyze_file`, and `analyze_str` example signatures (synchronous, 2 params, no tokio wrapper)
  - Update no-op version comment from `0.3` to `0.4`

## Test plan

- [ ] No code changes -- documentation only
- [ ] Content verified against current `crates/code-analyze-core/src/types.rs` and `crates/code-analyze-mcp/src/lib.rs`