### PR TITLE
refactor(api): rename 5 Wave 9 tools into analyze_* and edit_* families

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Rust workspace with two crates:
 - `crates/aptu-coder-core` -- parsing, analysis, formatting, graph, pagination, types
 - `crates/aptu-coder` -- MCP server, tool handlers, logging, metrics
 
-Four MCP tools: `analyze_directory`, `analyze_file`, `analyze_symbol`, `analyze_module`.
+Nine MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family).
 Rust edition 2024, async with tokio, MCP protocol via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -224,6 +224,79 @@ analyze_symbol path: /path/to/project symbol: my_function follow_depth: 3
 analyze_symbol path: /path/to/project symbol: my_function max_depth: 3 follow_depth: 2
 ```
 
+### `analyze_raw`
+
+Read a file or range of lines from a file. Returns the file content with line numbers. Specify start_line and end_line (1-indexed, inclusive) to read a range; omit for full file.
+
+**Required:** `path` *(string)* -- file to read
+
+**Additional optional:**
+- `start_line` *(integer, optional)* -- starting line number (1-indexed, inclusive). Defaults to 1 if omitted.
+- `end_line` *(integer, optional)* -- ending line number (1-indexed, inclusive). Defaults to the last line if omitted.
+
+```bash
+analyze_raw path: /path/to/file.rs
+analyze_raw path: /path/to/file.rs start_line: 1 end_line: 50
+analyze_raw path: /path/to/file.rs start_line: 100 end_line: 150
+```
+
+### `edit_overwrite`
+
+Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use `edit_replace` to replace a specific block instead of the whole file.
+
+**Required:**
+- `path` *(string)* -- file to create or overwrite
+- `content` *(string)* -- UTF-8 content to write
+
+```bash
+edit_overwrite path: tests/foo_test.rs content: "..."
+edit_overwrite path: src/config.rs content: "..."
+```
+
+### `edit_replace`
+
+Replace a unique exact text block in a file. Errors if `old_text` appears zero times or more than once; fix by making `old_text` longer and more specific. Use `edit_overwrite` to replace the whole file.
+
+**Required:**
+- `path` *(string)* -- file to edit
+- `old_text` *(string)* -- exact text block to find and replace (must appear exactly once)
+- `new_text` *(string)* -- replacement text
+
+```bash
+edit_replace path: src/main.rs old_text: "..." new_text: "..."
+```
+
+### `edit_rename`
+
+AST-aware rename within a single file. Matches only syntactic identifiers -- identifiers in string literals and comments are excluded. Errors if `old_name` not found. Note: the `kind` parameter is reserved for future use; supplying it currently returns an error.
+
+**Required:**
+- `path` *(string)* -- file to modify
+- `old_name` *(string)* -- current name of the symbol (identifier) to rename
+- `new_name` *(string)* -- new name for the symbol
+
+**Additional optional:** `kind` *(string, optional)* -- reserved for future use; currently returns an error if supplied.
+
+```bash
+edit_rename path: src/config.rs old_name: parse_config new_name: load_config
+edit_rename path: src/client.rs old_name: timeout new_name: timeout_ms
+```
+
+### `edit_insert`
+
+Insert content immediately before or after a named AST node. `position` is `before` or `after`. The caller is responsible for including necessary newlines in `content`. Uses the first occurrence if `symbol_name` appears multiple times.
+
+**Required:**
+- `path` *(string)* -- file to modify
+- `symbol_name` *(string)* -- name of the symbol (identifier) to locate
+- `position` *(string)* -- `before` or `after`
+- `content` *(string)* -- content to insert verbatim; include leading/trailing newlines as needed
+
+```bash
+edit_insert path: src/lib.rs symbol_name: handle_request position: before content: "#[instrument]\n"
+edit_insert path: src/types.rs symbol_name: MyStruct position: after content: "\n#[derive(Debug)]\n"
+```
+
 ## Output Management
 
 For large codebases, two mechanisms prevent context overflow:
@@ -269,7 +342,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 ## Observability
 
-All four tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for the full schema.
+All nine tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for the full schema.
 
 ## Documentation
 

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
-//! File read utilities for the edit tools.
+//! File read and write utilities for the `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, and `edit_insert` tools.
 
 use crate::types::{
     AnalyzeRawOutput, EditInsertOutput, EditOverwriteOutput, EditRenameOutput, EditReplaceOutput,

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -3,8 +3,8 @@
 //! File read utilities for the edit tools.
 
 use crate::types::{
-    EditFileOutput, InsertAtSymbolOutput, InsertPosition, ReadFileOutput, RenameSymbolOutput,
-    WriteFileOutput,
+    AnalyzeRawOutput, EditInsertOutput, EditOverwriteOutput, EditRenameOutput, EditReplaceOutput,
+    InsertPosition,
 };
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -47,11 +47,11 @@ pub enum EditError {
 
 const IDENTIFIER_QUERY: &str = "(identifier) @name";
 
-pub fn read_file_range(
+pub fn analyze_raw_range(
     path: &Path,
     start_line: Option<usize>,
     end_line: Option<usize>,
-) -> Result<ReadFileOutput, EditError> {
+) -> Result<AnalyzeRawOutput, EditError> {
     if path.is_dir() {
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
@@ -59,7 +59,7 @@ pub fn read_file_range(
     let lines: Vec<&str> = raw.lines().collect();
     let total = lines.len();
     if total == 0 {
-        return Ok(ReadFileOutput {
+        return Ok(AnalyzeRawOutput {
             path: path.display().to_string(),
             total_lines: 0,
             start_line: 0,
@@ -79,7 +79,7 @@ pub fn read_file_range(
         .map(|(i, line)| format!("{:>width$}: {}", start + i, line, width = width))
         .collect::<Vec<_>>()
         .join("\n");
-    Ok(ReadFileOutput {
+    Ok(AnalyzeRawOutput {
         path: path.display().to_string(),
         total_lines: total,
         start_line: start,
@@ -88,7 +88,10 @@ pub fn read_file_range(
     })
 }
 
-pub fn write_file_content(path: &Path, content: &str) -> Result<WriteFileOutput, EditError> {
+pub fn edit_overwrite_content(
+    path: &Path,
+    content: &str,
+) -> Result<EditOverwriteOutput, EditError> {
     if path.is_dir() {
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
@@ -98,17 +101,17 @@ pub fn write_file_content(path: &Path, content: &str) -> Result<WriteFileOutput,
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, content)?;
-    Ok(WriteFileOutput {
+    Ok(EditOverwriteOutput {
         path: path.display().to_string(),
         bytes_written: content.len(),
     })
 }
 
-pub fn edit_file_replace(
+pub fn edit_replace_block(
     path: &Path,
     old_text: &str,
     new_text: &str,
-) -> Result<EditFileOutput, EditError> {
+) -> Result<EditReplaceOutput, EditError> {
     if path.is_dir() {
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
@@ -132,19 +135,19 @@ pub fn edit_file_replace(
     let updated = content.replacen(old_text, new_text, 1);
     let bytes_after = updated.len();
     std::fs::write(path, &updated)?;
-    Ok(EditFileOutput {
+    Ok(EditReplaceOutput {
         path: path.display().to_string(),
         bytes_before,
         bytes_after,
     })
 }
 
-pub fn rename_symbol_in_file(
+pub fn edit_rename_in_file(
     path: &Path,
     old_name: &str,
     new_name: &str,
     kind: Option<&str>,
-) -> Result<RenameSymbolOutput, EditError> {
+) -> Result<EditRenameOutput, EditError> {
     if kind.is_some() {
         return Err(EditError::KindFilterUnsupported);
     }
@@ -194,7 +197,7 @@ pub fn rename_symbol_in_file(
 
     std::fs::write(path, &updated)?;
 
-    Ok(RenameSymbolOutput {
+    Ok(EditRenameOutput {
         path: path.display().to_string(),
         old_name: old_name.to_string(),
         new_name: new_name.to_string(),
@@ -202,12 +205,12 @@ pub fn rename_symbol_in_file(
     })
 }
 
-pub fn insert_at_symbol_in_file(
+pub fn edit_insert_at_symbol(
     path: &Path,
     symbol_name: &str,
     position: InsertPosition,
     content: &str,
-) -> Result<InsertAtSymbolOutput, EditError> {
+) -> Result<EditInsertOutput, EditError> {
     if path.is_dir() {
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
@@ -255,7 +258,7 @@ pub fn insert_at_symbol_in_file(
         InsertPosition::After => "after",
     };
 
-    Ok(InsertAtSymbolOutput {
+    Ok(EditInsertOutput {
         path: path.display().to_string(),
         symbol_name: symbol_name.to_string(),
         position: position_str.to_string(),
@@ -276,9 +279,9 @@ mod tests {
     }
 
     #[test]
-    fn test_read_full_file() {
+    fn test_analyze_raw_full_file() {
         let f = make_temp_file("line1\nline2\nline3\n");
-        let out = read_file_range(f.path(), None, None).unwrap();
+        let out = analyze_raw_range(f.path(), None, None).unwrap();
         assert_eq!(out.total_lines, 3);
         assert_eq!(out.start_line, 1);
         assert_eq!(out.end_line, 3);
@@ -287,9 +290,9 @@ mod tests {
     }
 
     #[test]
-    fn test_read_partial_range() {
+    fn test_analyze_raw_partial_range() {
         let f = make_temp_file("a\nb\nc\nd\ne\n");
-        let out = read_file_range(f.path(), Some(2), Some(4)).unwrap();
+        let out = analyze_raw_range(f.path(), Some(2), Some(4)).unwrap();
         assert_eq!(out.start_line, 2);
         assert_eq!(out.end_line, 4);
         assert!(out.content.contains("b"));
@@ -299,97 +302,97 @@ mod tests {
     }
 
     #[test]
-    fn test_read_invalid_range() {
+    fn test_analyze_raw_invalid_range() {
         let f = make_temp_file("a\nb\nc\n");
-        let err = read_file_range(f.path(), Some(3), Some(1)).unwrap_err();
+        let err = analyze_raw_range(f.path(), Some(3), Some(1)).unwrap_err();
         assert!(matches!(err, EditError::InvalidRange { .. }));
     }
 
     #[test]
-    fn test_read_clamped_range() {
+    fn test_analyze_raw_clamped_range() {
         let f = make_temp_file("x\ny\nz\n");
         // end_line beyond total should clamp
-        let out = read_file_range(f.path(), Some(1), Some(999)).unwrap();
+        let out = analyze_raw_range(f.path(), Some(1), Some(999)).unwrap();
         assert_eq!(out.end_line, 3);
         assert_eq!(out.total_lines, 3);
     }
 
     #[test]
-    fn test_read_empty_file() {
+    fn test_analyze_raw_empty_file() {
         let f = make_temp_file("");
-        let out = read_file_range(f.path(), None, None).unwrap();
+        let out = analyze_raw_range(f.path(), None, None).unwrap();
         assert_eq!(out.total_lines, 0);
         assert_eq!(out.content, "");
     }
 
     #[test]
-    fn write_file_content_creates_new_file() {
+    fn edit_overwrite_content_creates_new_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("new.txt");
-        let result = write_file_content(&path, "hello world").unwrap();
+        let result = edit_overwrite_content(&path, "hello world").unwrap();
         assert_eq!(result.bytes_written, 11);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello world");
     }
 
     #[test]
-    fn write_file_content_overwrites_existing() {
+    fn edit_overwrite_content_overwrites_existing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("existing.txt");
         std::fs::write(&path, "old content").unwrap();
-        let result = write_file_content(&path, "new content").unwrap();
+        let result = edit_overwrite_content(&path, "new content").unwrap();
         assert_eq!(result.bytes_written, 11);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "new content");
     }
 
     #[test]
-    fn write_file_content_creates_parent_dirs() {
+    fn edit_overwrite_content_creates_parent_dirs() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("a").join("b").join("c.txt");
-        let result = write_file_content(&path, "nested").unwrap();
+        let result = edit_overwrite_content(&path, "nested").unwrap();
         assert_eq!(result.bytes_written, 6);
         assert!(path.exists());
     }
 
     #[test]
-    fn write_file_content_directory_guard() {
+    fn edit_overwrite_content_directory_guard() {
         let dir = tempfile::tempdir().unwrap();
-        let err = write_file_content(dir.path(), "content").unwrap_err();
+        let err = edit_overwrite_content(dir.path(), "content").unwrap_err();
         assert!(matches!(err, EditError::NotAFile(_)));
     }
 
     #[test]
-    fn edit_file_replace_happy_path() {
+    fn edit_replace_block_happy_path() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo bar baz").unwrap();
-        let result = edit_file_replace(&path, "bar", "qux").unwrap();
+        let result = edit_replace_block(&path, "bar", "qux").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "foo qux baz");
         assert_eq!(result.bytes_before, 11);
         assert_eq!(result.bytes_after, 11);
     }
 
     #[test]
-    fn edit_file_replace_not_found() {
+    fn edit_replace_block_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo bar baz").unwrap();
-        let err = edit_file_replace(&path, "missing", "x").unwrap_err();
+        let err = edit_replace_block(&path, "missing", "x").unwrap_err();
         assert!(matches!(err, EditError::NotFound { .. }));
     }
 
     #[test]
-    fn edit_file_replace_ambiguous() {
+    fn edit_replace_block_ambiguous() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo foo baz").unwrap();
-        let err = edit_file_replace(&path, "foo", "x").unwrap_err();
+        let err = edit_replace_block(&path, "foo", "x").unwrap_err();
         assert!(matches!(err, EditError::Ambiguous { count: 2, .. }));
     }
 
     #[test]
-    fn edit_file_replace_directory_guard() {
+    fn edit_replace_block_directory_guard() {
         let dir = tempfile::tempdir().unwrap();
-        let err = edit_file_replace(dir.path(), "old", "new").unwrap_err();
+        let err = edit_replace_block(dir.path(), "old", "new").unwrap_err();
         assert!(matches!(err, EditError::NotAFile(_)));
     }
 
@@ -401,10 +404,10 @@ mod tests {
     }
 
     #[test]
-    fn rename_symbol_renames_identifier_not_comment() {
+    fn edit_rename_in_file_renames_identifier_not_comment() {
         let src = "fn foo() {}\n// foo is a function\n";
         let f = write_temp(src, ".rs");
-        let out = rename_symbol_in_file(f.path(), "foo", "bar", None).unwrap();
+        let out = edit_rename_in_file(f.path(), "foo", "bar", None).unwrap();
         assert_eq!(out.occurrences_renamed, 1);
         let updated = std::fs::read_to_string(f.path()).unwrap();
         assert!(updated.contains("fn bar()"));
@@ -412,61 +415,59 @@ mod tests {
     }
 
     #[test]
-    fn rename_symbol_not_found_error() {
+    fn edit_rename_in_file_not_found_error() {
         let f = write_temp("fn foo() {}\n", ".rs");
-        let err = rename_symbol_in_file(f.path(), "missing", "bar", None).unwrap_err();
+        let err = edit_rename_in_file(f.path(), "missing", "bar", None).unwrap_err();
         assert!(matches!(err, EditError::SymbolNotFound { .. }));
     }
 
     #[test]
-    fn rename_symbol_kind_returns_kind_filter_unsupported() {
+    fn edit_rename_in_file_kind_returns_kind_filter_unsupported() {
         let f = write_temp("fn foo() {}\n", ".rs");
-        let err = rename_symbol_in_file(f.path(), "foo", "bar", Some("function")).unwrap_err();
+        let err = edit_rename_in_file(f.path(), "foo", "bar", Some("function")).unwrap_err();
         assert!(matches!(err, EditError::KindFilterUnsupported));
     }
 
     #[test]
-    fn rename_symbol_unsupported_extension() {
+    fn edit_rename_in_file_unsupported_extension() {
         let f = write_temp("foo bar\n", ".txt");
-        let err = rename_symbol_in_file(f.path(), "foo", "bar", None).unwrap_err();
+        let err = edit_rename_in_file(f.path(), "foo", "bar", None).unwrap_err();
         assert!(matches!(err, EditError::UnsupportedLanguage(_)));
     }
 
     #[test]
-    fn insert_before_symbol() {
+    fn edit_insert_at_symbol_before() {
         let src = "fn foo() {}\n";
         let f = write_temp(src, ".rs");
-        let out =
-            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::Before, "bar_").unwrap();
+        let out = edit_insert_at_symbol(f.path(), "foo", InsertPosition::Before, "bar_").unwrap();
         let updated = std::fs::read_to_string(f.path()).unwrap();
         assert!(updated.contains("fn bar_foo()"));
         assert_eq!(out.position, "before");
     }
 
     #[test]
-    fn insert_after_symbol() {
+    fn edit_insert_at_symbol_after() {
         let src = "fn foo() {}\n";
         let f = write_temp(src, ".rs");
         let out =
-            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::After, "_renamed").unwrap();
+            edit_insert_at_symbol(f.path(), "foo", InsertPosition::After, "_renamed").unwrap();
         let updated = std::fs::read_to_string(f.path()).unwrap();
         assert!(updated.contains("fn foo_renamed()"));
         assert_eq!(out.position, "after");
     }
 
     #[test]
-    fn insert_symbol_not_found_error() {
+    fn edit_insert_at_symbol_not_found_error() {
         let f = write_temp("fn foo() {}\n", ".rs");
         let err =
-            insert_at_symbol_in_file(f.path(), "missing", InsertPosition::Before, "x").unwrap_err();
+            edit_insert_at_symbol(f.path(), "missing", InsertPosition::Before, "x").unwrap_err();
         assert!(matches!(err, EditError::SymbolNotFound { .. }));
     }
 
     #[test]
-    fn insert_unsupported_extension() {
+    fn edit_insert_at_symbol_unsupported_extension() {
         let f = write_temp("foo bar\n", ".txt");
-        let err =
-            insert_at_symbol_in_file(f.path(), "foo", InsertPosition::Before, "x").unwrap_err();
+        let err = edit_insert_at_symbol(f.path(), "foo", InsertPosition::Before, "x").unwrap_err();
         assert!(matches!(err, EditError::UnsupportedLanguage(_)));
     }
 }

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use analyze::{
 };
 pub use config::AnalysisConfig;
 pub use edit::{
-    EditError, edit_file_replace, insert_at_symbol_in_file, read_file_range, rename_symbol_in_file,
-    write_file_content,
+    EditError, analyze_raw_range, edit_insert_at_symbol, edit_overwrite_content,
+    edit_rename_in_file, edit_replace_block,
 };
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -769,7 +769,7 @@ mod error_meta_tests {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct ReadFileParams {
+pub struct AnalyzeRawParams {
     /// Path to the file to read (must be a file, not a directory).
     pub path: String,
     /// Starting line number (1-indexed, inclusive). Defaults to 1 if omitted.
@@ -780,7 +780,7 @@ pub struct ReadFileParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct ReadFileOutput {
+pub struct AnalyzeRawOutput {
     pub path: String,
     pub total_lines: usize,
     pub start_line: usize,
@@ -790,7 +790,7 @@ pub struct ReadFileOutput {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct WriteFileParams {
+pub struct EditOverwriteParams {
     /// Path to the file to create or overwrite.
     pub path: String,
     /// UTF-8 content to write.
@@ -799,7 +799,7 @@ pub struct WriteFileParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct WriteFileOutput {
+pub struct EditOverwriteOutput {
     /// Path of the file that was written.
     pub path: String,
     /// Number of bytes written (UTF-8 byte length of content).
@@ -808,7 +808,7 @@ pub struct WriteFileOutput {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct EditFileParams {
+pub struct EditReplaceParams {
     /// Path to the file to edit.
     pub path: String,
     /// Exact text block to find and replace. Must appear exactly once in the file.
@@ -819,7 +819,7 @@ pub struct EditFileParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct EditFileOutput {
+pub struct EditReplaceOutput {
     /// Path of the file that was edited.
     pub path: String,
     /// File size in bytes before the edit.
@@ -830,7 +830,7 @@ pub struct EditFileOutput {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct RenameSymbolParams {
+pub struct EditRenameParams {
     /// File path to modify.
     pub path: String,
     /// Current name of the symbol (identifier) to rename.
@@ -843,7 +843,7 @@ pub struct RenameSymbolParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct RenameSymbolOutput {
+pub struct EditRenameOutput {
     pub path: String,
     pub old_name: String,
     pub new_name: String,
@@ -861,7 +861,7 @@ pub enum InsertPosition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct InsertAtSymbolParams {
+pub struct EditInsertParams {
     /// File path to modify.
     pub path: String,
     /// Name of the symbol (identifier) to locate.
@@ -874,7 +874,7 @@ pub struct InsertAtSymbolParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct InsertAtSymbolOutput {
+pub struct EditInsertOutput {
     pub path: String,
     pub symbol_name: String,
     pub position: String,

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -46,11 +46,11 @@ use aptu_coder_core::traversal::{
 };
 use aptu_coder_core::types::{
     AnalysisMode, AnalyzeDirectoryParams, AnalyzeFileParams, AnalyzeModuleParams,
-    AnalyzeSymbolParams, EditFileOutput, EditFileParams, InsertAtSymbolOutput,
-    InsertAtSymbolParams, RenameSymbolOutput, RenameSymbolParams, SymbolMatchMode, WriteFileOutput,
-    WriteFileParams,
+    AnalyzeSymbolParams, EditInsertOutput, EditInsertParams, EditOverwriteOutput,
+    EditOverwriteParams, EditRenameOutput, EditRenameParams, EditReplaceOutput, EditReplaceParams,
+    SymbolMatchMode,
 };
-use aptu_coder_core::{insert_at_symbol_in_file, rename_symbol_in_file};
+use aptu_coder_core::{edit_insert_at_symbol, edit_rename_in_file};
 use logging::LogEvent;
 use rmcp::handler::server::tool::{ToolRouter, schema_for_type};
 use rmcp::handler::server::wrapper::Parameters;
@@ -1662,20 +1662,20 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self, _context))]
     #[tool(
-        name = "read_file",
+        name = "analyze_raw",
         description = "Read a file or range of lines from a file. Returns the file content with line numbers. Specify start_line and end_line (1-indexed, inclusive) to read a range; omit for full file. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs.",
-        output_schema = schema_for_type::<types::ReadFileOutput>(),
+        output_schema = schema_for_type::<types::AnalyzeRawOutput>(),
         annotations(
-            title = "Read File",
+            title = "Analyze Raw",
             read_only_hint = true,
             destructive_hint = false,
             idempotent_hint = true,
             open_world_hint = false
         )
     )]
-    async fn read_file(
+    async fn analyze_raw(
         &self,
-        params: Parameters<types::ReadFileParams>,
+        params: Parameters<types::AnalyzeRawParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
@@ -1694,7 +1694,7 @@ impl CodeAnalyzer {
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             self.metrics_tx.send(crate::metrics::MetricEvent {
                 ts: crate::metrics::unix_ms(),
-                tool: "read_file",
+                tool: "analyze_raw",
                 duration_ms: dur,
                 output_chars: 0,
                 param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1718,7 +1718,7 @@ impl CodeAnalyzer {
 
         let path = std::path::PathBuf::from(&params.path);
         let handle = tokio::task::spawn_blocking(move || {
-            aptu_coder_core::read_file_range(&path, params.start_line, params.end_line)
+            aptu_coder_core::analyze_raw_range(&path, params.start_line, params.end_line)
         });
 
         let output = match handle.await {
@@ -1727,7 +1727,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "read_file",
+                    tool: "analyze_raw",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1752,7 +1752,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "read_file",
+                    tool: "analyze_raw",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1777,7 +1777,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "read_file",
+                    tool: "analyze_raw",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1802,7 +1802,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "read_file",
+                    tool: "analyze_raw",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1845,7 +1845,7 @@ impl CodeAnalyzer {
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
-            tool: "read_file",
+            tool: "analyze_raw",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1861,20 +1861,20 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self, _context))]
     #[tool(
-        name = "write_file",
-        description = "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_file to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content.",
-        output_schema = schema_for_type::<WriteFileOutput>(),
+        name = "edit_overwrite",
+        description = "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_replace to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content.",
+        output_schema = schema_for_type::<EditOverwriteOutput>(),
         annotations(
-            title = "Write File",
+            title = "Edit Overwrite",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = false,
             open_world_hint = false
         )
     )]
-    async fn write_file(
+    async fn edit_overwrite(
         &self,
-        params: Parameters<WriteFileParams>,
+        params: Parameters<EditOverwriteParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
@@ -1893,7 +1893,7 @@ impl CodeAnalyzer {
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             self.metrics_tx.send(crate::metrics::MetricEvent {
                 ts: crate::metrics::unix_ms(),
-                tool: "write_file",
+                tool: "edit_overwrite",
                 duration_ms: dur,
                 output_chars: 0,
                 param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1918,7 +1918,7 @@ impl CodeAnalyzer {
         let path = std::path::PathBuf::from(&params.path);
         let content = params.content.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            aptu_coder_core::write_file_content(&path, &content)
+            aptu_coder_core::edit_overwrite_content(&path, &content)
         });
 
         let output = match handle.await {
@@ -1927,7 +1927,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "write_file",
+                    tool: "edit_overwrite",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1952,7 +1952,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "write_file",
+                    tool: "edit_overwrite",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -1977,7 +1977,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "write_file",
+                    tool: "edit_overwrite",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2019,7 +2019,7 @@ impl CodeAnalyzer {
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
-            tool: "write_file",
+            tool: "edit_overwrite",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2035,20 +2035,20 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self, _context))]
     #[tool(
-        name = "edit_file",
-        description = "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once — fix by making old_text longer and more specific. Use write_file to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs.",
-        output_schema = schema_for_type::<EditFileOutput>(),
+        name = "edit_replace",
+        description = "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once — fix by making old_text longer and more specific. Use edit_overwrite to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs.",
+        output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
-            title = "Edit File",
+            title = "Edit Replace",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = false,
             open_world_hint = false
         )
     )]
-    async fn edit_file(
+    async fn edit_replace(
         &self,
-        params: Parameters<EditFileParams>,
+        params: Parameters<EditReplaceParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
@@ -2067,7 +2067,7 @@ impl CodeAnalyzer {
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             self.metrics_tx.send(crate::metrics::MetricEvent {
                 ts: crate::metrics::unix_ms(),
-                tool: "edit_file",
+                tool: "edit_replace",
                 duration_ms: dur,
                 output_chars: 0,
                 param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2093,7 +2093,7 @@ impl CodeAnalyzer {
         let old_text = params.old_text.clone();
         let new_text = params.new_text.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            aptu_coder_core::edit_file_replace(&path, &old_text, &new_text)
+            aptu_coder_core::edit_replace_block(&path, &old_text, &new_text)
         });
 
         let output = match handle.await {
@@ -2102,7 +2102,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "edit_file",
+                    tool: "edit_replace",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2127,7 +2127,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "edit_file",
+                    tool: "edit_replace",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2154,7 +2154,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "edit_file",
+                    tool: "edit_replace",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2179,7 +2179,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "edit_file",
+                    tool: "edit_replace",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2204,7 +2204,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "edit_file",
+                    tool: "edit_replace",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2249,7 +2249,7 @@ impl CodeAnalyzer {
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
-            tool: "edit_file",
+            tool: "edit_replace",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2265,20 +2265,20 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self, _context))]
     #[tool(
-        name = "rename_symbol",
+        name = "edit_rename",
         description = "AST-aware rename within a single file. Matches only syntactic identifiers — identifiers in string literals and comments are excluded. Errors if old_name not found. Note: the kind parameter is reserved for future use; supplying it currently returns an error. Example queries: Rename function parse_config to load_config in src/config.rs; Rename variable timeout to timeout_ms in src/client.rs.",
-        output_schema = schema_for_type::<RenameSymbolOutput>(),
+        output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
-            title = "Rename Symbol",
+            title = "Edit Rename",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = false,
             open_world_hint = false
         )
     )]
-    async fn rename_symbol(
+    async fn edit_rename(
         &self,
-        params: Parameters<RenameSymbolParams>,
+        params: Parameters<EditRenameParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
@@ -2297,7 +2297,7 @@ impl CodeAnalyzer {
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             self.metrics_tx.send(crate::metrics::MetricEvent {
                 ts: crate::metrics::unix_ms(),
-                tool: "rename_symbol",
+                tool: "edit_rename",
                 duration_ms: dur,
                 output_chars: 0,
                 param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2310,7 +2310,7 @@ impl CodeAnalyzer {
             });
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
-                "rename_symbol operates on a single file — provide a file path, not a directory"
+                "edit_rename operates on a single file — provide a file path, not a directory"
                     .to_string(),
                 Some(error_meta(
                     "validation",
@@ -2325,7 +2325,7 @@ impl CodeAnalyzer {
         let new_name = params.new_name.clone();
         let kind = params.kind.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            rename_symbol_in_file(&path, &old_name, &new_name, kind.as_deref())
+            edit_rename_in_file(&path, &old_name, &new_name, kind.as_deref())
         });
 
         let output = match handle.await {
@@ -2334,7 +2334,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2359,7 +2359,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2384,7 +2384,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2409,7 +2409,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2435,7 +2435,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2460,7 +2460,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2485,7 +2485,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "rename_symbol",
+                    tool: "edit_rename",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2530,7 +2530,7 @@ impl CodeAnalyzer {
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
-            tool: "rename_symbol",
+            tool: "edit_rename",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2546,20 +2546,20 @@ impl CodeAnalyzer {
 
     #[instrument(skip(self, _context))]
     #[tool(
-        name = "insert_at_symbol",
+        name = "edit_insert",
         description = "Insert content immediately before or after a named AST node. position is before or after. The caller is responsible for including necessary newlines in content. Uses the first occurrence if symbol_name appears multiple times. Example queries: Insert a #[instrument] attribute before the handle_request function; Add a derive macro after the MyStruct definition. Note: content is inserted verbatim at the byte boundary — include leading/trailing newlines as needed.",
-        output_schema = schema_for_type::<InsertAtSymbolOutput>(),
+        output_schema = schema_for_type::<EditInsertOutput>(),
         annotations(
-            title = "Insert At Symbol",
+            title = "Edit Insert",
             read_only_hint = false,
             destructive_hint = true,
             idempotent_hint = false,
             open_world_hint = false
         )
     )]
-    async fn insert_at_symbol(
+    async fn edit_insert(
         &self,
-        params: Parameters<InsertAtSymbolParams>,
+        params: Parameters<EditInsertParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
@@ -2578,7 +2578,7 @@ impl CodeAnalyzer {
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
             self.metrics_tx.send(crate::metrics::MetricEvent {
                 ts: crate::metrics::unix_ms(),
-                tool: "insert_at_symbol",
+                tool: "edit_insert",
                 duration_ms: dur,
                 output_chars: 0,
                 param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2591,7 +2591,7 @@ impl CodeAnalyzer {
             });
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
-                "insert_at_symbol operates on a single file — provide a file path, not a directory"
+                "edit_insert operates on a single file — provide a file path, not a directory"
                     .to_string(),
                 Some(error_meta(
                     "validation",
@@ -2606,7 +2606,7 @@ impl CodeAnalyzer {
         let position = params.position;
         let content = params.content.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            insert_at_symbol_in_file(&path, &symbol_name, position, &content)
+            edit_insert_at_symbol(&path, &symbol_name, position, &content)
         });
 
         let output = match handle.await {
@@ -2615,7 +2615,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "insert_at_symbol",
+                    tool: "edit_insert",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2640,7 +2640,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "insert_at_symbol",
+                    tool: "edit_insert",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2665,7 +2665,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "insert_at_symbol",
+                    tool: "edit_insert",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2690,7 +2690,7 @@ impl CodeAnalyzer {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
-                    tool: "insert_at_symbol",
+                    tool: "edit_insert",
                     duration_ms: dur,
                     output_chars: 0,
                     param_path_depth: crate::metrics::path_component_count(&param_path),
@@ -2735,7 +2735,7 @@ impl CodeAnalyzer {
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
         self.metrics_tx.send(crate::metrics::MetricEvent {
             ts: crate::metrics::unix_ms(),
-            tool: "insert_at_symbol",
+            tool: "edit_insert",
             duration_ms: dur,
             output_chars: text.len(),
             param_path_depth: crate::metrics::path_component_count(&param_path),

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -14,11 +14,11 @@ fn test_all_tools_have_correct_annotations() {
         "analyze_file",
         "analyze_module",
         "analyze_symbol",
-        "read_file",
-        "write_file",
-        "edit_file",
-        "rename_symbol",
-        "insert_at_symbol",
+        "analyze_raw",
+        "edit_overwrite",
+        "edit_replace",
+        "edit_rename",
+        "edit_insert",
     ];
 
     for tool in &tools {
@@ -34,11 +34,11 @@ fn test_all_tools_have_correct_annotations() {
             .as_ref()
             .unwrap_or_else(|| panic!("tool {} is missing annotations", name));
 
-        // write_file, edit_file, rename_symbol, and insert_at_symbol are destructive; others are read-only
-        if name == "write_file"
-            || name == "edit_file"
-            || name == "rename_symbol"
-            || name == "insert_at_symbol"
+        // edit_overwrite, edit_replace, edit_rename, and edit_insert are destructive; others are read-only
+        if name == "edit_overwrite"
+            || name == "edit_replace"
+            || name == "edit_rename"
+            || name == "edit_insert"
         {
             assert_eq!(
                 annotations.read_only_hint,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 
 - **Minimize token usage**: Return only structured, relevant context - no prose, no noise
 - **Language-agnostic parsing via tree-sitter**: Support 11 languages (Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C, C++, C#) with a unified query-based extraction system; TypeScript and TSX use distinct grammars (`LANGUAGE_TYPESCRIPT` and `LANGUAGE_TSX`) but share the same queries in `crates/aptu-coder-core/src/languages/typescript.rs`
-- **Four focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, and `analyze_symbol` -- each with a clear, explicit interface rather than a single tool with auto-detected modes
+- **Nine focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
 - **Compatible with any MCP orchestrator**: Designed to work with any standards-compliant MCP host
 - **Performance via parallelism**: Use rayon for parallel file processing and ignore crate for efficient .gitignore-aware directory walking
 
@@ -21,14 +21,14 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | Module | File | Responsibility |
 |--------|------|-----------------|
 | `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
-| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` |
+| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` |
 | `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
 | `schema_helpers` | `crates/aptu-coder-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
 | `metrics` | `crates/aptu-coder/src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
-| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all four tools |
+| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all nine tools |
 | `traversal` | `crates/aptu-coder-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
 | `types` | `crates/aptu-coder-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
@@ -48,6 +48,11 @@ graph TD
     A --> B2["analyze_file"]
     A --> B4["analyze_module"]
     A --> B3["analyze_symbol"]
+    A --> B5["analyze_raw"]
+    A --> B6["edit_overwrite"]
+    A --> B7["edit_replace"]
+    A --> B8["edit_rename"]
+    A --> B9["edit_insert"]
     B1 --> M["walk_directory"]
     M --> N["Parallel Parse rayon"]
     N --> O["ElementExtractor"]
@@ -58,14 +63,23 @@ graph TD
     B4 --> R["Read File"]
     R --> S["analyze_module_file"]
     S --> T["format_module_info"]
-    T --> Q["MCP Response"]
     B3 --> G["walk_directory"]
     G --> H["Build CallGraph BFS"]
     H --> I["format_focused"]
+    B5 --> F1["analyze_raw_range"]
+    B6 --> F2["edit_overwrite_content"]
+    B7 --> F3["edit_replace_block"]
+    B8 --> F4["edit_rename_in_file"]
+    B9 --> F5["edit_insert_at_symbol"]
     P --> Q["MCP Response"]
     L --> Q
     T --> Q
     I --> Q
+    F1 --> Q
+    F2 --> Q
+    F3 --> Q
+    F4 --> Q
+    F5 --> Q
 ```
 
 ## Analysis Modes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,22 +140,22 @@ The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0
 
 Three tools with no tree-sitter dependency. These validate the BUILD agent workflow and establish the write-path integration before adding AST complexity.
 
-- `read_file(path, start_line?, end_line?)` -- "Raw file content with optional line range. Prefer start_line/end_line to limit tokens on large files; omit both for full content. Use analyze_file for structure, not content. Example queries: Read lines 10-40 of src/lib.rs; Show the full contents of config.toml." `read_only_hint=true`, `idempotent_hint=true`
-- `write_file(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_file to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
-- `edit_file(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use write_file to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `analyze_raw(path, start_line?, end_line?)` -- "Raw file content with optional line range. Prefer start_line/end_line to limit tokens on large files; omit both for full content. Use analyze_file for structure, not content. Example queries: Read lines 10-40 of src/lib.rs; Show the full contents of config.toml." `read_only_hint=true`, `idempotent_hint=true`
+- `edit_overwrite(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_replace to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `edit_replace(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use edit_overwrite to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
-Cache invalidation: `write_file` and `edit_file` must call `cache.invalidate_file(path)` after every write. mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations); explicit invalidation prevents stale reads within the same second.
+Cache invalidation: `edit_overwrite` and `edit_replace` must call `cache.invalidate_file(path)` after every write. mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations); explicit invalidation prevents stale reads within the same second.
 
 ### Phase 2: AST-backed tools
 
 Two tools that require `aptu-coder-core` (formerly `code-analyze-core`) capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
 
-- `rename_symbol(path, old_name, new_name, kind?)` -- "AST-aware rename within a single file. Matches by node kind, not string -- identifiers in string literals and comments are excluded. Errors if old_name not found; supply kind to disambiguate (function, variable, type). Directory-wide rename not supported in v1. Example queries: Rename function parse_config to load_config in src/config.rs; Rename struct field timeout to timeout_ms." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
-- `insert_at_symbol(path, symbol_name, position, content)` -- "Insert content immediately before or after a named AST node. position is before|after. Uses start_byte/end_byte from the capture pipeline; errors if symbol_name not found in file. Example queries: Insert a tracing span before the handle_request function; Add a derive macro after the MyStruct definition." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `edit_rename(path, old_name, new_name, kind?)` -- "AST-aware rename within a single file. Matches by node kind, not string -- identifiers in string literals and comments are excluded. Errors if old_name not found; supply kind to disambiguate (function, variable, type). Directory-wide rename not supported in v1. Example queries: Rename function parse_config to load_config in src/config.rs; Rename struct field timeout to timeout_ms." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
+- `edit_insert(path, symbol_name, position, content)` -- "Insert content immediately before or after a named AST node. position is before|after. Uses start_byte/end_byte from the capture pipeline; errors if symbol_name not found in file. Example queries: Insert a tracing span before the handle_request function; Add a derive macro after the MyStruct definition." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
 ### Annotation posture update
 
-Wave 9 write tools are the exception to the annotation freeze established in the Annotation Posture Policy section. Write tools (`write_file`, `edit_file`, `rename_symbol`, and `insert_at_symbol`) carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (`read_file`, and all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
+Wave 9 write tools are the exception to the annotation freeze established in the Annotation Posture Policy section. Write tools (`edit_overwrite`, `edit_replace`, `edit_rename`, and `edit_insert`) carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (`analyze_raw`, and all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
 
 Note: `read_only_hint` is a hint surfaced to MCP clients in `tools/list`; rmcp 1.5.0 has no per-tool access control enforcement.
 
@@ -165,7 +165,7 @@ Per the Small-Model-First Constraint: all five tools must be evaluated against H
 
 ### Risks
 
-- **Cache staleness** -- mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations). `write_file` and `edit_file` must always call `cache.invalidate_file(path)` after every write to prevent stale reads within the same second.
-- **`rename_symbol` scope creep** -- directory-wide rename requires type information tree-sitter cannot provide; enforce single-file boundary in v1 with a clear error if a directory path is supplied
+- **Cache staleness** -- mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations). `edit_overwrite` and `edit_replace` must always call `cache.invalidate_file(path)` after every write to prevent stale reads within the same second.
+- **`edit_rename` scope creep** -- directory-wide rename requires type information tree-sitter cannot provide; enforce single-file boundary in v1 with a clear error if a directory path is supplied
 - **Annotation posture drift** -- document the per-tool posture in this section; update REUSE.toml for any new source files
 - **SPDX headers** -- every new `.rs` file requires an SPDX header or `reuse lint` fails CI

--- a/docs/benchmarks/ISOLATION.md
+++ b/docs/benchmarks/ISOLATION.md
@@ -147,7 +147,7 @@ extensions:
     name: developer
     blocked_tools:
       - shell
-      - write_file
+      - edit_overwrite
 ```
 
 Blocked calls would return a structured error visible to the agent rather than silently


### PR DESCRIPTION
## Summary

Rename 5 MCP tool names from the Wave 9 additions into two coherent families: `analyze_*` (read-only, structural) and `edit_*` (mutating). No behavior, parameter signatures, or logic are changed -- this is a mechanical rename of the MCP-visible `name = "..."` strings and their associated Rust identifiers.

| Old name | New name | Family |
|---|---|---|
| `read_file` | `analyze_raw` | `analyze_*` |
| `write_file` | `edit_overwrite` | `edit_*` |
| `edit_file` | `edit_replace` | `edit_*` |
| `rename_symbol` | `edit_rename` | `edit_*` |
| `insert_at_symbol` | `edit_insert` | `edit_*` |

Resulting families after this change:

`analyze_*` (read-only, 5): `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`

`edit_*` (mutating, 4): `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`

## Changes

- `crates/aptu-coder-core/src/types.rs`: rename 10 Params/Output structs
- `crates/aptu-coder-core/src/edit.rs`: rename 5 public functions and 12 test functions
- `crates/aptu-coder-core/src/lib.rs`: update `pub use edit::{...}` re-exports
- `crates/aptu-coder/src/lib.rs`: update `name`/`title` strings in `#[tool(...)]`, ~38 `tool: "..."` log event strings, handler function names, type references, and description cross-references
- `crates/aptu-coder/tests/annotations.rs`: update `expected_names` array and destructive-tool condition (9 strings)
- `AGENTS.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/ROADMAP.md`, `docs/benchmarks/ISOLATION.md`: update all tool name references

No new dependencies. No unsafe code. No parameter or logic changes.

## Test plan

- [x] Tests pass: 374 passed, 0 failed (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] No advisories (`cargo deny check advisories licenses`)
- [x] Security scan: no findings
- [x] No old tool name strings remain in Rust code or documentation

Closes #689
