### PR TITLE
feat(tools): add write_file and edit_file tools

### DIFF
--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! File read utilities for the edit tools.
 
-use crate::types::ReadFileOutput;
+use crate::types::{EditFileOutput, ReadFileOutput, WriteFileOutput};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -18,6 +18,14 @@ pub enum EditError {
     },
     #[error("path is a directory, not a file: {0}")]
     NotAFile(PathBuf),
+    #[error(
+        "old_text not found in {path} — verify the text matches exactly, including whitespace and newlines"
+    )]
+    NotFound { path: String },
+    #[error(
+        "old_text appears {count} times in {path} — make old_text longer and more specific to uniquely identify the block"
+    )]
+    Ambiguous { count: usize, path: String },
 }
 
 pub fn read_file_range(
@@ -58,6 +66,57 @@ pub fn read_file_range(
         start_line: start,
         end_line: end,
         content,
+    })
+}
+
+pub fn write_file_content(path: &Path, content: &str) -> Result<WriteFileOutput, EditError> {
+    if path.is_dir() {
+        return Err(EditError::NotAFile(path.to_path_buf()));
+    }
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, content)?;
+    Ok(WriteFileOutput {
+        path: path.display().to_string(),
+        bytes_written: content.len(),
+    })
+}
+
+pub fn edit_file_replace(
+    path: &Path,
+    old_text: &str,
+    new_text: &str,
+) -> Result<EditFileOutput, EditError> {
+    if path.is_dir() {
+        return Err(EditError::NotAFile(path.to_path_buf()));
+    }
+    let content = std::fs::read_to_string(path)?;
+    let count = content.matches(old_text).count();
+    match count {
+        0 => {
+            return Err(EditError::NotFound {
+                path: path.display().to_string(),
+            });
+        }
+        1 => {}
+        n => {
+            return Err(EditError::Ambiguous {
+                count: n,
+                path: path.display().to_string(),
+            });
+        }
+    }
+    let bytes_before = content.len();
+    let updated = content.replacen(old_text, new_text, 1);
+    let bytes_after = updated.len();
+    std::fs::write(path, &updated)?;
+    Ok(EditFileOutput {
+        path: path.display().to_string(),
+        bytes_before,
+        bytes_after,
     })
 }
 
@@ -118,5 +177,76 @@ mod tests {
         let out = read_file_range(f.path(), None, None).unwrap();
         assert_eq!(out.total_lines, 0);
         assert_eq!(out.content, "");
+    }
+
+    #[test]
+    fn write_file_content_creates_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.txt");
+        let result = write_file_content(&path, "hello world").unwrap();
+        assert_eq!(result.bytes_written, 11);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn write_file_content_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("existing.txt");
+        std::fs::write(&path, "old content").unwrap();
+        let result = write_file_content(&path, "new content").unwrap();
+        assert_eq!(result.bytes_written, 11);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new content");
+    }
+
+    #[test]
+    fn write_file_content_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a").join("b").join("c.txt");
+        let result = write_file_content(&path, "nested").unwrap();
+        assert_eq!(result.bytes_written, 6);
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn write_file_content_directory_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = write_file_content(dir.path(), "content").unwrap_err();
+        assert!(matches!(err, EditError::NotAFile(_)));
+    }
+
+    #[test]
+    fn edit_file_replace_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        std::fs::write(&path, "foo bar baz").unwrap();
+        let result = edit_file_replace(&path, "bar", "qux").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "foo qux baz");
+        assert_eq!(result.bytes_before, 11);
+        assert_eq!(result.bytes_after, 11);
+    }
+
+    #[test]
+    fn edit_file_replace_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        std::fs::write(&path, "foo bar baz").unwrap();
+        let err = edit_file_replace(&path, "missing", "x").unwrap_err();
+        assert!(matches!(err, EditError::NotFound { .. }));
+    }
+
+    #[test]
+    fn edit_file_replace_ambiguous() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        std::fs::write(&path, "foo foo baz").unwrap();
+        let err = edit_file_replace(&path, "foo", "x").unwrap_err();
+        assert!(matches!(err, EditError::Ambiguous { count: 2, .. }));
+    }
+
+    #[test]
+    fn edit_file_replace_directory_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = edit_file_replace(dir.path(), "old", "new").unwrap_err();
+        assert!(matches!(err, EditError::NotAFile(_)));
     }
 }

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -64,7 +64,7 @@ pub use analyze::{
     analyze_module_file, analyze_str,
 };
 pub use config::AnalysisConfig;
