### PR TITLE
docs: replace pinned versions with version-agnostic references

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ To build with a subset of languages, disable default features and opt in:
 
 ```toml
 [dependencies]
-code-analyze-core = { version = "0.3", default-features = false, features = ["lang-rust", "lang-python"] }
+code-analyze-core = { version = "*", default-features = false, features = ["lang-rust", "lang-python"] }
 ```
+
+The current version is published on [crates.io](https://crates.io/crates/code-analyze-core). Replace `"*"` with the latest version string if you prefer a pinned dependency.
 
 ## Installation
 

--- a/crates/code-analyze-core/README.md
+++ b/crates/code-analyze-core/README.md
@@ -30,8 +30,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-code-analyze-core = "0.4"
+code-analyze-core = "*"
 ```
+
+The current version is published on [crates.io](https://crates.io/crates/code-analyze-core). Replace `"*"` with the latest version string if you prefer a pinned dependency.
 
 ## Example
 
@@ -81,7 +83,7 @@ use code_analyze_core::AnalysisConfig;
 
 let config = AnalysisConfig {
     max_file_bytes: Some(1_000_000), // skip files > 1 MB
-    parse_timeout_micros: None,      // reserved, no-op in 0.4
+    parse_timeout_micros: None,      // reserved, currently a no-op
     cache_capacity: None,            // use default LRU capacity
 };
 ```

--- a/crates/code-analyze-core/src/languages/csharp.rs
+++ b/crates/code-analyze-core/src/languages/csharp.rs
@@ -33,10 +33,10 @@ pub const REFERENCE_QUERY: &str = r"
 
 /// Tree-sitter query for extracting C# `using` directives.
 ///
-/// In tree-sitter-c-sharp 0.23.1 all `using` forms (namespace, `using static`,
-/// and `using alias = ...`) are represented by a single `using_directive` node
-/// kind.  There are no separate `using_static_directive` or
-/// `using_alias_directive` node kinds, so one pattern captures everything.
+/// All `using` forms (namespace, `using static`, and `using alias = ...`)
+/// are represented by a single `using_directive` node kind. There are no
+/// separate `using_static_directive` or `using_alias_directive` node kinds,
+/// so one pattern captures everything.
 pub const IMPORT_QUERY: &str = r"
 (using_directive) @import_path
 ";

--- a/crates/code-analyze-core/src/languages/fortran.rs
+++ b/crates/code-analyze-core/src/languages/fortran.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 /// Tree-sitter query for extracting Fortran elements (functions and subroutines).
 ///
-/// Module constructs are omitted: `module_statement` has no `name` field in
-/// tree-sitter-fortran 0.5.1, so `@class` captures would be counted in
+/// Module constructs are omitted: `module_statement` has no `name` field
+/// in the current grammar, so `@class` captures would be counted in
 /// `analyze_directory` but produce no names in `analyze_file`. Modules will
 /// be added here once the grammar exposes a `name` field.
 pub const ELEMENT_QUERY: &str = r"


### PR DESCRIPTION
## Summary

Remove all stale version strings from user-facing documentation and in-code doc comments. 4 files, 6 targeted edits. Zero code logic changes.

The motivation: version numbers in documentation rot silently. Every release creates silent inaccuracies. This PR eliminates the root cause by making all documentation version-agnostic and low-maintenance.

## Changes

| File | Change |
|------|--------|
| `README.md` | Replace `version = "0.3"` with `"*"` in Cargo feature opt-in example; add crates.io guidance note |
| `crates/code-analyze-core/README.md` | Replace `"0.4"` with `"*"` in installation example; add crates.io guidance note; reword `parse_timeout_micros` comment from `no-op in 0.4` to `currently a no-op` |
| `crates/code-analyze-core/src/languages/csharp.rs` | Reword doc comment: remove `tree-sitter-c-sharp 0.23.1` version pin, preserve behavior description of `using_directive` node kind |
| `crates/code-analyze-core/src/languages/fortran.rs` | Reword module-level doc comment: remove `tree-sitter-fortran 0.5.1` version pin, preserve grammar limitation description |

`docs/REPO-STANDARDS.md` is intentionally unchanged -- version strings there are security-practice illustrations (SHA pins with version comments), not dependency version references.

## Rationale for `"*"` in Cargo examples

`"*"` is canonical Cargo syntax for "any version" and is the standard way to write version-agnostic dependency examples in documentation. Both Cargo examples now include a prose note pointing users to [crates.io](https://crates.io/crates/code-analyze-core) for the current published version and suggesting they pin to it in production -- following Rust ecosystem best practices.

## Test plan

- [x] `cargo test` -- 334 tests pass, 0 failed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo deny check advisories licenses` -- clean (no dependency changes)
- [x] gitleaks -- no secrets detected