### PR TITLE
feat(cache): add invalidate_file and read_file tool (#674 #675)

### DIFF
--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -187,6 +187,24 @@ impl AnalysisCache {
             }
         });
     }
+
+    /// Invalidate all cache entries for a given file path.
+    /// Removes all entries regardless of modification time or analysis mode.
+    #[instrument(skip(self), fields(path = ?path))]
+    pub fn invalidate_file(&self, path: &std::path::Path) {
+        lock_or_recover(&self.cache, self.file_capacity, |guard| {
+            let keys: Vec<CacheKey> = guard
+                .iter()
+                .filter(|(k, _)| k.path == path)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in keys {
+                guard.pop(&key);
+            }
+            let cache_size = guard.len();
+            debug!(cache_event = "invalidate_file", cache_size = cache_size, path = ?path);
+        });
+    }
 }
 
 impl Clone for AnalysisCache {
@@ -203,6 +221,7 @@ impl Clone for AnalysisCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::SemanticAnalysis;
 
     #[test]
     fn test_from_entries_skips_dirs() {
@@ -235,5 +254,62 @@ mod tests {
         // The directory entry should be filtered out
         assert_eq!(key.files.len(), 1);
         assert_eq!(key.files[0].0, file_path);
+    }
+
+    #[test]
+    fn test_invalidate_file_single_mode() {
+        // Arrange: create a cache and insert one entry for a path
+        let cache = AnalysisCache::new(10);
+        let path = PathBuf::from("/test/file.rs");
+        let key = CacheKey {
+            path: path.clone(),
+            modified: SystemTime::UNIX_EPOCH,
+            mode: AnalysisMode::Overview,
+        };
+        let output = Arc::new(FileAnalysisOutput::new(
+            String::new(),
+            SemanticAnalysis::default(),
+            0,
+            None,
+        ));
+        cache.put(key.clone(), output);
+
+        // Act: invalidate the file
+        cache.invalidate_file(&path);
+
+        // Assert: the entry should be removed
+        assert!(cache.get(&key).is_none());
+    }
+
+    #[test]
+    fn test_invalidate_file_multi_mode() {
+        // Arrange: create a cache and insert two entries for the same path with different modes
+        let cache = AnalysisCache::new(10);
+        let path = PathBuf::from("/test/file.rs");
+        let key1 = CacheKey {
+            path: path.clone(),
+            modified: SystemTime::UNIX_EPOCH,
+            mode: AnalysisMode::Overview,
+        };
+        let key2 = CacheKey {
+            path: path.clone(),
+            modified: SystemTime::UNIX_EPOCH,
+            mode: AnalysisMode::FileDetails,
+        };
+        let output = Arc::new(FileAnalysisOutput::new(
+            String::new(),
+            SemanticAnalysis::default(),
+            0,
+            None,
+        ));
+        cache.put(key1.clone(), output.clone());
+        cache.put(key2.clone(), output);
+
+        // Act: invalidate the file
+        cache.invalidate_file(&path);
+
+        // Assert: both entries should be removed
+        assert!(cache.get(&key1).is_none());
+        assert!(cache.get(&key2).is_none());
     }
 }

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! File read utilities for the edit tools.
+
+use crate::types::ReadFileOutput;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EditError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid range: start ({start}) > end ({end}); file has {total} lines")]
+    InvalidRange {
+        start: usize,
+        end: usize,
+        total: usize,
+    },
+    #[error("path is a directory, not a file: {0}")]
+    NotAFile(PathBuf),
+}
+
+pub fn read_file_range(
+    path: &Path,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) -> Result<ReadFileOutput, EditError> {
+    if path.is_dir() {
+        return Err(EditError::NotAFile(path.to_path_buf()));
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let lines: Vec<&str> = raw.lines().collect();
+    let total = lines.len();
+    if total == 0 {
+        return Ok(ReadFileOutput {
+            path: path.display().to_string(),
+            total_lines: 0,
+            start_line: 0,
+            end_line: 0,
+            content: String::new(),
+        });
+    }
+    let start = start_line.unwrap_or(1).max(1).min(total.max(1));
+    let end = end_line.unwrap_or(total).min(total).max(1);
+    if start > end {
+        return Err(EditError::InvalidRange { start, end, total });
+    }
+    let width = end.to_string().len();
+    let content = lines[start - 1..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| format!("{:>width$}: {}", start + i, line, width = width))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(ReadFileOutput {
+        path: path.display().to_string(),
+        total_lines: total,
+        start_line: start,
+        end_line: end,
+        content,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn make_temp_file(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        write!(f, "{}", content).unwrap();
+        f
+    }
+
+    #[test]
+    fn test_read_full_file() {
+        let f = make_temp_file("line1\nline2\nline3\n");
+        let out = read_file_range(f.path(), None, None).unwrap();
+        assert_eq!(out.total_lines, 3);
+        assert_eq!(out.start_line, 1);
+        assert_eq!(out.end_line, 3);
+        assert!(out.content.contains("line1"));
+        assert!(out.content.contains("line3"));
+    }
+
+    #[test]
+    fn test_read_partial_range() {
+        let f = make_temp_file("a\nb\nc\nd\ne\n");
+        let out = read_file_range(f.path(), Some(2), Some(4)).unwrap();
+        assert_eq!(out.start_line, 2);
+        assert_eq!(out.end_line, 4);
+        assert!(out.content.contains("b"));
+        assert!(out.content.contains("d"));
+        assert!(!out.content.contains("a"));
+        assert!(!out.content.contains("e"));
+    }
+
+    #[test]
+    fn test_read_invalid_range() {
+        let f = make_temp_file("a\nb\nc\n");
+        let err = read_file_range(f.path(), Some(3), Some(1)).unwrap_err();
+        assert!(matches!(err, EditError::InvalidRange { .. }));
+    }
+
+    #[test]
+    fn test_read_clamped_range() {
+        let f = make_temp_file("x\ny\nz\n");
+        // end_line beyond total should clamp
+        let out = read_file_range(f.path(), Some(1), Some(999)).unwrap();
+        assert_eq!(out.end_line, 3);
+        assert_eq!(out.total_lines, 3);
+    }
+
+    #[test]
+    fn test_read_empty_file() {
+        let f = make_temp_file("");
+        let out = read_file_range(f.path(), None, None).unwrap();
+        assert_eq!(out.total_lines, 0);
+        assert_eq!(out.content, "");
+    }
+}

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod analyze;
 pub mod cache;
 pub mod completion;
 mod config;
+pub mod edit;
 pub mod formatter;
 pub mod formatter_defuse;
 pub mod graph;
@@ -63,6 +64,7 @@ pub use analyze::{
     analyze_module_file, analyze_str,
 };
 pub use config::AnalysisConfig;
+pub use edit::{EditError, read_file_range};
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;
 pub use types::*;

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -766,3 +766,24 @@ mod error_meta_tests {
         assert!(meta.is_retryable);
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct ReadFileParams {
+    /// Path to the file to read (must be a file, not a directory).
+    pub path: String,
+    /// Starting line number (1-indexed, inclusive). Defaults to 1 if omitted.
+    pub start_line: Option<usize>,
+    /// Ending line number (1-indexed, inclusive). Defaults to the last line if omitted.
+    pub end_line: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct ReadFileOutput {
+    pub path: String,
+    pub total_lines: usize,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub content: String,
+}

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1656,6 +1656,205 @@ impl CodeAnalyzer {
         });
         Ok(result)
     }
+
+    #[instrument(skip(self, _context))]
+    #[tool(
+        name = "read_file",
+        description = "Read a file or range of lines from a file. Returns the file content with line numbers. Specify start_line and end_line (1-indexed, inclusive) to read a range; omit for full file. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs.",
+        output_schema = schema_for_type::<types::ReadFileOutput>(),
+        annotations(
+            title = "Read File",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn read_file(
+        &self,
+        params: Parameters<types::ReadFileParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let params = params.0;
+        let t_start = std::time::Instant::now();
+        let param_path = params.path.clone();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+
+        // Guard against directory paths
+        if std::fs::metadata(&params.path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "read_file",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(&param_path),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid.clone(),
+                seq: Some(seq),
+                cache_hit: None,
+            });
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "path is a directory; use analyze_directory instead".to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "pass a file path, not a directory",
+                )),
+            )));
+        }
+
+        let path = std::path::PathBuf::from(&params.path);
+        let handle = tokio::task::spawn_blocking(move || {
+            aptu_coder_core::read_file_range(&path, params.start_line, params.end_line)
+        });
+
+        let output = match handle.await {
+            Ok(Ok(v)) => v,
+            Ok(Err(aptu_coder_core::EditError::InvalidRange { start, end, total })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "read_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    format!("invalid range: start ({start}) > end ({end}); file has {total} lines"),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "ensure start_line <= end_line",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::NotAFile(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "read_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "path is not a file".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "provide a file path, not a directory",
+                    )),
+                )));
+            }
+            Ok(Err(e)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "read_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "read_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+        };
+
+        let text = format!(
+            "File: {} (total: {} lines, showing: {}-{})\n\n{}",
+            output.path, output.total_lines, output.start_line, output.end_line, output.content
+        );
+        let mut result = CallToolResult::success(vec![Content::text(text.clone())])
+            .with_meta(Some(no_cache_meta()));
+        let structured = match serde_json::to_value(&output).map_err(|e| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("serialization failed: {e}"),
+                Some(error_meta("internal", false, "report this as a bug")),
+            )
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
+        result.structured_content = Some(structured);
+        let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            ts: crate::metrics::unix_ms(),
+            tool: "read_file",
+            duration_ms: dur,
+            output_chars: text.len(),
+            param_path_depth: crate::metrics::path_component_count(&param_path),
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: sid,
+            seq: Some(seq),
+            cache_hit: None,
+        });
+        Ok(result)
+    }
 }
 
 // Parameters for focused analysis task.

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -7,13 +7,14 @@ use serde_json::Value;
 fn test_all_tools_have_correct_annotations() {
     let tools = CodeAnalyzer::list_tools();
 
-    assert_eq!(tools.len(), 4, "expected 4 registered tools");
+    assert_eq!(tools.len(), 5, "expected 5 registered tools");
 
     let expected_names = [
         "analyze_directory",
         "analyze_file",
         "analyze_module",
         "analyze_symbol",
+        "read_file",
     ];
 
     for tool in &tools {


### PR DESCRIPTION
## Summary

Implements two Wave 9 prerequisites in a single atomic commit: `invalidate_file` on `AnalysisCache` (issue #674) and the `read_file` MCP tool (issue #675). Both changes are orthogonal and were built in parallel shards against disjoint file sets.

## Changes

**Issue #674 — `AnalysisCache::invalidate_file`**

- `crates/aptu-coder-core/src/cache.rs`: adds `pub fn invalidate_file(&self, path: &Path)` that evicts all cache entries for the given path regardless of mtime or analysis mode. Uses the two-pass pattern required by lru 0.17 (`iter().filter().collect()` then `pop()` each key; `retain()` does not exist on this version). Uses the existing `lock_or_recover` helper. Two unit tests: single-mode eviction and multi-mode eviction (same path, different `AnalysisMode`).

**Issue #675 — `read_file` MCP tool**

- `crates/aptu-coder-core/src/edit.rs` (new): SPDX header, `EditError` enum (`Io`, `InvalidRange`, `NotAFile`) via thiserror, `read_file_range(path, start_line?, end_line?)`. Five unit tests cover full read, partial range, invalid range, out-of-range clamping, and empty file.
- `crates/aptu-coder-core/src/types.rs`: `ReadFileParams` and `ReadFileOutput` structs with schemars feature gate.
- `crates/aptu-coder-core/src/lib.rs`: `pub mod edit;` declaration and re-exports for `read_file_range` and `EditError`.
- `crates/aptu-coder/src/lib.rs`: `read_file` tool handler in the `#[tool_router]` impl block. Uses `spawn_blocking` with explicit `match handle.await` (no `.await??`). Maps `InvalidRange` and `NotAFile` to `INVALID_PARAMS`; `Io` errors to `INTERNAL_ERROR`. Directory guard returns `INVALID_PARAMS` steering agents to `analyze_directory`. Line numbers left-padded to the width of the max line number in the requested range. Out-of-range bounds clamped silently; empty files return empty content. Emits metrics with `cache_hit: None`. `no_cache_meta()` on every success response. Annotations: `read_only_hint=true`, `destructive_hint=false`, `idempotent_hint=true`, `open_world_hint=false`.
- `crates/aptu-coder/tests/annotations.rs`: updated expected tool count from 4 to 5.

## Test plan

- [x] 363 tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Dependency audit clean (`cargo deny check advisories licenses`)
- [x] Security scan clean (0 findings)
- [x] GPG signed and DCO signed-off

Closes #674
Closes #675
