### PR TITLE
refactor(core): move analyze_raw_range from edit.rs to analyze.rs

### DIFF
--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -43,6 +43,16 @@ pub enum AnalyzeError {
     Cancelled,
     #[error("unsupported language: {0}")]
     UnsupportedLanguage(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid range: start ({start}) > end ({end}); file has {total} lines")]
+    InvalidRange {
+        start: usize,
+        end: usize,
+        total: usize,
+    },
+    #[error("path is a directory, not a file: {0}")]
+    NotAFile(PathBuf),
 }
 
 /// Result of directory analysis containing both formatted output and file data.
@@ -1384,6 +1394,59 @@ fn extract_string_list_from_list_node(
     }
 }
 
+/// Read a file and return its raw content with line numbers for a specified range.
+///
+/// # Arguments
+/// - `path`: File path to read
+/// - `start_line`: Starting line (1-indexed, optional; defaults to 1)
+/// - `end_line`: Ending line (1-indexed, optional; defaults to total lines)
+///
+/// # Returns
+/// - `Ok(AnalyzeRawOutput)` with formatted content and metadata
+/// - `Err(AnalyzeError::NotAFile)` if path is a directory
+/// - `Err(AnalyzeError::InvalidRange)` if start > end
+/// - `Err(AnalyzeError::Io)` for file I/O errors
+pub fn analyze_raw_range(
+    path: &Path,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+) -> Result<crate::types::AnalyzeRawOutput, AnalyzeError> {
+    if path.is_dir() {
+        return Err(AnalyzeError::NotAFile(path.to_path_buf()));
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let lines: Vec<&str> = raw.lines().collect();
+    let total = lines.len();
+    if total == 0 {
+        return Ok(crate::types::AnalyzeRawOutput {
+            path: path.display().to_string(),
+            total_lines: 0,
+            start_line: 0,
+            end_line: 0,
+            content: String::new(),
+        });
+    }
+    let start = start_line.unwrap_or(1).max(1).min(total.max(1));
+    let end = end_line.unwrap_or(total).min(total).max(1);
+    if start > end {
+        return Err(AnalyzeError::InvalidRange { start, end, total });
+    }
+    let width = end.to_string().len();
+    let content = lines[start - 1..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| format!("{:>width$}: {}", start + i, line, width = width))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(crate::types::AnalyzeRawOutput {
+        path: path.display().to_string(),
+        total_lines: total,
+        start_line: start,
+        end_line: end,
+        content,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1848,5 +1911,60 @@ fn caller_c() { target(); }
             output.formatted.contains("DEF-USE SITES"),
             "formatted output should contain DEF-USE SITES"
         );
+    }
+
+    fn make_temp_file(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_analyze_raw_full_file() {
+        let f = make_temp_file("line1\nline2\nline3\n");
+        let out = analyze_raw_range(f.path(), None, None).unwrap();
+        assert_eq!(out.total_lines, 3);
+        assert_eq!(out.start_line, 1);
+        assert_eq!(out.end_line, 3);
+        assert!(out.content.contains("line1"));
+        assert!(out.content.contains("line3"));
+    }
+
+    #[test]
+    fn test_analyze_raw_partial_range() {
+        let f = make_temp_file("a\nb\nc\nd\ne\n");
+        let out = analyze_raw_range(f.path(), Some(2), Some(4)).unwrap();
+        assert_eq!(out.start_line, 2);
+        assert_eq!(out.end_line, 4);
+        assert!(out.content.contains("b"));
+        assert!(out.content.contains("d"));
+        assert!(!out.content.contains("a"));
+        assert!(!out.content.contains("e"));
+    }
+
+    #[test]
+    fn test_analyze_raw_invalid_range() {
+        let f = make_temp_file("a\nb\nc\n");
+        let err = analyze_raw_range(f.path(), Some(3), Some(1)).unwrap_err();
+        assert!(matches!(err, AnalyzeError::InvalidRange { .. }));
+    }
+
+    #[test]
+    fn test_analyze_raw_clamped_range() {
+        let f = make_temp_file("x\ny\nz\n");
+        // end_line beyond total should clamp
+        let out = analyze_raw_range(f.path(), Some(1), Some(999)).unwrap();
+        assert_eq!(out.end_line, 3);
+        assert_eq!(out.total_lines, 3);
+    }
+
+    #[test]
+    fn test_analyze_raw_empty_file() {
+        let f = make_temp_file("");
+        let out = analyze_raw_range(f.path(), None, None).unwrap();
+        assert_eq!(out.total_lines, 0);
+        assert_eq!(out.content, "");
     }
 }

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
-//! File read and write utilities for the `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, and `edit_insert` tools.
+//! File write utilities for the `edit_overwrite`, `edit_replace`, `edit_rename`, and `edit_insert` tools.
 
 use crate::types::{
-    AnalyzeRawOutput, EditInsertOutput, EditOverwriteOutput, EditRenameOutput, EditReplaceOutput,
-    InsertPosition,
+    EditInsertOutput, EditOverwriteOutput, EditRenameOutput, EditReplaceOutput, InsertPosition,
 };
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -46,47 +45,6 @@ pub enum EditError {
 }
 
 const IDENTIFIER_QUERY: &str = "(identifier) @name";
-
-pub fn analyze_raw_range(
-    path: &Path,
-    start_line: Option<usize>,
-    end_line: Option<usize>,
-) -> Result<AnalyzeRawOutput, EditError> {
-    if path.is_dir() {
-        return Err(EditError::NotAFile(path.to_path_buf()));
-    }
-    let raw = std::fs::read_to_string(path)?;
-    let lines: Vec<&str> = raw.lines().collect();
-    let total = lines.len();
-    if total == 0 {
-        return Ok(AnalyzeRawOutput {
-            path: path.display().to_string(),
-            total_lines: 0,
-            start_line: 0,
-            end_line: 0,
-            content: String::new(),
-        });
-    }
-    let start = start_line.unwrap_or(1).max(1).min(total.max(1));
-    let end = end_line.unwrap_or(total).min(total).max(1);
-    if start > end {
-        return Err(EditError::InvalidRange { start, end, total });
-    }
-    let width = end.to_string().len();
-    let content = lines[start - 1..end]
-        .iter()
-        .enumerate()
-        .map(|(i, line)| format!("{:>width$}: {}", start + i, line, width = width))
-        .collect::<Vec<_>>()
-        .join("\n");
-    Ok(AnalyzeRawOutput {
-        path: path.display().to_string(),
-        total_lines: total,
-        start_line: start,
-        end_line: end,
-        content,
-    })
-}
 
 pub fn edit_overwrite_content(
     path: &Path,
@@ -276,53 +234,6 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         write!(f, "{}", content).unwrap();
         f
-    }
-
-    #[test]
-    fn test_analyze_raw_full_file() {
-        let f = make_temp_file("line1\nline2\nline3\n");
-        let out = analyze_raw_range(f.path(), None, None).unwrap();
-        assert_eq!(out.total_lines, 3);
-        assert_eq!(out.start_line, 1);
-        assert_eq!(out.end_line, 3);
-        assert!(out.content.contains("line1"));
-        assert!(out.content.contains("line3"));
-    }
-
-    #[test]
-    fn test_analyze_raw_partial_range() {
-        let f = make_temp_file("a\nb\nc\nd\ne\n");
-        let out = analyze_raw_range(f.path(), Some(2), Some(4)).unwrap();
-        assert_eq!(out.start_line, 2);
-        assert_eq!(out.end_line, 4);
-        assert!(out.content.contains("b"));
-        assert!(out.content.contains("d"));
-        assert!(!out.content.contains("a"));
-        assert!(!out.content.contains("e"));
-    }
-
-    #[test]
-    fn test_analyze_raw_invalid_range() {
-        let f = make_temp_file("a\nb\nc\n");
-        let err = analyze_raw_range(f.path(), Some(3), Some(1)).unwrap_err();
-        assert!(matches!(err, EditError::InvalidRange { .. }));
-    }
-
-    #[test]
-    fn test_analyze_raw_clamped_range() {
-        let f = make_temp_file("x\ny\nz\n");
-        // end_line beyond total should clamp
-        let out = analyze_raw_range(f.path(), Some(1), Some(999)).unwrap();
-        assert_eq!(out.end_line, 3);
-        assert_eq!(out.total_lines, 3);
-    }
-
-    #[test]
-    fn test_analyze_raw_empty_file() {
-        let f = make_temp_file("");
-        let out = analyze_raw_range(f.path(), None, None).unwrap();
-        assert_eq!(out.total_lines, 0);
-        assert_eq!(out.content, "");
     }
 
     #[test]

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -61,12 +61,12 @@ pub use analyze::{
     AnalysisOutput, AnalyzeError, CallChainEntry, FileAnalysisOutput, FocusedAnalysisConfig,
     FocusedAnalysisOutput, analyze_directory, analyze_directory_with_progress, analyze_file,
     analyze_focused, analyze_focused_with_progress, analyze_focused_with_progress_with_entries,
-    analyze_module_file, analyze_str,
+    analyze_module_file, analyze_raw_range, analyze_str,
 };
 pub use config::AnalysisConfig;
 pub use edit::{
-    EditError, analyze_raw_range, edit_insert_at_symbol, edit_overwrite_content,
-    edit_rename_in_file, edit_replace_block,
+    EditError, edit_insert_at_symbol, edit_overwrite_content, edit_rename_in_file,
+    edit_replace_block,
 };
 pub use lang::{language_for_extension, supported_languages};
 pub use parser::ParserError;

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1723,7 +1723,7 @@ impl CodeAnalyzer {
 
         let output = match handle.await {
             Ok(Ok(v)) => v,
-            Ok(Err(aptu_coder_core::EditError::InvalidRange { start, end, total })) => {
+            Ok(Err(aptu_coder_core::AnalyzeError::InvalidRange { start, end, total })) => {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),
@@ -1748,7 +1748,7 @@ impl CodeAnalyzer {
                     )),
                 )));
             }
