### PR TITLE
docs: update all documentation for v0.8.0 nine-tool release

### DIFF
--- a/.github/instructions/src-languages.instructions.md
+++ b/.github/instructions/src-languages.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/languages/**/*.rs"
+applyTo: "crates/**/src/languages/**/*.rs"
 excludeAgent: "coding-agent"
 description: "tree-sitter query conventions and language handler patterns"
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `impl_only=true` restricts `analyze_symbol` callers to `impl Trait for Type` blocks; returns INVALID_PARAMS for non-Rust directories.
 - `analyze_module` supports `path` only -- pagination, summary, force, and verbose are not supported.
 - `import_lookup=true` on `analyze_symbol` requires a non-empty `symbol` (the module path to search for); returns INVALID_PARAMS if symbol is empty. Mutually exclusive with normal call-graph lookup.
-- `def_use=true` on `analyze_symbol` populates `def_use_sites` in structuredContent with write and read sites.
+- `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 
 ## Do not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `summary=true` and `cursor` are mutually exclusive; passing both returns INVALID_PARAMS.
 - `impl_only=true` restricts `analyze_symbol` callers to `impl Trait for Type` blocks; returns INVALID_PARAMS for non-Rust directories.
 - `analyze_module` supports `path` only -- pagination, summary, force, and verbose are not supported.
+- `import_lookup=true` on `analyze_symbol` requires a non-empty `symbol` (the module path to search for); returns INVALID_PARAMS if symbol is empty. Mutually exclusive with normal call-graph lookup.
+- `def_use=true` on `analyze_symbol` populates `def_use_sites` in structuredContent with write and read sites.
+- `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 
 ## Do not
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Builds a call graph for a named symbol across all files in a directory. Uses sen
   All non-exact modes return an error with candidate names when the match is ambiguous; use the listed candidates to refine to a unique match.
 - `import_lookup` *(boolean, optional)* -- When true, find all files in the directory that import the module named by `symbol`. Mutually exclusive with call-graph mode.
 - `git_ref` *(string, optional)* -- Restrict analysis to files changed relative to this git ref (branch, tag, or commit SHA). Empty string or unset means no filtering.
-- `def_use` *(boolean, optional)* -- When true, extract definition and use sites for the symbol. Populates `def_use_sites` in structuredContent.
+- `def_use` *(boolean, optional)* -- When true, extract definition and use sites for the symbol. The initial response returns callers and callees as usual and includes a cursor that, when followed, pages through `def_use_sites` (each with `kind`, `symbol`, `file`, `line`, `column`, `snippet`, `enclosing_scope`). `def_use_sites` is empty in `structuredContent` until the client follows that cursor into def-use pagination mode.
 
 The tool also returns `structuredContent` with typed arrays for programmatic consumption: `callers` (production callers), `test_callers` (callers from test files), and `callees` (direct callees), each as `Option<Vec<CallChainEntry>>`. A `CallChainEntry` has three fields: `symbol` (string), `file` (string), and `line` (JSON integer; `usize` in the Rust API). These arrays represent depth-1 relationships only; `follow_depth` does not affect them.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Walks a directory tree, counts lines of code, functions, and classes per file. R
 
 **Required:** `path` *(string)* -- directory to analyze
 
-**Additional optional:** `max_depth` *(integer, default unlimited)* -- recursion limit; use 2-3 for large monorepos
+**Additional optional:**
+- `max_depth` *(integer, default unlimited)* -- recursion limit; use 2-3 for large monorepos
+- `git_ref` *(string, optional)* -- Restrict analysis to files changed relative to this git ref (branch, tag, or commit SHA). Empty string or unset means no filtering.
 
 
 
@@ -205,6 +207,9 @@ Builds a call graph for a named symbol across all files in a directory. Uses sen
   - `prefix`: Case-insensitive prefix match; returns an error listing candidates when multiple symbols match
   - `contains`: Case-insensitive substring match; returns an error listing candidates when multiple symbols match
   All non-exact modes return an error with candidate names when the match is ambiguous; use the listed candidates to refine to a unique match.
