### PR TITLE
docs: add Wave 9 editing tools to ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,3 +123,49 @@ Unimplemented and pertinent:
 
 - MCP SEP adoption: #1487 (`trustedHint`), #1561 (`unsafeOutputHint`), #1913 (trust/sensitivity annotations), #1984 (governance annotations) -- open upstream; no action until specs stabilize. #1560 (`secretHint`) closed 2026-03-23; evaluate adoption once merged into spec.
 - Streamable HTTP transport: add `--http` flag exposing `StreamableHttpService` (axum + rmcp `transport-streamable-http-server` + `transport-streamable-http-server-session` features) alongside existing stdio. Tower middleware: `RequestBodyLimitLayer` (4 MB) + `tower-governor` (per-token rate limit) + static Bearer token from env var. Target deployment: GCP e2-micro Always Free (us-central1) behind Cloudflare proxy (free tier, TLS termination, WAF, 5 rate-limit rules). No changes to tool handlers or session logic required.
+
+## Wave 9: Editing Tools
+
+Augments aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyse-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
+
+**Prerequisite:** the rename PR (#664) must merge before this wave begins.
+
+### Rationale
+
+Both a combined server and two separate servers inject into the same model context window. Token cost is identical. A single server with one MCP config entry, one binary, and one version pin is operationally simpler. Five editing tools keep the total tool count below the reliable SML selection ceiling (~10-12 tools).
+
+The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0 source) supports multi-group composition with no breaking changes from 1.1.0. Write tools are placed in a second `#[tool_router(router = write_router, vis = "pub")]` impl block and merged at construction.
+
+### Phase 1: Mechanical tools [no AST required]
+
+Three tools with no tree-sitter dependency. These validate the BUILD agent workflow and establish the write-path integration before adding AST complexity.
+
+- `read_file(path, start_line?, end_line?)` -- raw file content with optional line range; `read_only_hint=true`, `idempotent_hint=true`
+- `write_file(path, content)` -- create or overwrite; `destructive_hint=true`, `idempotent_hint=false`
+- `edit_file(path, old_text, new_text)` -- replace a unique exact text block; errors if the block appears zero or more than once; `destructive_hint=true`, `idempotent_hint=false`
+
+Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate(path)` after every successful write or the next `analyze_file` call returns stale data.
+
+### Phase 2: AST-backed tools
+
+Two tools that require `code-analyze-core` capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
+
+- `rename_symbol(path, old_name, new_name, kind?)` -- renames by AST node kind, not string match, so identifiers in string literals are excluded; single-file scope in v1; directory-wide is a follow-up
+- `insert_at_symbol(path, symbol_name, position, content)` -- inserts content before or after a named AST node using `start_byte`/`end_byte` from the existing capture pipeline; `position` is `before | after`
+
+### Annotation posture update
+
+Phase 2 tools are the first exception to the annotation freeze established in the Annotation Posture Policy section. Write tools carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (`read_file`, and all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
+
+Note: `read_only_hint` is a hint surfaced to MCP clients in `tools/list`; rmcp 1.5.0 has no per-tool access control enforcement.
+
+### SML validation requirement
+
+Per the Small-Model-First Constraint: all five tools must be evaluated against Haiku, Mistral-small-2603, and MiniMax-M2.5 before Sonnet in a Wave 9 benchmark. Tool descriptions must follow literal-instruction style -- SML models follow tool descriptions literally.
+
+### Risks
+
+- **Cache staleness** -- mitigated by mandatory `cache.invalidate(path)` in all write paths
+- **`rename_symbol` scope creep** -- directory-wide rename requires type information tree-sitter cannot provide; enforce single-file boundary in v1 with a clear error if a directory path is supplied
+- **Annotation posture drift** -- document the per-tool posture in this section; update REUSE.toml for any new source files
+- **SPDX headers** -- every new `.rs` file requires an SPDX header or `reuse lint` fails CI

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -144,7 +144,7 @@ Three tools with no tree-sitter dependency. These validate the BUILD agent workf
 - `write_file(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_file to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 - `edit_file(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use write_file to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
-Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate(path)` after every successful write or the next `analyze_file` call returns stale data.
+Cache invalidation: `write_file` and `edit_file` must ensure subsequent analyses do not reuse stale cached entries. The existing `AnalysisCache` is keyed by file mtime, so writes that update mtime will naturally bypass stale entries; if mtime-based invalidation proves insufficient, an explicit `cache.invalidate(path)` method will need to be added.
 
 ### Phase 2: AST-backed tools
 
@@ -155,7 +155,7 @@ Two tools that require `aptu-coder-core` (formerly `code-analyze-core`) capture 
 
 ### Annotation posture update
 
-Phase 2 tools are the first exception to the annotation freeze established in the Annotation Posture Policy section. Write tools carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (`read_file`, and all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
+Wave 9 write tools are the exception to the annotation freeze established in the Annotation Posture Policy section. Write tools (`write_file`, `edit_file`, `rename_symbol`, and `insert_at_symbol`) carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (`read_file`, and all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
 
 Note: `read_only_hint` is a hint surfaced to MCP clients in `tools/list`; rmcp 1.5.0 has no per-tool access control enforcement.
 
@@ -165,7 +165,7 @@ Per the Small-Model-First Constraint: all five tools must be evaluated against H
 
 ### Risks
 
-- **Cache staleness** -- mitigated by mandatory `cache.invalidate(path)` in all write paths
+- **Cache staleness** -- mtime-based cache keys handle the common case; add explicit `cache.invalidate(path)` if mtime invalidation proves insufficient
 - **`rename_symbol` scope creep** -- directory-wide rename requires type information tree-sitter cannot provide; enforce single-file boundary in v1 with a clear error if a directory path is supplied
 - **Annotation posture drift** -- document the per-tool posture in this section; update REUSE.toml for any new source files
 - **SPDX headers** -- every new `.rs` file requires an SPDX header or `reuse lint` fails CI

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,9 +140,9 @@ The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0
 
 Three tools with no tree-sitter dependency. These validate the BUILD agent workflow and establish the write-path integration before adding AST complexity.
 
-- `read_file(path, start_line?, end_line?)` -- raw file content with optional line range; `read_only_hint=true`, `idempotent_hint=true`
-- `write_file(path, content)` -- create or overwrite; `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
-- `edit_file(path, old_text, new_text)` -- replace a unique exact text block; errors if the block appears zero times or more than once; `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `read_file(path, start_line?, end_line?)` -- "Raw file content with optional line range. Prefer start_line/end_line to limit tokens on large files; omit both for full content. Use analyze_file for structure, not content. Example queries: Read lines 10-40 of src/lib.rs; Show the full contents of config.toml." `read_only_hint=true`, `idempotent_hint=true`
+- `write_file(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_file to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `edit_file(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use write_file to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
 Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate(path)` after every successful write or the next `analyze_file` call returns stale data.
 
@@ -150,8 +150,8 @@ Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate(pat
 
 Two tools that require `aptu-coder-core` (formerly `code-analyze-core`) capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
 
-- `rename_symbol(path, old_name, new_name, kind?)` -- renames by AST node kind, not string match, so identifiers in string literals are excluded; single-file scope in v1; directory-wide is a follow-up
-- `insert_at_symbol(path, symbol_name, position, content)` -- inserts content before or after a named AST node using `start_byte`/`end_byte` from the existing capture pipeline; `position` is `before | after`
+- `rename_symbol(path, old_name, new_name, kind?)` -- "AST-aware rename within a single file. Matches by node kind, not string -- identifiers in string literals and comments are excluded. Errors if old_name not found; supply kind to disambiguate (function, variable, type). Directory-wide rename not supported in v1. Example queries: Rename function parse_config to load_config in src/config.rs; Rename struct field timeout to timeout_ms." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `insert_at_symbol(path, symbol_name, position, content)` -- "Insert content immediately before or after a named AST node. position is before|after. Uses start_byte/end_byte from the capture pipeline; errors if symbol_name not found in file. Example queries: Insert a tracing span before the handle_request function; Add a derive macro after the MyStruct definition." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
 ### Annotation posture update
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -126,7 +126,7 @@ Unimplemented and pertinent:
 
 ## Wave 9: Editing Tools
 
-Augments aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyse-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
+Augments aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyze-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
 
 **Prerequisite:** the rename PR (#664) must merge before this wave begins.
 
@@ -141,14 +141,14 @@ The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0
 Three tools with no tree-sitter dependency. These validate the BUILD agent workflow and establish the write-path integration before adding AST complexity.
 
 - `read_file(path, start_line?, end_line?)` -- raw file content with optional line range; `read_only_hint=true`, `idempotent_hint=true`
-- `write_file(path, content)` -- create or overwrite; `destructive_hint=true`, `idempotent_hint=false`
-- `edit_file(path, old_text, new_text)` -- replace a unique exact text block; errors if the block appears zero or more than once; `destructive_hint=true`, `idempotent_hint=false`
+- `write_file(path, content)` -- create or overwrite; `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `edit_file(path, old_text, new_text)` -- replace a unique exact text block; errors if the block appears zero times or more than once; `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
 Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate(path)` after every successful write or the next `analyze_file` call returns stale data.
 
 ### Phase 2: AST-backed tools
 
-Two tools that require `code-analyze-core` capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
+Two tools that require `aptu-coder-core` (formerly `code-analyze-core`) capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
 
 - `rename_symbol(path, old_name, new_name, kind?)` -- renames by AST node kind, not string match, so identifiers in string literals are excluded; single-file scope in v1; directory-wide is a follow-up
 - `insert_at_symbol(path, symbol_name, position, content)` -- inserts content before or after a named AST node using `start_byte`/`end_byte` from the existing capture pipeline; `position` is `before | after`


### PR DESCRIPTION
## Summary

Adds Wave 9 to `docs/ROADMAP.md`: five mechanical code-editing tools that augment aptu-coder without introducing a second MCP server.

## Changes

- `docs/ROADMAP.md`: append Wave 9 section

## Wave 9 scope

- Phase 1 (no AST): `read_file`, `write_file`, `edit_file`
- Phase 2 (AST-backed): `rename_symbol`, `insert_at_symbol`
- Prerequisite: rename PR #664 must merge first
- Annotation posture policy updated for write tools
- SML validation requirement documented per Small-Model-First Constraint

## Notes

- rmcp API claims verified against 1.5.0 source; all composition patterns unchanged from 1.1.0
- No code changes in this PR; roadmap only
