### PR TITLE
feat(tools): add rename_symbol and insert_at_symbol tools

### DIFF
--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! File read utilities for the edit tools.
 
-use crate::types::{EditFileOutput, ReadFileOutput, WriteFileOutput};
+use crate::types::{
+    EditFileOutput, InsertAtSymbolOutput, InsertPosition, ReadFileOutput, RenameSymbolOutput,
+    WriteFileOutput,
+};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -26,7 +29,23 @@ pub enum EditError {
         "old_text appears {count} times in {path} — make old_text longer and more specific to uniquely identify the block"
     )]
     Ambiguous { count: usize, path: String },
+    #[error("symbol '{name}' not found in {path}")]
+    SymbolNotFound { name: String, path: String },
+    #[error("symbol '{name}' matches multiple node kinds in {path} — supply kind to disambiguate")]
+    AmbiguousKind {
+        name: String,
+        kinds: Vec<String>,
+        path: String,
+    },
+    #[error("unsupported file extension for AST operations: {0}")]
+    UnsupportedLanguage(String),
+    #[error(
+        "kind filtering is not supported with the current identifier query infrastructure; omit kind to rename all occurrences"
+    )]
+    KindFilterUnsupported,
 }
+
+const IDENTIFIER_QUERY: &str = "(identifier) @name";
 
 pub fn read_file_range(
     path: &Path,
@@ -117,6 +136,130 @@ pub fn edit_file_replace(
         path: path.display().to_string(),
         bytes_before,
         bytes_after,
+    })
+}
+
+pub fn rename_symbol_in_file(
+    path: &Path,
+    old_name: &str,
+    new_name: &str,
+    kind: Option<&str>,
+) -> Result<RenameSymbolOutput, EditError> {
+    if kind.is_some() {
+        return Err(EditError::KindFilterUnsupported);
+    }
+
+    if path.is_dir() {
+        return Err(EditError::NotAFile(path.to_path_buf()));
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| EditError::UnsupportedLanguage("no extension".to_string()))?;
+
+    let language = crate::lang::language_for_extension(ext)
+        .ok_or_else(|| EditError::UnsupportedLanguage(ext.to_string()))?;
+
+    let source = std::fs::read_to_string(path)?;
+
+    let captures = crate::execute_query(language, &source, IDENTIFIER_QUERY)
+        .map_err(|_| EditError::UnsupportedLanguage(language.to_string()))?;
+
+    let matching_captures: Vec<_> = captures.iter().filter(|c| c.text == old_name).collect();
+
+    if matching_captures.is_empty() {
+        return Err(EditError::SymbolNotFound {
+            name: old_name.to_string(),
+            path: path.display().to_string(),
+        });
+    }
+
+    let mut bytes: Vec<u8> = source.into_bytes();
+    let mut sorted_captures = matching_captures.clone();
+    sorted_captures.sort_by_key(|b| std::cmp::Reverse(b.start_byte));
+
+    for capture in sorted_captures {
+        let start = capture.start_byte;
+        let end = capture.end_byte;
+        bytes.splice(start..end, new_name.bytes());
+    }
+
+    let updated = String::from_utf8(bytes).map_err(|_| {
+        EditError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid UTF-8 after rename",
+        ))
+    })?;
+
+    std::fs::write(path, &updated)?;
+
+    Ok(RenameSymbolOutput {
+        path: path.display().to_string(),
+        old_name: old_name.to_string(),
+        new_name: new_name.to_string(),
+        occurrences_renamed: matching_captures.len(),
+    })
+}
+
+pub fn insert_at_symbol_in_file(
+    path: &Path,
+    symbol_name: &str,
+    position: InsertPosition,
+    content: &str,
+) -> Result<InsertAtSymbolOutput, EditError> {
+    if path.is_dir() {
+        return Err(EditError::NotAFile(path.to_path_buf()));
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| EditError::UnsupportedLanguage("no extension".to_string()))?;
+
+    let language = crate::lang::language_for_extension(ext)
+        .ok_or_else(|| EditError::UnsupportedLanguage(ext.to_string()))?;
+
+    let source = std::fs::read_to_string(path)?;
+
+    let captures = crate::execute_query(language, &source, IDENTIFIER_QUERY)
+        .map_err(|_| EditError::UnsupportedLanguage(language.to_string()))?;
+
+    let target = captures
+        .iter()
+        .find(|c| c.text == symbol_name)
+        .ok_or_else(|| EditError::SymbolNotFound {
+            name: symbol_name.to_string(),
+            path: path.display().to_string(),
+        })?;
+
+    let byte_offset = match position {
+        InsertPosition::Before => target.start_byte,
+        InsertPosition::After => target.end_byte,
+    };
+
+    let mut bytes: Vec<u8> = source.into_bytes();
+    bytes.splice(byte_offset..byte_offset, content.bytes());
+
+    let updated = String::from_utf8(bytes).map_err(|_| {
+        EditError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid UTF-8 after insert",
+        ))
+    })?;
+
+    std::fs::write(path, &updated)?;
+
+    let position_str = match position {
+        InsertPosition::Before => "before",
+        InsertPosition::After => "after",
+    };
+
+    Ok(InsertAtSymbolOutput {
+        path: path.display().to_string(),
+        symbol_name: symbol_name.to_string(),
+        position: position_str.to_string(),
+        byte_offset,
     })
 }
 