-            Ok(Err(aptu_coder_core::EditError::NotAFile(_))) => {
+            Ok(Err(aptu_coder_core::AnalyzeError::NotAFile(_))) => {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {
                     ts: crate::metrics::unix_ms(),


### PR DESCRIPTION
## Summary

Moves `analyze_raw_range` from `crates/aptu-coder-core/src/edit.rs` to `crates/aptu-coder-core/src/analyze.rs`, where it belongs alongside the rest of the read-only `analyze_*` tool family. The `edit` module is now exclusively concerned with mutation operations. Error handling uses Option A: three new variants (`NotAFile`, `InvalidRange`, `Io`) are added to `AnalyzeError`, keeping `analyze.rs` self-contained without any cross-module dependency on `EditError`.

## Changes

- `crates/aptu-coder-core/src/analyze.rs`: added `NotAFile`, `InvalidRange`, and `Io` variants to `AnalyzeError`; added `analyze_raw_range` function with updated return type; moved all 5 tests from `edit.rs`.
- `crates/aptu-coder-core/src/edit.rs`: removed `analyze_raw_range` function and its tests; fixed module doc to no longer reference `analyze_raw`.
- `crates/aptu-coder-core/src/lib.rs`: moved `analyze_raw_range` from `pub use edit::{...}` to `pub use analyze::{...}`.
- `crates/aptu-coder/src/lib.rs`: updated two match arms from `EditError::InvalidRange` / `EditError::NotAFile` to `AnalyzeError::InvalidRange` / `AnalyzeError::NotAFile`.

## Test plan

- [x] All 371 existing tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Dependency audit clean (`cargo deny check advisories licenses`)
- [x] No new dependencies added
- [x] No unsafe code

Closes #691
