### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.7", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.8", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }


### PR DESCRIPTION
Bump workspace version from 0.7.0 to 0.8.0 and update the `aptu-coder-core` dependency constraint in `aptu-coder/Cargo.toml` from `"0.7"` to `"0.8"`. Cargo.lock updated accordingly.

## Changes

- `Cargo.toml`: workspace version 0.7.0 → 0.8.0
- `crates/aptu-coder/Cargo.toml`: dependency version constraint `"0.7"` → `"0.8"`
- `Cargo.lock`: regenerated with new version

## Test plan

- [ ] CI passes (build, test, clippy, fmt, deny)