-pub use edit::{EditError, read_file_range};
+pub use edit::{EditError, edit_file_replace, read_file_range, write_file_content};
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;
 pub use types::*;

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -787,3 +787,43 @@ pub struct ReadFileOutput {
     pub end_line: usize,
     pub content: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct WriteFileParams {
+    /// Path to the file to create or overwrite.
+    pub path: String,
+    /// UTF-8 content to write.
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct WriteFileOutput {
+    /// Path of the file that was written.
+    pub path: String,
+    /// Number of bytes written (UTF-8 byte length of content).
+    pub bytes_written: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct EditFileParams {
+    /// Path to the file to edit.
+    pub path: String,
+    /// Exact text block to find and replace. Must appear exactly once in the file.
+    pub old_text: String,
+    /// Replacement text.
+    pub new_text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct EditFileOutput {
+    /// Path of the file that was edited.
+    pub path: String,
+    /// File size in bytes before the edit.
+    pub bytes_before: usize,
+    /// File size in bytes after the edit.
+    pub bytes_after: usize,
+}

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -46,7 +46,8 @@ use aptu_coder_core::traversal::{
 };
 use aptu_coder_core::types::{
     AnalysisMode, AnalyzeDirectoryParams, AnalyzeFileParams, AnalyzeModuleParams,
-    AnalyzeSymbolParams, SymbolMatchMode,
+    AnalyzeSymbolParams, EditFileOutput, EditFileParams, SymbolMatchMode, WriteFileOutput,
+    WriteFileParams,
 };
 use logging::LogEvent;
 use rmcp::handler::server::tool::{ToolRouter, schema_for_type};
@@ -1843,6 +1844,410 @@ impl CodeAnalyzer {
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
             tool: "read_file",
+            duration_ms: dur,
+            output_chars: text.len(),
+            param_path_depth: crate::metrics::path_component_count(&param_path),
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: sid,
+            seq: Some(seq),
+            cache_hit: None,
+        });
+        Ok(result)
+    }
+
+    #[instrument(skip(self, _context))]
+    #[tool(
+        name = "write_file",
+        description = "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_file to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content.",
+        output_schema = schema_for_type::<WriteFileOutput>(),
+        annotations(
+            title = "Write File",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn write_file(
+        &self,
+        params: Parameters<WriteFileParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let params = params.0;
+        let t_start = std::time::Instant::now();
+        let param_path = params.path.clone();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+
+        // Guard against directory paths
+        if std::fs::metadata(&params.path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "write_file",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(&param_path),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid.clone(),
+                seq: Some(seq),
+                cache_hit: None,
+            });
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "path is a directory; cannot write to a directory".to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a file path, not a directory",
+                )),
+            )));
+        }
+
+        let path = std::path::PathBuf::from(&params.path);
+        let content = params.content.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            aptu_coder_core::write_file_content(&path, &content)
+        });
+
+        let output = match handle.await {
+            Ok(Ok(v)) => v,
+            Ok(Err(aptu_coder_core::EditError::NotAFile(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "write_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "path is a directory".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "provide a file path, not a directory",
+                    )),
+                )));
+            }
+            Ok(Err(e)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "write_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "write_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+        };
+
+        let text = format!("Wrote {} bytes to {}", output.bytes_written, output.path);
+        let mut result = CallToolResult::success(vec![Content::text(text.clone())])
+            .with_meta(Some(no_cache_meta()));
+        let structured = match serde_json::to_value(&output).map_err(|e| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("serialization failed: {e}"),
+                Some(error_meta("internal", false, "report this as a bug")),
+            )
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
+        result.structured_content = Some(structured);
+        self.cache
+            .invalidate_file(&std::path::PathBuf::from(&param_path));
+        let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            ts: crate::metrics::unix_ms(),
+            tool: "write_file",
+            duration_ms: dur,
+            output_chars: text.len(),
+            param_path_depth: crate::metrics::path_component_count(&param_path),
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: sid,
+            seq: Some(seq),
+            cache_hit: None,
+        });
+        Ok(result)
+    }
+
+    #[instrument(skip(self, _context))]
+    #[tool(
+        name = "edit_file",
+        description = "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once — fix by making old_text longer and more specific. Use write_file to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs.",
+        output_schema = schema_for_type::<EditFileOutput>(),
+        annotations(
+            title = "Edit File",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn edit_file(
+        &self,
+        params: Parameters<EditFileParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let params = params.0;
+        let t_start = std::time::Instant::now();
+        let param_path = params.path.clone();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+
+        // Guard against directory paths
+        if std::fs::metadata(&params.path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "edit_file",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(&param_path),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid.clone(),
+                seq: Some(seq),
+                cache_hit: None,
+            });
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "path is a directory; cannot edit a directory".to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a file path, not a directory",
+                )),
+            )));
+        }
+
+        let path = std::path::PathBuf::from(&params.path);
+        let old_text = params.old_text.clone();
+        let new_text = params.new_text.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            aptu_coder_core::edit_file_replace(&path, &old_text, &new_text)
+        });
+
+        let output = match handle.await {
+            Ok(Ok(v)) => v,
+            Ok(Err(aptu_coder_core::EditError::NotFound { path: _ })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "edit_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "old_text not found in file — verify the text matches exactly, including whitespace and newlines".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "check that old_text appears in the file",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::Ambiguous { count, path: _ })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "edit_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    format!(
+                        "old_text appears {count} times in file — make old_text longer and more specific to uniquely identify the block"
+                    ),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "include more context in old_text to make it unique",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::NotAFile(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "edit_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "path is a directory".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "provide a file path, not a directory",
+                    )),
+                )));
+            }
+            Ok(Err(e)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "edit_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "edit_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+        };
+
+        let text = format!(
+            "Edited {}: {} bytes -> {} bytes",
+            output.path, output.bytes_before, output.bytes_after
+        );
+        let mut result = CallToolResult::success(vec![Content::text(text.clone())])
+            .with_meta(Some(no_cache_meta()));
+        let structured = match serde_json::to_value(&output).map_err(|e| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("serialization failed: {e}"),
+                Some(error_meta("internal", false, "report this as a bug")),
+            )
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
+        result.structured_content = Some(structured);
+        self.cache
+            .invalidate_file(&std::path::PathBuf::from(&param_path));
+        let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            ts: crate::metrics::unix_ms(),
+            tool: "edit_file",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 fn test_all_tools_have_correct_annotations() {
     let tools = CodeAnalyzer::list_tools();
 
-    assert_eq!(tools.len(), 5, "expected 5 registered tools");
+    assert_eq!(tools.len(), 7, "expected 7 registered tools");
 
     let expected_names = [
         "analyze_directory",
@@ -15,6 +15,8 @@ fn test_all_tools_have_correct_annotations() {
         "analyze_module",
         "analyze_symbol",
         "read_file",
+        "write_file",
+        "edit_file",
     ];
 
     for tool in &tools {
@@ -30,24 +32,57 @@ fn test_all_tools_have_correct_annotations() {
             .as_ref()
             .unwrap_or_else(|| panic!("tool {} is missing annotations", name));
 
-        assert_eq!(
-            annotations.read_only_hint,
-            Some(true),
-            "tool {} must have read_only_hint=true",
-            name
-        );
-        assert_eq!(
-            annotations.destructive_hint,
-            Some(false),
-            "tool {} must have destructive_hint=false",
-            name
-        );
-        assert_eq!(
-            annotations.idempotent_hint,
-            Some(true),
-            "tool {} must have idempotent_hint=true",
-            name
-        );
+        // write_file and edit_file are destructive; others are read-only
+        if name == "write_file" || name == "edit_file" {
+            assert_eq!(
+                annotations.read_only_hint,
+                Some(false),
+                "tool {} must have read_only_hint=false",
+                name
+            );
+            assert_eq!(
+                annotations.destructive_hint,
+                Some(true),
+                "tool {} must have destructive_hint=true",
+                name
+            );
+            assert_eq!(
+                annotations.idempotent_hint,
+                Some(false),
+                "tool {} must have idempotent_hint=false",
+                name
+            );
+        } else {
+            assert_eq!(
+                annotations.read_only_hint,
+                Some(true),
+                "tool {} must have read_only_hint=true",
+                name
+            );
+            assert_eq!(
+                annotations.destructive_hint,
+                Some(false),
+                "tool {} must have destructive_hint=false",
+                name
+            );
+            // analyze_directory is idempotent; others are not
+            if name == "analyze_directory" {
+                assert_eq!(
+                    annotations.idempotent_hint,
+                    Some(true),
+                    "tool {} must have idempotent_hint=true",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    annotations.idempotent_hint,
+                    Some(true),
+                    "tool {} must have idempotent_hint=true",
+                    name
+                );
+            }
+        }
+
         assert_eq!(
             annotations.open_world_hint,
             Some(false),


### PR DESCRIPTION
## Summary

Adds `write_file` and `edit_file` MCP tools to aptu-coder (Wave 9 Phase 1), completing issues #676 and #677 in a single PR. Both tools follow the established `read_file` handler pattern exactly: `is_dir` guard before `spawn_blocking`, cache invalidation on success only, metrics on every code path, `no_cache_meta()`, and `structured_content`.

## Changes

- `crates/aptu-coder-core/src/types.rs` — `WriteFileParams`, `WriteFileOutput`, `EditFileParams`, `EditFileOutput` structs added
- `crates/aptu-coder-core/src/edit.rs` — `EditError` extended with `NotFound` and `Ambiguous { count }` variants; `write_file_content()` and `edit_file_replace()` implemented; 8 unit tests added
- `crates/aptu-coder-core/src/lib.rs` — `write_file_content` and `edit_file_replace` re-exported
- `crates/aptu-coder/src/lib.rs` — `write_file` and `edit_file` tool handlers wired into the `#[tool_router]` impl block
- `crates/aptu-coder/tests/annotations.rs` — updated to expect 7 tools with correct destructive annotations

## Tool annotations

Both tools carry: `read_only_hint = false`, `destructive_hint = true`, `idempotent_hint = false`, `open_world_hint = false`.

## Error handling

| Condition | Error code |
|-----------|------------|
| Path is a directory | `INVALID_PARAMS` |
| `before` text not found in file | `INVALID_PARAMS` |
| `before` text matches more than once | `INVALID_PARAMS` (includes match count) |
| Parent dir creation fails | `INTERNAL_ERROR` |
| Write / read fails | `INTERNAL_ERROR` |
| `spawn_blocking` join error | `INTERNAL_ERROR` |

## Test plan

- [x] 8 new unit tests (create new file, overwrite, create with missing parent dirs, directory guard for write; happy path, not-found, ambiguous, directory guard for edit)
- [x] 366 tests pass: `cargo test`
- [x] Linter clean: `cargo clippy -- -D warnings`
- [x] Format clean: `cargo fmt --check`
- [x] Dependency audit clean: `cargo deny check advisories licenses`
- [x] Security scan clean (gitleaks: 0 leaks)

Closes #676
Closes #677
