### PR TITLE
docs(agents): prohibit removing DISABLE_PROMPT_CACHING from server instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,5 +56,5 @@ Canonical parameter lists live in the `types` module (`crates/code-analyze-core/
 - Modify files outside the scope of the assigned issue
 - Assume any API exists based on training data; verify against installed crate versions
 - Reference host-specific tools or clients in tool descriptions or server instructions (e.g. Claude Code's Grep, Glob, Read)
-- Keep `DISABLE_PROMPT_CACHING=1` in server instructions; caching data never read again is detrimental
 - Use `gh release create` to tag releases; always create a GPG-signed annotated tag and push it to trigger the release workflow
+- Remove `DISABLE_PROMPT_CACHING=1` from server instructions; caching data never read again is detrimental


### PR DESCRIPTION
## Summary

The `DISABLE_PROMPT_CACHING=1` rule in AGENTS.md was incorrectly placed in the `## Do not` section with wording that read as a prohibition to keep it, causing the polish scanner to treat the directive in `lib.rs` as a violation and remove it.

The fix: reword to `Do not remove ...` so the intent is unambiguous.

## Changes

- `AGENTS.md`: moves rule from misread phrasing to an explicit `Do not remove` statement under `## Do not`

## References

- https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2419
- https://github.com/anthropics/claude-code/issues/47487

## Test plan

- [ ] No code changes; docs only