@@ -248,5 +391,82 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let err = edit_file_replace(dir.path(), "old", "new").unwrap_err();
         assert!(matches!(err, EditError::NotAFile(_)));
+    }
+
+    fn write_temp(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(ext).tempfile().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn rename_symbol_renames_identifier_not_comment() {
+        let src = "fn foo() {}\n// foo is a function\n";
+        let f = write_temp(src, ".rs");
+        let out = rename_symbol_in_file(f.path(), "foo", "bar", None).unwrap();
+        assert_eq!(out.occurrences_renamed, 1);
+        let updated = std::fs::read_to_string(f.path()).unwrap();
+        assert!(updated.contains("fn bar()"));
+        assert!(updated.contains("// foo is a function"));
+    }
+
+    #[test]
+    fn rename_symbol_not_found_error() {
+        let f = write_temp("fn foo() {}\n", ".rs");
+        let err = rename_symbol_in_file(f.path(), "missing", "bar", None).unwrap_err();
+        assert!(matches!(err, EditError::SymbolNotFound { .. }));
+    }
+
+    #[test]
+    fn rename_symbol_kind_returns_kind_filter_unsupported() {
+        let f = write_temp("fn foo() {}\n", ".rs");
+        let err = rename_symbol_in_file(f.path(), "foo", "bar", Some("function")).unwrap_err();
+        assert!(matches!(err, EditError::KindFilterUnsupported));
+    }
+
+    #[test]
+    fn rename_symbol_unsupported_extension() {
+        let f = write_temp("foo bar\n", ".txt");
+        let err = rename_symbol_in_file(f.path(), "foo", "bar", None).unwrap_err();
+        assert!(matches!(err, EditError::UnsupportedLanguage(_)));
+    }
+
+    #[test]
+    fn insert_before_symbol() {
+        let src = "fn foo() {}\n";
+        let f = write_temp(src, ".rs");
+        let out =
+            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::Before, "bar_").unwrap();
+        let updated = std::fs::read_to_string(f.path()).unwrap();
+        assert!(updated.contains("fn bar_foo()"));
+        assert_eq!(out.position, "before");
+    }
+
+    #[test]
+    fn insert_after_symbol() {
+        let src = "fn foo() {}\n";
+        let f = write_temp(src, ".rs");
+        let out =
+            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::After, "_renamed").unwrap();
+        let updated = std::fs::read_to_string(f.path()).unwrap();
+        assert!(updated.contains("fn foo_renamed()"));
+        assert_eq!(out.position, "after");
+    }
+
+    #[test]
+    fn insert_symbol_not_found_error() {
+        let f = write_temp("fn foo() {}\n", ".rs");
+        let err =
+            insert_at_symbol_in_file(f.path(), "missing", InsertPosition::Before, "x").unwrap_err();
+        assert!(matches!(err, EditError::SymbolNotFound { .. }));
+    }
+
+    #[test]
+    fn insert_unsupported_extension() {
+        let f = write_temp("foo bar\n", ".txt");
+        let err =
+            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::Before, "x").unwrap_err();
+        assert!(matches!(err, EditError::UnsupportedLanguage(_)));
     }
 }

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -64,7 +64,10 @@ pub use analyze::{
     analyze_module_file, analyze_str,
 };
 pub use config::AnalysisConfig;
