### PR TITLE
refactor(logging): restrict level_to_mcp to pub(crate)

### DIFF
--- a/crates/code-analyze-mcp/src/logging.rs
+++ b/crates/code-analyze-mcp/src/logging.rs
@@ -17,7 +17,7 @@ use tracing_subscriber::layer::Context;
 
 /// Maps `tracing::Level` to `MCP` [`LoggingLevel`].
 #[must_use]
-pub fn level_to_mcp(level: &Level) -> LoggingLevel {
+pub(crate) fn level_to_mcp(level: &Level) -> LoggingLevel {
     match *level {
         Level::TRACE | Level::DEBUG => LoggingLevel::Debug,
         Level::INFO => LoggingLevel::Info,
@@ -141,5 +141,19 @@ impl tracing::field::Visit for MessageVisitor<'_> {
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         self.0.insert(field.name().to_string(), Value::Bool(value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::Level;
+    #[test]
+    fn test_logging_level_to_mcp_mapping() {
+        assert_eq!(level_to_mcp(&Level::TRACE), LoggingLevel::Debug);
+        assert_eq!(level_to_mcp(&Level::DEBUG), LoggingLevel::Debug);
+        assert_eq!(level_to_mcp(&Level::INFO), LoggingLevel::Info);
+        assert_eq!(level_to_mcp(&Level::WARN), LoggingLevel::Warning);
+        assert_eq!(level_to_mcp(&Level::ERROR), LoggingLevel::Error);
     }
 }

--- a/crates/code-analyze-mcp/tests/integration_tests.rs
+++ b/crates/code-analyze-mcp/tests/integration_tests.rs
@@ -1,18 +1,7 @@
 // SPDX-FileCopyrightText: 2026 code-analyze-mcp contributors
 // SPDX-License-Identifier: Apache-2.0
-use code_analyze_mcp::logging::{LogEvent, level_to_mcp};
+use code_analyze_mcp::logging::LogEvent;
 use rmcp::model::{CallToolResult, Content, LoggingLevel, Meta};
-#[test]
-fn test_logging_level_to_mcp_mapping() {
-    use tracing::Level;
-
-    assert_eq!(level_to_mcp(&Level::TRACE), LoggingLevel::Debug);
-    assert_eq!(level_to_mcp(&Level::DEBUG), LoggingLevel::Debug);
-    assert_eq!(level_to_mcp(&Level::INFO), LoggingLevel::Info);
-    assert_eq!(level_to_mcp(&Level::WARN), LoggingLevel::Warning);
-    assert_eq!(level_to_mcp(&Level::ERROR), LoggingLevel::Error);
-}
-
 #[tokio::test]
 async fn test_batch_draining_with_multiple_events() {
     use serde_json::json;


### PR DESCRIPTION
## Summary

- `level_to_mcp` has exactly one caller within the crate and is not part of the public API
- Restrict visibility from `pub` to `pub(crate)`
- Move test coverage to an inline `#[cfg(test)]` module in `logging.rs`
- Remove the now-unreachable import and test from `integration_tests.rs`

## Changes

- `crates/code-analyze-mcp/src/logging.rs` -- visibility change + inline test
- `crates/code-analyze-mcp/tests/integration_tests.rs` -- remove import and test

## Test plan

- [x] Tests pass (142 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] `cargo deny` clean
- [x] Security scan clean (gitleaks: no leaks found)