+- `import_lookup` *(boolean, optional)* -- When true, find all files in the directory that import the module named by `symbol`. Mutually exclusive with call-graph mode.
+- `git_ref` *(string, optional)* -- Restrict analysis to files changed relative to this git ref (branch, tag, or commit SHA). Empty string or unset means no filtering.
+- `def_use` *(boolean, optional)* -- When true, extract definition and use sites for the symbol. Populates `def_use_sites` in structuredContent.
 
 The tool also returns `structuredContent` with typed arrays for programmatic consumption: `callers` (production callers), `test_callers` (callers from test files), and `callees` (direct callees), each as `Option<Vec<CallChainEntry>>`. A `CallChainEntry` has three fields: `symbol` (string), `file` (string), and `line` (JSON integer; `usize` in the Rust API). These arrays represent depth-1 relationships only; `follow_depth` does not affect them.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,6 +91,8 @@ graph TD
 3. Parallel parse with rayon: extract function/class counts via ElementExtractor
 4. Format as tree with LOC and counts per file
 
+When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files, and `filter_entries_by_git_ref()` restricts the walk to those files before analysis begins.
+
 ### analyze_file (File Details)
 
 1. Detect language from extension
@@ -127,6 +129,12 @@ Exported from `aptu_coder_core` as a public API for library consumers that hold 
 - `callees: Option<Vec<CallChainEntry>>` -- depth-1 callees
 
 `CallChainEntry` is a stable public type (exported from `aptu_coder_core`) with fields `symbol: String`, `file: String`, `line: usize`. Conversion from the internal `InternalCallChain` (which is non-serializable and stays internal) happens at the output boundary via the private `chains_to_entries` helper. The `follow_depth` parameter does not affect these arrays; they always represent depth-1 relationships.
+
+**Import lookup mode:** When `import_lookup=true`, instead of building a call graph, the tool scans all files in the directory for imports of the module path specified in `symbol`. Returns a list of files that import that module. Mutually exclusive with the call-graph mode.
+
+**Git ref filtering:** When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files, and `filter_entries_by_git_ref()` restricts the analysis to those files before the graph is built.
+
+**Def-use mode:** When `def_use=true`, instead of (or in addition to) the call graph, the tool extracts definition and use sites for the symbol. Populates `def_use_sites` in the structured output as a `Vec<DefUseSite>`. Each `DefUseSite` has: `kind` (write/read/write_read), `symbol`, `file`, `line`, `column`, `snippet`, `enclosing_scope`.
 
 ## Language Handler System
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ graph TD
 3. Parallel parse with rayon: extract function/class counts via ElementExtractor
 4. Format as tree with LOC and counts per file
 
-When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files, and `filter_entries_by_git_ref()` restricts the walk to those files before analysis begins.
+When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files; `filter_entries_by_git_ref()` then post-filters the already-walked entries to those files before formatting begins.
 
 ### analyze_file (File Details)
 
@@ -134,7 +134,7 @@ Exported from `aptu_coder_core` as a public API for library consumers that hold 
 
 **Git ref filtering:** When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files, and `filter_entries_by_git_ref()` restricts the analysis to those files before the graph is built.
 
