### PR TITLE
fix(api): add #[non_exhaustive] to all structs and uniform validation guards

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -18,6 +18,7 @@ pub struct CallEdge {
 }
 
 /// Information about an `impl Trait for Type` block found in Rust source.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ImplTraitInfo {
     pub trait_name: String,
@@ -60,7 +61,8 @@ pub struct DefUseSite {
 }
 
 /// Pagination parameters shared across all tools.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PaginationParams {
     /// Pagination cursor from a previous response's `next_cursor` field. Pass unchanged to retrieve the next page. Omit on the first call.
@@ -74,7 +76,8 @@ pub struct PaginationParams {
 }
 
 /// Output control parameters shared across all tools.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct OutputControlParams {
     /// Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses.
@@ -130,7 +133,8 @@ pub enum AnalyzeFileField {
     Imports,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct AnalyzeFileParams {
     /// File path to analyze
@@ -158,7 +162,8 @@ pub struct AnalyzeFileParams {
     pub output_control: OutputControlParams,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct AnalyzeModuleParams {
     /// File path to analyze
@@ -251,6 +256,7 @@ pub struct AnalyzeSymbolParams {
     pub def_use: Option<bool>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct AnalysisResult {
@@ -272,7 +278,8 @@ pub struct AnalysisResult {
     pub references: Vec<ReferenceInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct FileInfo {
     pub path: String,
@@ -296,7 +303,8 @@ pub struct FileInfo {
     pub is_test: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct FunctionInfo {
     pub name: String,
@@ -354,7 +362,8 @@ impl FunctionInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ClassInfo {
     pub name: String,
@@ -378,6 +387,7 @@ pub struct ClassInfo {
     pub inherits: Vec<String>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct CallInfo {
@@ -402,6 +412,7 @@ pub struct CallInfo {
     pub arg_count: Option<usize>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ReferenceInfo {
@@ -449,6 +460,7 @@ pub struct CallChain {
     pub depth: u32,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct FocusedAnalysisData {
@@ -458,7 +470,8 @@ pub struct FocusedAnalysisData {
     pub references: Vec<ReferenceInfo>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ImportInfo {
     /// Full module path excluding the imported symbol (e.g., `std::collections` for `use std::collections::HashMap`).
@@ -523,7 +536,8 @@ impl SemanticAnalysis {
         }
     }
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ModuleFunctionInfo {
     /// Function name
@@ -537,7 +551,8 @@ pub struct ModuleFunctionInfo {
 }
 
 /// Minimal import info for `analyze_module`: module and items only.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ModuleImportInfo {
     /// Full module path (e.g., `std::collections` for `use std::collections::HashMap`)
@@ -547,7 +562,8 @@ pub struct ModuleImportInfo {
 }
 
 /// Minimal fixed schema for `analyze_module`: lightweight code understanding.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ModuleInfo {
     /// File name (basename only, e.g., 'lib.rs')
@@ -767,6 +783,7 @@ mod error_meta_tests {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct AnalyzeRawParams {
@@ -778,6 +795,7 @@ pub struct AnalyzeRawParams {
     pub end_line: Option<usize>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct AnalyzeRawOutput {
@@ -788,6 +806,7 @@ pub struct AnalyzeRawOutput {
     pub content: String,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditOverwriteParams {
@@ -797,6 +816,7 @@ pub struct EditOverwriteParams {
     pub content: String,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditOverwriteOutput {
@@ -806,6 +826,7 @@ pub struct EditOverwriteOutput {
     pub bytes_written: usize,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditReplaceParams {
@@ -817,6 +838,7 @@ pub struct EditReplaceParams {
     pub new_text: String,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditReplaceOutput {
@@ -828,6 +850,7 @@ pub struct EditReplaceOutput {
     pub bytes_after: usize,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditRenameParams {
@@ -841,6 +864,7 @@ pub struct EditRenameParams {
     pub kind: Option<String>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditRenameOutput {
@@ -859,6 +883,7 @@ pub enum InsertPosition {
     After,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditInsertParams {
@@ -872,6 +897,7 @@ pub struct EditInsertParams {
     pub content: String,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct EditInsertOutput {

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -2827,22 +2827,19 @@ pub fn world() {}
     use aptu_coder_core::types::SemanticAnalysis;
 
     let mut semantic = SemanticAnalysis::default();
-    semantic.functions = vec![
-        aptu_coder_core::types::FunctionInfo {
-            name: "hello".to_string(),
-            line: 2,
-            end_line: 2,
-            parameters: vec![],
-            return_type: None,
-        },
-        aptu_coder_core::types::FunctionInfo {
-            name: "world".to_string(),
-            line: 4,
-            end_line: 4,
-            parameters: vec![],
-            return_type: None,
-        },
-    ];
+    let mut fi1 = aptu_coder_core::types::FunctionInfo::default();
+    fi1.name = "hello".to_string();
+    fi1.line = 2;
+    fi1.end_line = 2;
+    fi1.parameters = vec![];
+    fi1.return_type = None;
+    let mut fi2 = aptu_coder_core::types::FunctionInfo::default();
+    fi2.name = "world".to_string();
+    fi2.line = 4;
+    fi2.end_line = 4;
+    fi2.parameters = vec![];
+    fi2.return_type = None;
+    semantic.functions = vec![fi1, fi2];
 
     let summary = format_file_details_summary(&semantic, "src/lib.rs", 5);
 
@@ -2864,13 +2861,13 @@ fn test_file_details_force_bypasses_summary() {
 
     let mut functions = Vec::new();
     for i in 0..50 {
-        functions.push(FunctionInfo {
-            name: format!("function_{}", i),
-            line: i * 10,
-            end_line: i * 10 + 5,
-            parameters: vec![],
-            return_type: None,
-        });
+        let mut fi = FunctionInfo::default();
+        fi.name = format!("function_{}", i);
+        fi.line = i * 10;
+        fi.end_line = i * 10 + 5;
+        fi.parameters = vec![];
+        fi.return_type = None;
+        functions.push(fi);
     }
 
     let mut semantic = SemanticAnalysis::default();
@@ -2899,13 +2896,15 @@ fn test_format_file_details_summary_many_classes() {
     use aptu_coder_core::types::{ClassInfo, SemanticAnalysis};
 
     let classes: Vec<ClassInfo> = (0..15)
-        .map(|i| ClassInfo {
-            name: format!("Class{}", i),
-            line: i * 10,
-            end_line: i * 10 + 5,
-            methods: vec![],
-            fields: vec![],
-            inherits: vec![],
+        .map(|i| {
+            let mut ci = ClassInfo::default();
+            ci.name = format!("Class{}", i);
+            ci.line = i * 10;
+            ci.end_line = i * 10 + 5;
+            ci.methods = vec![];
+            ci.fields = vec![];
+            ci.inherits = vec![];
+            ci
         })
         .collect();
 
@@ -2937,12 +2936,14 @@ fn test_file_details_pagination_first_page() {
 
     // Arrange: 25 functions, page_size=10
     let functions: Vec<FunctionInfo> = (0..25)
-        .map(|i| FunctionInfo {
-            name: format!("fn_{:02}", i),
-            line: i + 1,
-            end_line: i + 5,
-            parameters: vec![],
-            return_type: None,
+        .map(|i| {
+            let mut fi = FunctionInfo::default();
+            fi.name = format!("fn_{:02}", i);
+            fi.line = i + 1;
+            fi.end_line = i + 5;
+            fi.parameters = vec![];
+            fi.return_type = None;
+            fi
         })
         .collect();
 
@@ -2993,12 +2994,14 @@ fn test_file_details_pagination_last_page() {
 
     // Arrange: 25 functions, page 2 starts at offset 10 with page_size 20 -> 15 items remaining
     let functions: Vec<FunctionInfo> = (0..25)
-        .map(|i| FunctionInfo {
-            name: format!("fn_{:02}", i),
-            line: i + 1,
-            end_line: i + 5,
-            parameters: vec![],
-            return_type: None,
+        .map(|i| {
+            let mut fi = FunctionInfo::default();
+            fi.name = format!("fn_{:02}", i);
+            fi.line = i + 1;
+            fi.end_line = i + 5;
+            fi.parameters = vec![];
+            fi.return_type = None;
+            fi
         })
         .collect();
 
@@ -3048,12 +3051,14 @@ fn test_file_details_single_page_no_cursor() {
 
     // Arrange: 5 functions, page_size=100
     let functions: Vec<FunctionInfo> = (0..5)
-        .map(|i| FunctionInfo {
-            name: format!("fn_{}", i),
-            line: i + 1,
-            end_line: i + 5,
-            parameters: vec![],
-            return_type: None,
+        .map(|i| {
+            let mut fi = FunctionInfo::default();
+            fi.name = format!("fn_{}", i);
+            fi.line = i + 1;
+            fi.end_line = i + 5;
+            fi.parameters = vec![];
+            fi.return_type = None;
+            fi
         })
         .collect();
 
@@ -3090,12 +3095,14 @@ fn test_format_file_details_paginated_unit() {
 
     // Arrange: simulate page 2 of 3 (functions 11-20 of 30)
     let all_functions: Vec<FunctionInfo> = (0..30)
-        .map(|i| FunctionInfo {
-            name: format!("fn_{:02}", i),
-            line: i + 1,
-            end_line: i + 5,
-            parameters: vec![],
-            return_type: None,
+        .map(|i| {
+            let mut fi = FunctionInfo::default();
+            fi.name = format!("fn_{:02}", i);
+            fi.line = i + 1;
+            fi.end_line = i + 5;
+            fi.parameters = vec![];
+            fi.return_type = None;
+            fi
         })
         .collect();
 
@@ -3103,19 +3110,19 @@ fn test_format_file_details_paginated_unit() {
 
     let mut semantic = SemanticAnalysis::default();
     semantic.functions = all_functions;
-    semantic.classes = vec![ClassInfo {
-        name: "MyClass".to_string(),
-        line: 100,
-        end_line: 150,
-        methods: vec![],
-        fields: vec![],
-        inherits: vec![],
-    }];
-    semantic.imports = vec![ImportInfo {
-        module: "std".to_string(),
-        items: vec![],
-        line: 1,
-    }];
+    let mut ci = ClassInfo::default();
+    ci.name = "MyClass".to_string();
+    ci.line = 100;
+    ci.end_line = 150;
+    ci.methods = vec![];
+    ci.fields = vec![];
+    ci.inherits = vec![];
+    semantic.classes = vec![ci];
+    let mut ii = ImportInfo::default();
+    ii.module = "std".to_string();
+    ii.items = vec![];
+    ii.line = 1;
+    semantic.imports = vec![ii];
 
     // Act: format page 2 (offset=10)
     let formatted = format_file_details_paginated(
@@ -3629,14 +3636,14 @@ fn test_analyze_directory_verbose_no_summary() {
     use aptu_coder_core::formatter::format_structure_paginated;
     use aptu_coder_core::types::FileInfo;
 
-    let files = vec![FileInfo {
-        path: "src/main.rs".to_string(),
-        language: "rust".to_string(),
-        line_count: 10,
-        function_count: 1,
-        class_count: 0,
-        is_test: false,
-    }];
+    let mut fi = FileInfo::default();
+    fi.path = "src/main.rs".to_string();
+    fi.language = "rust".to_string();
+    fi.line_count = 10;
+    fi.function_count = 1;
+    fi.class_count = 0;
+    fi.is_test = false;
+    let files = vec![fi];
 
     // verbose=true: format_structure_paginated must emit PAGINATED header, not SUMMARY
     let output = format_structure_paginated(&files, 1, None, None, true);

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1667,6 +1667,17 @@ impl CodeAnalyzer {
                                 Some(error_meta("internal", false, "report this as a bug")),
                             ),
                         },
+                        analyze::AnalyzeError::UnsupportedLanguage(_)
+                        | analyze::AnalyzeError::InvalidRange { .. }
+                        | analyze::AnalyzeError::NotAFile(_) => ErrorData::new(
+                            rmcp::model::ErrorCode::INVALID_PARAMS,
+                            format!("Failed to analyze module: {e}"),
+                            Some(error_meta(
+                                "validation",
+                                false,
+                                "ensure the path is a supported source file",
+                            )),
+                        ),
                         _ => ErrorData::new(
                             rmcp::model::ErrorCode::INTERNAL_ERROR,
                             format!("Failed to analyze module: {e}"),

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -952,7 +952,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_file",
-        description = "Functions, types, classes, and imports from a single source file; use analyze_directory for directories. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Passing a directory path returns an error. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
+        description = "Functions, types, classes, and imports from a single source file; use analyze_directory for directories. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Passing a directory path returns INVALID_PARAMS; use analyze_directory instead. git_ref filtering is not supported for single-file analysis. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
         output_schema = schema_for_type::<analyze::FileAnalysisOutput>(),
         annotations(
             title = "Analyze File",
@@ -974,6 +974,39 @@ impl CodeAnalyzer {
             .session_call_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let sid = self.session_id.lock().await.clone();
+
+        // Check if path is a directory (not allowed for analyze_file)
+        if std::path::Path::new(&params.path).is_dir() {
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                format!(
+                    "'{}' is a directory; use analyze_directory instead",
+                    params.path
+                ),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "pass a file path, not a directory",
+                )),
+            )));
+        }
+
+        // summary=true and cursor are mutually exclusive
+        if summary_cursor_conflict(
+            params.output_control.summary,
+            params.pagination.cursor.as_deref(),
+        ) {
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "summary=true is incompatible with a pagination cursor; use one or the other"
+                    .to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "remove cursor or set summary=false",
+                )),
+            )));
+        }
 
         // Call handler for analysis and caching
         let (arc_output, file_cache_hit) = match self.handle_file_details_mode(&params).await {
@@ -1130,7 +1163,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         name = "analyze_symbol",
-        description = "Call graph for a named function/method across all files in a directory to trace usage. Returns direct callers and callees. Unknown symbols return error; symbols with no callers/callees return empty chains. Use import_lookup=true with symbol set to the module path to find all files that import a given module path instead of tracing a call graph. When def_use is true, returns write and read sites for the symbol in def_use_sites; write sites include assignments and initializations, read sites include all references, augmented assignments appear as kind write_read. Example queries: Find all callers of the parse_config function; Trace the call chain for MyClass.process_request up to 2 levels deep; Show only trait impl callers of the write method; Find all files that import std::collections",
+        description = "Call graph for a named function/method across all files in a directory to trace usage. Returns direct callers and callees. Unknown symbols return error; symbols with no callers/callees return empty chains. Use import_lookup=true with symbol set to the module path to find all files that import a given module path instead of tracing a call graph. When def_use is true, returns write and read sites for the symbol in def_use_sites; write sites include assignments and initializations, read sites include all references, augmented assignments appear as kind write_read. Passing a file path returns INVALID_PARAMS. summary=true and cursor are mutually exclusive. Example queries: Find all callers of the parse_config function; Trace the call chain for MyClass.process_request up to 2 levels deep; Show only trait impl callers of the write method; Find all files that import std::collections",
         output_schema = schema_for_type::<analyze::FocusedAnalysisOutput>(),
         annotations(
             title = "Analyze Symbol",
@@ -1154,6 +1187,39 @@ impl CodeAnalyzer {
             .session_call_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let sid = self.session_id.lock().await.clone();
+
+        // Check if path is a file (not allowed for analyze_symbol)
+        if std::path::Path::new(&params.path).is_file() {
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                format!(
+                    "'{}' is a file; analyze_symbol requires a directory path",
+                    params.path
+                ),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "pass a directory path, not a file",
+                )),
+            )));
+        }
+
+        // summary=true and cursor are mutually exclusive
+        if summary_cursor_conflict(
+            params.output_control.summary,
+            params.pagination.cursor.as_deref(),
+        ) {
+            return Ok(err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "summary=true is incompatible with a pagination cursor; use one or the other"
+                    .to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "remove cursor or set summary=false",
+                )),
+            )));
+        }
 
         // import_lookup=true is mutually exclusive with a non-empty symbol.
         if let Err(e) = Self::validate_import_lookup(params.import_lookup, &params.symbol) {
@@ -1273,7 +1339,10 @@ impl CodeAnalyzer {
             PaginationMode::Callers
         };
 
-        let use_summary = params.output_control.summary == Some(true);
+        let mut use_summary = params.output_control.summary == Some(true);
+        if params.output_control.force == Some(true) {
+            use_summary = false;
+        }
         let verbose = params.output_control.verbose.unwrap_or(false);
 
         let mut callee_cursor = match cursor_mode {
@@ -1463,7 +1532,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_module",
-        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Pagination, summary, force, and verbose not supported. Example queries: What functions are defined in src/analyze.rs?; List all imports in src/lib.rs.",
+        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Pagination, summary, force, and verbose not supported. git_ref filtering is not supported. Example queries: What functions are defined in src/analyze.rs?; List all imports in src/lib.rs.",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",
@@ -1545,47 +1614,67 @@ impl CodeAnalyzer {
                 .and_then(aptu_coder_core::lang::language_for_extension)
                 .unwrap_or("unknown")
                 .to_string();
-            let mi = types::ModuleInfo {
-                name,
-                line_count: cached_file.line_count,
-                language,
-                functions: cached_file
-                    .semantic
-                    .functions
-                    .iter()
-                    .map(|f| types::ModuleFunctionInfo {
-                        name: f.name.clone(),
-                        line: f.line,
-                    })
-                    .collect(),
-                imports: cached_file
-                    .semantic
-                    .imports
-                    .iter()
-                    .map(|i| types::ModuleImportInfo {
-                        module: i.module.clone(),
-                        items: i.items.clone(),
-                    })
-                    .collect(),
-            };
+            let mut mi = types::ModuleInfo::default();
+            mi.name = name;
+            mi.line_count = cached_file.line_count;
+            mi.language = language;
+            mi.functions = cached_file
+                .semantic
+                .functions
+                .iter()
+                .map(|f| {
+                    let mut mfi = types::ModuleFunctionInfo::default();
+                    mfi.name = f.name.clone();
+                    mfi.line = f.line;
+                    mfi
+                })
+                .collect();
+            mi.imports = cached_file
+                .semantic
+                .imports
+                .iter()
+                .map(|i| {
+                    let mut mii = types::ModuleImportInfo::default();
+                    mii.module = i.module.clone();
+                    mii.items = i.items.clone();
+                    mii
+                })
+                .collect();
             (mi, true)
         } else {
             // Cache miss: call analyze_file (returns FileAnalysisOutput) so we can populate
             // the file cache for future calls. Then reconstruct ModuleInfo from the result,
             // mirroring the cache-hit path above.
-            let file_output = match analyze::analyze_file(&params.path, None).map_err(|e| {
-                ErrorData::new(
-                    rmcp::model::ErrorCode::INVALID_PARAMS,
-                    format!("Failed to analyze module: {e}"),
-                    Some(error_meta(
-                        "validation",
-                        false,
-                        "ensure file exists, is readable, and has a supported extension",
-                    )),
-                )
-            }) {
+            let file_output = match analyze::analyze_file(&params.path, None) {
                 Ok(v) => v,
-                Err(e) => return Ok(err_to_tool_result(e)),
+                Err(e) => {
+                    let error_data = match &e {
+                        analyze::AnalyzeError::Io(io_err) => match io_err.kind() {
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => {
+                                ErrorData::new(
+                                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                                    format!("Failed to analyze module: {e}"),
+                                    Some(error_meta(
+                                        "validation",
+                                        false,
+                                        "ensure file exists, is readable, and has a supported extension",
+                                    )),
+                                )
+                            }
+                            _ => ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                format!("Failed to analyze module: {e}"),
+                                Some(error_meta("internal", false, "report this as a bug")),
+                            ),
+                        },
+                        _ => ErrorData::new(
+                            rmcp::model::ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to analyze module: {e}"),
+                            Some(error_meta("internal", false, "report this as a bug")),
+                        ),
+                    };
+                    return Ok(err_to_tool_result(error_data));
+                }
             };
             let arc_output = std::sync::Arc::new(file_output);
             if let Some(key) = module_cache_key.clone() {
@@ -1603,29 +1692,32 @@ impl CodeAnalyzer {
                 .and_then(aptu_coder_core::lang::language_for_extension)
                 .unwrap_or("unknown")
                 .to_string();
-            let mi = types::ModuleInfo {
-                name,
-                line_count: arc_output.line_count,
-                language,
-                functions: arc_output
-                    .semantic
-                    .functions
-                    .iter()
-                    .map(|f| types::ModuleFunctionInfo {
-                        name: f.name.clone(),
-                        line: f.line,
-                    })
-                    .collect(),
-                imports: arc_output
-                    .semantic
-                    .imports
-                    .iter()
-                    .map(|i| types::ModuleImportInfo {
-                        module: i.module.clone(),
-                        items: i.items.clone(),
-                    })
-                    .collect(),
-            };
+            let mut mi = types::ModuleInfo::default();
+            mi.name = name;
+            mi.line_count = arc_output.line_count;
+            mi.language = language;
+            mi.functions = arc_output
+                .semantic
+                .functions
+                .iter()
+                .map(|f| {
+                    let mut mfi = types::ModuleFunctionInfo::default();
+                    mfi.name = f.name.clone();
+                    mfi.line = f.line;
+                    mfi
+                })
+                .collect();
+            mi.imports = arc_output
+                .semantic
+                .imports
+                .iter()
+                .map(|i| {
+                    let mut mii = types::ModuleImportInfo::default();
+                    mii.module = i.module.clone();
+                    mii.items = i.items.clone();
+                    mii
+                })
+                .collect();
             (mi, false)
         };
 
@@ -3157,27 +3249,23 @@ mod tests {
         let analyzer = make_analyzer();
 
         // Prime the file cache by calling handle_file_details_mode once
-        let file_params = aptu_coder_core::types::AnalyzeFileParams {
-            path: path.clone(),
-            ast_recursion_limit: None,
-            fields: None,
-            pagination: aptu_coder_core::types::PaginationParams {
-                cursor: None,
-                page_size: None,
-            },
-            output_control: aptu_coder_core::types::OutputControlParams {
-                summary: None,
-                force: None,
-                verbose: None,
-            },
-        };
+        let mut file_params = aptu_coder_core::types::AnalyzeFileParams::default();
+        file_params.path = path.clone();
+        file_params.ast_recursion_limit = None;
+        file_params.fields = None;
+        file_params.pagination.cursor = None;
+        file_params.pagination.page_size = None;
+        file_params.output_control.summary = None;
+        file_params.output_control.force = None;
+        file_params.output_control.verbose = None;
         let (_cached, _) = analyzer
             .handle_file_details_mode(&file_params)
             .await
             .unwrap();
 
         // Act: now call analyze_module; the cache key is mtime-based so same file = hit
-        let module_params = aptu_coder_core::types::AnalyzeModuleParams { path: path.clone() };
+        let mut module_params = aptu_coder_core::types::AnalyzeModuleParams::default();
+        module_params.path = path.clone();
 
         // Replicate the cache lookup the handler does (no public method; test via build path)
         let module_cache_key = std::fs::metadata(&path).ok().and_then(|meta| {


### PR DESCRIPTION
## Summary

Resolves two related issues in a single PR. Issue 688 adds `#[non_exhaustive]` to all 26 parameter and output structs in `types.rs` that were missing it, making the public API forward-compatible. Issue 687 closes the remaining uniform-validation gaps across all MCP tool handlers: `summary`+`cursor` mutex guards, `force` override for `use_summary`, path-type guards (`is_dir`/`is_file`), corrected error codes for `analyze_module`, and schema description improvements.

## Changes

- `crates/aptu-coder-core/src/types.rs` -- `#[non_exhaustive]` added to 26 structs (3 already had it); `#[derive(Default)]` added to 11 structs to support the mutation pattern required by external-crate callers after `#[non_exhaustive]` is applied
- `crates/aptu-coder/src/lib.rs` -- `summary_cursor_conflict` guard added to `analyze_file` and `analyze_symbol`; `force=Some(true)` now suppresses `use_summary` in `analyze_symbol`; `analyze_file` returns `INVALID_PARAMS` when path is a directory; `analyze_symbol` returns `INVALID_PARAMS` when path is a file; `analyze_module` F3 fix: `io::ErrorKind::NotFound` and `PermissionDenied` map to `INVALID_PARAMS`, all other IO errors map to `INTERNAL_ERROR`; schema descriptions updated for `symbol`/`import_lookup` dual semantics, `git_ref` unsupported notes, and directory/file rejection messages; struct literals at ~6 production sites converted to the mutation pattern (`let mut s = Type::default(); s.field = val; s`) since `#[non_exhaustive]` forbids struct expressions from external crates (E0639)
- `crates/aptu-coder-core/tests/integration_tests.rs` -- 11 struct literal sites converted to the mutation pattern for the same E0639 reason

## Test plan

- [ ] `cargo test` -- 373 tests pass, 0 failures
- [ ] `cargo clippy -- -D warnings` -- clean
- [ ] `cargo fmt --check` -- clean
- [ ] `cargo deny check advisories licenses` -- clean
- [ ] Build verified with both shards merged: `cargo build` exits 0
