### PR TITLE
refactor(polish): improve naming clarity and inline trivial helper

### DIFF
--- a/crates/code-analyze-core/src/analyze.rs
+++ b/crates/code-analyze-core/src/analyze.rs
@@ -455,7 +455,7 @@ pub struct FocusedAnalysisConfig {
 
 /// Internal parameters for focused analysis phases.
 #[derive(Clone)]
-struct FocusedAnalysisParams {
+struct InternalFocusedParams {
     focus: String,
     match_mode: SymbolMatchMode,
     follow_depth: u32,
@@ -465,7 +465,7 @@ struct FocusedAnalysisParams {
 }
 
 /// Type alias for analysis results: (`file_path`, `semantic_analysis`) pairs and impl-trait info.
-type AnalysisResults = (Vec<(PathBuf, SemanticAnalysis)>, Vec<ImplTraitInfo>);
+type FileAnalysisBatch = (Vec<(PathBuf, SemanticAnalysis)>, Vec<ImplTraitInfo>);
 
 /// Phase 1: Collect semantic analysis for all files in parallel.
 fn collect_file_analysis(
@@ -473,7 +473,7 @@ fn collect_file_analysis(
     progress: &Arc<AtomicUsize>,
     ct: &CancellationToken,
     ast_recursion_limit: Option<usize>,
-) -> Result<AnalysisResults, AnalyzeError> {
+) -> Result<FileAnalysisBatch, AnalyzeError> {
     // Check if already cancelled
     if ct.is_cancelled() {
         return Err(AnalyzeError::Cancelled);
@@ -562,7 +562,7 @@ fn build_call_graph(
 /// then compute `impl_trait_caller_count`.
 fn resolve_symbol(
     graph: &mut CallGraph,
-    params: &FocusedAnalysisParams,
+    params: &InternalFocusedParams,
 ) -> Result<(String, usize, usize), AnalyzeError> {
     // Resolve symbol name using the requested match mode.
     let resolved_focus = if params.match_mode == SymbolMatchMode::Exact {
@@ -667,7 +667,7 @@ fn compute_chains(
     graph: &CallGraph,
     resolved_focus: &str,
     root: &Path,
-    params: &FocusedAnalysisParams,
+    params: &InternalFocusedParams,
     unfiltered_caller_count: usize,
     impl_trait_caller_count: usize,
 ) -> Result<ChainComputeResult, AnalyzeError> {
@@ -732,7 +732,7 @@ pub fn analyze_focused_with_progress(
     ct: CancellationToken,
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
     let entries = walk_directory(root, params.max_depth)?;
-    let internal_params = FocusedAnalysisParams {
+    let internal_params = InternalFocusedParams {
         focus: params.focus.clone(),
         match_mode: params.match_mode.clone(),
         follow_depth: params.follow_depth,
@@ -757,7 +757,7 @@ fn analyze_focused_with_progress_with_entries_internal(
     _max_depth: Option<u32>,
     progress: &Arc<AtomicUsize>,
     ct: &CancellationToken,
-    params: &FocusedAnalysisParams,
+    params: &InternalFocusedParams,
     entries: &[WalkEntry],
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
     // Check if already cancelled
@@ -872,7 +872,7 @@ pub fn analyze_focused_with_progress_with_entries(
     ct: &CancellationToken,
     entries: &[WalkEntry],
 ) -> Result<FocusedAnalysisOutput, AnalyzeError> {
-    let internal_params = FocusedAnalysisParams {
+    let internal_params = InternalFocusedParams {
         focus: params.focus.clone(),
         match_mode: params.match_mode.clone(),
         follow_depth: params.follow_depth,

--- a/crates/code-analyze-core/src/graph.rs
+++ b/crates/code-analyze-core/src/graph.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tracing::{debug, instrument};
 
 /// Type info for a function: (path, line, parameters, `return_type`)
-type FunctionTypeInfo = (PathBuf, usize, Vec<String>, Option<String>);
+type FunctionSignatureEntry = (PathBuf, usize, Vec<String>, Option<String>);
 
 const MAX_CANDIDATES_IN_ERROR: usize = 20;
 
@@ -215,7 +215,7 @@ pub struct CallGraph {
     /// Definitions map: `function_name` -> vec of (`file_path`, `line_number`).
     pub definitions: HashMap<String, Vec<(PathBuf, usize)>>,
     /// Internal: maps function name to type info for type-aware disambiguation.
-    function_types: HashMap<String, Vec<FunctionTypeInfo>>,
+    function_types: HashMap<String, Vec<FunctionSignatureEntry>>,
     /// Index for O(1) case-insensitive symbol lookup: lowercased -> vec of originals.
     lowercase_index: HashMap<String, Vec<String>>,
 }
@@ -245,7 +245,7 @@ impl CallGraph {
         _call_line: usize,
         _arg_count: Option<usize>,
         definitions: &HashMap<String, Vec<(PathBuf, usize)>>,
-        _function_types: &HashMap<String, Vec<FunctionTypeInfo>>,
+        _function_types: &HashMap<String, Vec<FunctionSignatureEntry>>,
     ) -> String {
         // Try raw callee name first
         if let Some(_defs) = definitions.get(callee) {

--- a/crates/code-analyze-mcp/src/metrics.rs
+++ b/crates/code-analyze-mcp/src/metrics.rs
@@ -84,7 +84,10 @@ impl MetricsWriter {
             }
 
             if current_file.is_none() {
-                current_file = Some(rotate_path(&self.base_dir, &current_date));
+                current_file = Some(
+                    self.base_dir
+                        .join(format!("metrics-{}.jsonl", current_date)),
+                );
             }
 
             let path = current_file.as_ref().unwrap();
@@ -148,10 +151,6 @@ fn xdg_metrics_dir() -> PathBuf {
     } else {
         PathBuf::from(".")
     }
-}
-
-fn rotate_path(base_dir: &Path, date_str: &str) -> PathBuf {
-    base_dir.join(format!("metrics-{date_str}.jsonl"))
 }
 
 async fn cleanup_old_files(base_dir: &Path) {


### PR DESCRIPTION
## Summary

Automated polish pass. Resolves a name collision between two identically-named structs in different layers, clarifies three other identifiers, and inlines a single-call-site private helper. No behavior changes; lint and format checks pass.

## Changes

| Finding | File | Change |
|---------|------|--------|
| P004 (medium) | `crates/code-analyze-core/src/analyze.rs` | Rename `FocusedAnalysisParams` -> `InternalFocusedParams` to eliminate collision with identically-named MCP-layer struct |
| P005 (low) | `crates/code-analyze-core/src/graph.rs` | Rename `FunctionTypeInfo` -> `FunctionSignatureEntry` (misleading alias name) |
| P010 (low) | `crates/code-analyze-core/src/analyze.rs` | Rename `AnalysisResults` -> `FileAnalysisBatch` (too generic) |
| P003 (low) | `crates/code-analyze-mcp/src/metrics.rs` | Inline `rotate_path` single-call-site private helper |

## Skipped (risky or lint-breaking)

- P001/P002: exported functions used only in tests -- removal needs deliberate test-suite audit
- P006: inlining `ChainComputeResult` triggered `clippy::type_complexity`; alias retained
- P007: `DISABLE_PROMPT_CACHING=1` directive is intentional; reverted (see #647)
- P008/P009: `find_incoming_chains`/`find_outgoing_chains` have 4-5 call sites each

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] `cargo test` (CI)