-**Def-use mode:** When `def_use=true`, instead of (or in addition to) the call graph, the tool extracts definition and use sites for the symbol. Populates `def_use_sites` in the structured output as a `Vec<DefUseSite>`. Each `DefUseSite` has: `kind` (write/read/write_read), `symbol`, `file`, `line`, `column`, `snippet`, `enclosing_scope`.
+**Def-use mode:** When `def_use=true`, the tool computes definition and use sites alongside the call graph. However, `def_use_sites` is cleared (`Vec::new()`) in `structuredContent` on the initial response. Once the callers and callees pages are exhausted, the handler automatically emits a `{mode: defuse, offset: 0}` cursor. Following that cursor enters `PaginationMode::DefUse`, where `def_use_sites` is populated as `Vec<DefUseSite>` and sliced per page. Each `DefUseSite` has: `kind` (write/read/write_read), `symbol`, `file`, `line`, `column`, `snippet`, `enclosing_scope`.
 
 ## Language Handler System
 

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -17,11 +17,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the module map, [MCP-BEST-PRACTICES.m
 
 ## 2. Tool Architecture Decisions
 
-### Why Four Tools Instead of One
+### Why Nine Tools Instead of One
 
 **Principle:** Each tool does one thing well. Non-overlapping interfaces eliminate ambiguous routing. When two tools can satisfy the same request, the model must guess; that is a reliability failure, not a model failure. (See [MCP-BEST-PRACTICES.md](MCP-BEST-PRACTICES.md), section 3.2.)
 
-*Example: This server has four tools — `analyze_directory`, `analyze_file`, `analyze_module`, and `analyze_symbol` — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
+*Example: This server has nine tools — `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analysis family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (editing family) — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
 
 ```mermaid
 graph TD
@@ -44,12 +44,17 @@ graph TD
 | `analyze_file` | Functions with signatures, classes, imports, type references | Call graph traversal, directory walking |
 | `analyze_module` | Minimal function/import index (~75% smaller than `analyze_file`) | Signatures, types, class details, call graphs |
 | `analyze_symbol` | Call graph for a named function/method across a directory | File-level details, directory counts |
+| `analyze_raw` | Raw file content with optional line range | AST parsing, structure extraction |
+| `edit_overwrite` | Create or overwrite a file | AST awareness, incremental updates |
+| `edit_replace` | Replace exact text block in a file | AST awareness, directory-wide changes |
+| `edit_rename` | AST-aware rename within a single file | Directory-wide rename, type-aware refactoring |
+| `edit_insert` | Insert content before/after a named identifier | Directory-wide insertion, AST-unaware insertion |
 
-*Table 1: The four tools, their purpose, and what each intentionally excludes.*
+*Table 1: The nine tools, their purpose, and what each intentionally excludes.*
 
 ### Single Responsibility Trade-off
 
-Splitting into four tools adds surface area (four tool descriptions to maintain, four output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse.
+Splitting into nine tools adds surface area (nine tool descriptions to maintain, nine output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
 
 ## 3. Designing for Small Models
 
@@ -195,16 +200,14 @@ Score outputs without seeing condition labels. Reveal assignments post-scoring. 
 
 The annotation posture for this server is stable and locked until new MCP SEPs land:
 
-| Annotation | Value | Rationale |
-|---|---|---|
-| `readOnlyHint` | `true` | All tools are read-only filesystem operations |
-| `destructiveHint` | `false` | No writes, no side effects |
-| `idempotentHint` | `true` | Same input produces same output |
-| `openWorldHint` | `false` | Results are bounded by the input path |
+| Tool Family | `readOnlyHint` | `destructiveHint` | `idempotentHint` | `openWorldHint` | Rationale |
+|---|---|---|---|---|---|
+| `analyze_*` | `true` | `false` | `true` | `false` | Read-only, deterministic, bounded by input path |
+| `edit_*` | `false` | `true` | `false` | `false` | Write-capable, non-idempotent, bounded by input path |
 
-*Table 4: Tool annotation posture. See [ROADMAP.md](ROADMAP.md) for the rationale and SEP tracking references.*
+*Table 4: Tool annotation posture by family. See [ROADMAP.md](ROADMAP.md) for the rationale and SEP tracking references.*
 
-`readOnlyHint: true` allows clients to call all four tools autonomously without a confirmation step, which is the correct behavior for a passive code analysis server. `openWorldHint: false` signals that results are deterministic given the input path, not dependent on external network state.
+`readOnlyHint: true` on `analyze_*` tools allows clients to call them autonomously without a confirmation step, which is the correct behavior for a passive code analysis server. `readOnlyHint: false` on `edit_*` tools signals that they perform writes; cautious clients may require confirmation before execution. `openWorldHint: false` on all tools signals that results are deterministic given the input path, not dependent on external network state.
 
 ### 7.1 rmcp Compile-Time Limitations
 
@@ -259,7 +262,7 @@ Ordered checklist for building a new MCP server applying the principles in this 
 6. **Design for small models first.** Write descriptions and error messages as if only Haiku or Mistral Small will read them. Test with small models before testing with Sonnet.
 7. **Add cursor pagination.** Any output that can exceed a token budget should support `cursor` + `page_size` for resumable chunked output.
 8. **Add summary mode.** Any output that agents use for orientation should have a compact `summary=true` mode.
-9. **Set annotation posture.** Set `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` on every tool before shipping.
+9. **Set annotation posture.** Set `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` on every tool before shipping. Use different postures for different tool families (e.g., read-only vs. write-capable).
 10. **Add observability.** Instrument each tool handler with a fire-and-forget channel metric. Do not block the hot path.
 11. **Benchmark before shipping.** Define a condition matrix (model × tool set), run blind scoring, report rank-biserial effect sizes. A wave that improves large models but regresses small models does not ship.
 12. **Add annotation quality tests.** Add a `list_tools()` test asserting non-empty description on every tool and every `inputSchema` property. Add a flatten propagation test for any parameter struct using `#[serde(flatten)]`. These run inside `cargo test` with no additional CI overhead and catch regressions the compiler cannot detect.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,7 +17,7 @@ Each line in the JSONL file is one JSON object:
 | Field | Type | Description |
 |---|---|---|
 | `ts` | `u64` | Unix timestamp in milliseconds at handler return |
-| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` |
+| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` |
 | `duration_ms` | `u64` | Wall-clock time from handler entry to return |
 | `output_chars` | `usize` | Byte length (`str::len()`) of the final text returned; `0` on error paths |
 | `param_path_depth` | `usize` | `Path::components().count()` on `params.path` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,6 +113,8 @@ Current settings are stable and reflect ground truth:
 | `idempotentHint` | `true` | Same input produces same output (verified by #347) |
 | `openWorldHint` | `false` | Results are bounded by the input path |
 
+**Exception:** The five `edit_*` tools (Wave 9) deviate from the default posture. They carry `readOnlyHint=false`, `destructiveHint=true`, and `idempotentHint=false` to accurately reflect their write-capable, non-idempotent nature.
+
 No annotation changes until new MCP SEPs land (tracked in #1913, #1984, #1561, #1560, #1487). Validated against external MCP Blog 2 reference (2026-03-16).
 
 ---
@@ -124,11 +126,9 @@ Unimplemented and pertinent:
 - MCP SEP adoption: #1487 (`trustedHint`), #1561 (`unsafeOutputHint`), #1913 (trust/sensitivity annotations), #1984 (governance annotations) -- open upstream; no action until specs stabilize. #1560 (`secretHint`) closed 2026-03-23; evaluate adoption once merged into spec.
 - Streamable HTTP transport: add `--http` flag exposing `StreamableHttpService` (axum + rmcp `transport-streamable-http-server` + `transport-streamable-http-server-session` features) alongside existing stdio. Tower middleware: `RequestBodyLimitLayer` (4 MB) + `tower-governor` (per-token rate limit) + static Bearer token from env var. Target deployment: GCP e2-micro Always Free (us-central1) behind Cloudflare proxy (free tier, TLS termination, WAF, 5 rate-limit rules). No changes to tool handlers or session logic required.
 
-## Wave 9: Editing Tools
+## Wave 9: Editing Tools [Complete]
 
-Augments aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyze-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
-
-**Prerequisite:** the rename PR (#664) must merge before this wave begins.
+Augmented aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyze-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
 
 ### Rationale
 
@@ -136,17 +136,17 @@ Both a combined server and two separate servers inject into the same model conte
 
 The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0 source) supports multi-group composition with no breaking changes from 1.1.0. Write tools are placed in a second `#[tool_router(router = write_router, vis = "pub")]` impl block and merged at construction.
 
-### Phase 1: Mechanical tools [no AST required]
+### Phase 1: Mechanical tools [Complete]
 
-Three tools with no tree-sitter dependency. These validate the BUILD agent workflow and establish the write-path integration before adding AST complexity.
+Three tools with no tree-sitter dependency. These validated the BUILD agent workflow and established the write-path integration before adding AST complexity.
 
 - `analyze_raw(path, start_line?, end_line?)` -- "Raw file content with optional line range. Prefer start_line/end_line to limit tokens on large files; omit both for full content. Use analyze_file for structure, not content. Example queries: Read lines 10-40 of src/lib.rs; Show the full contents of config.toml." `read_only_hint=true`, `idempotent_hint=true`
 - `edit_overwrite(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_replace to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 - `edit_replace(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use edit_overwrite to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
 
-Cache invalidation: `edit_overwrite` and `edit_replace` must call `cache.invalidate_file(path)` after every write. mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations); explicit invalidation prevents stale reads within the same second.
+Cache invalidation: `edit_overwrite` and `edit_replace` call `cache.invalidate_file(path)` after every write. mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations); explicit invalidation prevents stale reads within the same second.
 
-### Phase 2: AST-backed tools
+### Phase 2: AST-backed tools [Complete]
 
 Two tools that require `aptu-coder-core` (formerly `code-analyze-core`) capture data. These are the primary justification for keeping editing in the same crate rather than a separate repository.
 
@@ -163,9 +163,4 @@ Note: `read_only_hint` is a hint surfaced to MCP clients in `tools/list`; rmcp 1
 
 Per the Small-Model-First Constraint: all five tools must be evaluated against Haiku, Mistral-small-2603, and MiniMax-M2.5 before Sonnet in a Wave 9 benchmark. Tool descriptions must follow literal-instruction style -- SML models follow tool descriptions literally.
 
-### Risks
 
-- **Cache staleness** -- mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations). `edit_overwrite` and `edit_replace` must always call `cache.invalidate_file(path)` after every write to prevent stale reads within the same second.
-- **`edit_rename` scope creep** -- directory-wide rename requires type information tree-sitter cannot provide; enforce single-file boundary in v1 with a clear error if a directory path is supplied
-- **Annotation posture drift** -- document the per-tool posture in this section; update REUSE.toml for any new source files
-- **SPDX headers** -- every new `.rs` file requires an SPDX header or `reuse lint` fails CI

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ Current settings are stable and reflect ground truth:
 | `idempotentHint` | `true` | Same input produces same output (verified by #347) |
 | `openWorldHint` | `false` | Results are bounded by the input path |
 
-**Exception:** The five `edit_*` tools (Wave 9) deviate from the default posture. They carry `readOnlyHint=false`, `destructiveHint=true`, and `idempotentHint=false` to accurately reflect their write-capable, non-idempotent nature.
+**Exception:** The four `edit_*` tools (Wave 9) deviate from the default posture. They carry `readOnlyHint=false`, `destructiveHint=true`, and `idempotentHint=false` to accurately reflect their write-capable, non-idempotent nature.
 
 No annotation changes until new MCP SEPs land (tracked in #1913, #1984, #1561, #1560, #1487). Validated against external MCP Blog 2 reference (2026-03-16).
 
@@ -128,7 +128,7 @@ Unimplemented and pertinent:
 
 ## Wave 9: Editing Tools [Complete]
 
-Augmented aptu-coder with five mechanical code-editing tools in two phases. The existing analysis tools and composition API remain unchanged. This wave completes the read-analyze-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
+Augmented aptu-coder with five tools in two phases: one read-only file-content tool (`analyze_raw`) and four mechanical code-editing tools (`edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`). The existing analysis tools and composition API remain unchanged. This wave completes the read-analyze-write loop that the coder-build agent (#664, #665) requires without introducing a second MCP server.
 
 ### Rationale
 


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the v0.8.0 release. The Wave 9 editing tools shipped across PRs #682, #683, #684, and #690, and were subsequently renamed into the `analyze_*` / `edit_*` families in #690. This PR brings every user-facing and developer-facing doc up to date with the resulting nine-tool surface.

## Changes

- `docs/OBSERVABILITY.md` -- extend the `tool` field enum from 4 to 9 tools (adds `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`)
- `README.md` -- document `import_lookup`, `git_ref`, and `def_use` parameters for `analyze_symbol`; document `git_ref` for `analyze_directory`
- `AGENTS.md` -- add behavioral contract bullets for `import_lookup`, `def_use`, and `git_ref` under Tool parameters
- `docs/ARCHITECTURE.md` -- add import_lookup mode, git_ref filtering, and def_use mode subsections under `analyze_symbol`; add git_ref filter step under `analyze_directory`
- `docs/DESIGN-GUIDE.md` -- update "four tools" narrative to "nine tools" throughout; extend Table 1 with all 5 Wave 9 tools; update Table 4 to show mixed annotation posture (`analyze_*` read-only, `edit_*` destructive)
- `docs/ROADMAP.md` -- mark Wave 9 `[Complete]`, convert planning language to past tense, remove stale PR #664 prerequisite note, add write-tool exception note to annotation posture table
- `.github/instructions/src-languages.instructions.md` -- fix `applyTo` glob from `src/languages/**/*.rs` to `crates/**/src/languages/**/*.rs` to match actual workspace layout

## Test plan

- [x] Documentation only -- no Rust code changed
- [x] `cargo check` clean
- [x] All internal markdown links verified
- [x] All parameter names and struct field names verified against `types.rs` and `lib.rs`
- [x] 7 files changed, 43 insertions, 29 deletions (well within 500-line budget)