-pub use edit::{EditError, edit_file_replace, read_file_range, write_file_content};
+pub use edit::{
+    EditError, edit_file_replace, insert_at_symbol_in_file, read_file_range, rename_symbol_in_file,
+    write_file_content,
+};
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;
 pub use types::*;

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -827,3 +827,56 @@ pub struct EditFileOutput {
     /// File size in bytes after the edit.
     pub bytes_after: usize,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct RenameSymbolParams {
+    /// File path to modify.
+    pub path: String,
+    /// Current name of the symbol (identifier) to rename.
+    pub old_name: String,
+    /// New name for the symbol.
+    pub new_name: String,
+    /// Reserved for future use; currently not supported. Supplying a value returns an error.
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct RenameSymbolOutput {
+    pub path: String,
+    pub old_name: String,
+    pub new_name: String,
+    pub occurrences_renamed: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub enum InsertPosition {
+    #[serde(rename = "before")]
+    Before,
+    #[serde(rename = "after")]
+    After,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct InsertAtSymbolParams {
+    /// File path to modify.
+    pub path: String,
+    /// Name of the symbol (identifier) to locate.
+    pub symbol_name: String,
+    /// Insert before or after the symbol.
+    pub position: InsertPosition,
+    /// Content to insert verbatim; include leading/trailing newlines as needed.
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct InsertAtSymbolOutput {
+    pub path: String,
+    pub symbol_name: String,
+    pub position: String,
+    pub byte_offset: usize,
+}

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -46,9 +46,11 @@ use aptu_coder_core::traversal::{
 };
 use aptu_coder_core::types::{
     AnalysisMode, AnalyzeDirectoryParams, AnalyzeFileParams, AnalyzeModuleParams,
-    AnalyzeSymbolParams, EditFileOutput, EditFileParams, SymbolMatchMode, WriteFileOutput,
+    AnalyzeSymbolParams, EditFileOutput, EditFileParams, InsertAtSymbolOutput,
+    InsertAtSymbolParams, RenameSymbolOutput, RenameSymbolParams, SymbolMatchMode, WriteFileOutput,
     WriteFileParams,
 };
+use aptu_coder_core::{insert_at_symbol_in_file, rename_symbol_in_file};
 use logging::LogEvent;
 use rmcp::handler::server::tool::{ToolRouter, schema_for_type};
 use rmcp::handler::server::wrapper::Parameters;
@@ -2248,6 +2250,492 @@ impl CodeAnalyzer {
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
             tool: "edit_file",
+            duration_ms: dur,
+            output_chars: text.len(),
+            param_path_depth: crate::metrics::path_component_count(&param_path),
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: sid,
+            seq: Some(seq),
+            cache_hit: None,
+        });
+        Ok(result)
+    }
+
+    #[instrument(skip(self, _context))]
+    #[tool(
+        name = "rename_symbol",
+        description = "AST-aware rename within a single file. Matches only syntactic identifiers — identifiers in string literals and comments are excluded. Errors if old_name not found. Note: the kind parameter is reserved for future use; supplying it currently returns an error. Example queries: Rename function parse_config to load_config in src/config.rs; Rename variable timeout to timeout_ms in src/client.rs.",
+        output_schema = schema_for_type::<RenameSymbolOutput>(),
+        annotations(
+            title = "Rename Symbol",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn rename_symbol(
+        &self,
+        params: Parameters<RenameSymbolParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let params = params.0;
+        let t_start = std::time::Instant::now();
+        let param_path = params.path.clone();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+
+        // Guard against directory paths
+        if std::fs::metadata(&params.path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "rename_symbol",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(&param_path),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid.clone(),
+                seq: Some(seq),
+                cache_hit: None,
+            });
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "rename_symbol operates on a single file — provide a file path, not a directory"
+                    .to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a file path, not a directory",
+                )),
+            )));
+        }
+
+        let path = std::path::PathBuf::from(&params.path);
+        let old_name = params.old_name.clone();
+        let new_name = params.new_name.clone();
+        let kind = params.kind.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            rename_symbol_in_file(&path, &old_name, &new_name, kind.as_deref())
+        });
+
+        let output = match handle.await {
+            Ok(Ok(v)) => v,
+            Ok(Err(aptu_coder_core::EditError::SymbolNotFound { .. })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "symbol not found in file".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "verify the symbol name and file path",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::AmbiguousKind { .. })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "symbol name is ambiguous".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "verify the symbol name is unique",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::UnsupportedLanguage(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "file language is not supported".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "check that the file has a supported language extension",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::KindFilterUnsupported)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "kind filtering is not supported with the current identifier query infrastructure"
+                        .to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "omit the kind parameter",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::NotAFile(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "path is a directory".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "provide a file path, not a directory",
+                    )),
+                )));
+            }
+            Ok(Err(e)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "rename_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+        };
+
+        let text = format!(
+            "Renamed '{}' to '{}' in {} ({} occurrence(s))",
+            output.old_name, output.new_name, output.path, output.occurrences_renamed
+        );
+        let mut result = CallToolResult::success(vec![Content::text(text.clone())])
+            .with_meta(Some(no_cache_meta()));
+        let structured = match serde_json::to_value(&output).map_err(|e| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("serialization failed: {e}"),
+                Some(error_meta("internal", false, "report this as a bug")),
+            )
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
+        result.structured_content = Some(structured);
+        self.cache
+            .invalidate_file(&std::path::PathBuf::from(&param_path));
+        let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            ts: crate::metrics::unix_ms(),
+            tool: "rename_symbol",
+            duration_ms: dur,
+            output_chars: text.len(),
+            param_path_depth: crate::metrics::path_component_count(&param_path),
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: sid,
+            seq: Some(seq),
+            cache_hit: None,
+        });
+        Ok(result)
+    }
+
+    #[instrument(skip(self, _context))]
+    #[tool(
+        name = "insert_at_symbol",
+        description = "Insert content immediately before or after a named AST node. position is before or after. The caller is responsible for including necessary newlines in content. Uses the first occurrence if symbol_name appears multiple times. Example queries: Insert a #[instrument] attribute before the handle_request function; Add a derive macro after the MyStruct definition. Note: content is inserted verbatim at the byte boundary — include leading/trailing newlines as needed.",
+        output_schema = schema_for_type::<InsertAtSymbolOutput>(),
+        annotations(
+            title = "Insert At Symbol",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn insert_at_symbol(
+        &self,
+        params: Parameters<InsertAtSymbolParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let params = params.0;
+        let t_start = std::time::Instant::now();
+        let param_path = params.path.clone();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+
+        // Guard against directory paths
+        if std::fs::metadata(&params.path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "insert_at_symbol",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(&param_path),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid.clone(),
+                seq: Some(seq),
+                cache_hit: None,
+            });
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "insert_at_symbol operates on a single file — provide a file path, not a directory"
+                    .to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a file path, not a directory",
+                )),
+            )));
+        }
+
+        let path = std::path::PathBuf::from(&params.path);
+        let symbol_name = params.symbol_name.clone();
+        let position = params.position;
+        let content = params.content.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            insert_at_symbol_in_file(&path, &symbol_name, position, &content)
+        });
+
+        let output = match handle.await {
+            Ok(Ok(v)) => v,
+            Ok(Err(aptu_coder_core::EditError::SymbolNotFound { .. })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "insert_at_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "symbol not found in file".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "verify the symbol name and file path",
+                    )),
+                )));
+            }
+            Ok(Err(aptu_coder_core::EditError::UnsupportedLanguage(_))) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "insert_at_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    "file language is not supported".to_string(),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "check that the file has a supported language extension",
+                    )),
+                )));
+            }
+            Ok(Err(e)) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "insert_at_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "insert_at_symbol",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("internal_error".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    Some(error_meta(
+                        "resource",
+                        false,
+                        "check file path and permissions",
+                    )),
+                )));
+            }
+        };
+
+        let text = format!(
+            "Inserted content {} '{}' in {} (at byte offset {})",
+            output.position, output.symbol_name, output.path, output.byte_offset
+        );
+        let mut result = CallToolResult::success(vec![Content::text(text.clone())])
+            .with_meta(Some(no_cache_meta()));
+        let structured = match serde_json::to_value(&output).map_err(|e| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                format!("serialization failed: {e}"),
+                Some(error_meta("internal", false, "report this as a bug")),
+            )
+        }) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_to_tool_result(e)),
+        };
+        result.structured_content = Some(structured);
+        self.cache
+            .invalidate_file(&std::path::PathBuf::from(&param_path));
+        let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            ts: crate::metrics::unix_ms(),
+            tool: "insert_at_symbol",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 fn test_all_tools_have_correct_annotations() {
     let tools = CodeAnalyzer::list_tools();
 
-    assert_eq!(tools.len(), 7, "expected 7 registered tools");
+    assert_eq!(tools.len(), 9, "expected 9 registered tools");
 
     let expected_names = [
         "analyze_directory",
@@ -17,6 +17,8 @@ fn test_all_tools_have_correct_annotations() {
         "read_file",
         "write_file",
         "edit_file",
+        "rename_symbol",
+        "insert_at_symbol",
     ];
 
     for tool in &tools {
@@ -32,8 +34,12 @@ fn test_all_tools_have_correct_annotations() {
             .as_ref()
             .unwrap_or_else(|| panic!("tool {} is missing annotations", name));
 
-        // write_file and edit_file are destructive; others are read-only
-        if name == "write_file" || name == "edit_file" {
+        // write_file, edit_file, rename_symbol, and insert_at_symbol are destructive; others are read-only
+        if name == "write_file"
+            || name == "edit_file"
+            || name == "rename_symbol"
+            || name == "insert_at_symbol"
+        {
             assert_eq!(
                 annotations.read_only_hint,
                 Some(false),


### PR DESCRIPTION
## Summary

Implements Wave 9 Phase 2 AST-backed editing tools. Both tools use the existing `execute_query` / `QueryCapture` infrastructure in `aptu-coder-core` and perform byte-level splicing on `Vec<u8>` to safely handle multibyte UTF-8 identifiers.

`rename_symbol` matches only syntactic identifier nodes in the tree-sitter AST, skipping identifiers in string literals and comments — unlike `edit_file` which operates on raw text. `insert_at_symbol` pins insertion to a node's `start_byte` or `end_byte`, avoiding the need for callers to know exact line numbers.

The `kind` parameter on `rename_symbol` is reserved for future use. It currently returns `INVALID_PARAMS` because `QueryCapture` does not expose `node.kind()` yet; adding that field is a separate breaking change.

## Changes

- `crates/aptu-coder-core/src/types.rs` — `RenameSymbolParams`, `RenameSymbolOutput`, `InsertPosition` (Copy), `InsertAtSymbolParams`, `InsertAtSymbolOutput`
- `crates/aptu-coder-core/src/edit.rs` — `EditError` variants `SymbolNotFound`, `AmbiguousKind`, `UnsupportedLanguage`, `KindFilterUnsupported`; `IDENTIFIER_QUERY` const; `rename_symbol_in_file` and `insert_at_symbol_in_file` with 8 unit tests
- `crates/aptu-coder-core/src/lib.rs` — re-export both new functions
- `crates/aptu-coder/src/lib.rs` — `rename_symbol` and `insert_at_symbol` tool handlers following the `write_file`/`edit_file` pattern; `spawn_blocking`, `cache.invalidate_file`, `MetricEvent` on all paths
- `crates/aptu-coder/tests/annotations.rs` — expect 9 tools; new tools classified as destructive writes

## Test plan

- [x] Tests pass: 374 passed, 0 failed (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Dependency audit clean (`cargo deny check advisories licenses`)
- [x] Security scan clean (gitleaks, 0 leaks)

Closes #678
Closes #679
