### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-analyze-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "criterion",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "code-analyze-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "code-analyze-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump workspace version from 0.4.0 to 0.4.1.

## Changes

- \`Cargo.toml\`: version 0.4.0 → 0.4.1
- \`Cargo.lock\`: regenerated

## Test plan

- [ ] \`cargo build\` passes (verified locally)
- [ ] CI passes