### PR TITLE
ci: add aptu issue triage and PR review workflows

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,24 @@
+name: Triage New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  triage:
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run Aptu Triage
+        uses: clouatre-labs/aptu@9cdcf9ac5f62b88345a20f1f6748e622df7a9798 # v0.5.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          no-comment: 'true'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,4 +1,4 @@
-name: Triage Pull Requests
+name: Review Pull Requests
 
 on:
   pull_request:
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-24.04
@@ -14,12 +18,11 @@ jobs:
       pull-requests: write
       issues: write
       contents: read
-      attestations: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Triage PR
+      - name: Review PR
         uses: clouatre-labs/aptu@9cdcf9ac5f62b88345a20f1f6748e622df7a9798 # v0.5.1
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,34 @@
+name: Triage Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch: # Manual trigger for testing
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+      attestations: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Triage PR
+        uses: clouatre-labs/aptu@9cdcf9ac5f62b88345a20f1f6748e622df7a9798 # v0.5.1
+        continue-on-error: true  # Non-blocking - AI review is advisory
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          provider: gemini
+          model: gemini-3.1-flash-lite-preview
+          skip-labeled: 'false'
+          fallback-provider: 'openrouter'
+          fallback-model: 'inception/mercury-2'
+          repo-path: ${{ github.workspace }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- GitHub Actions workflow for automated issue triage using [aptu](https://github.com/clouatre-labs/aptu) (`clouatre-labs/aptu@v0.5.1`)
-- GitHub Actions workflow for automated PR review using aptu with Gemini primary and OpenRouter Mercury-2 fallback
+- GitHub Actions workflow for automated issue triage using [aptu](https://github.com/clouatre-labs/aptu) (pinned to `9cdcf9ac` = v0.5.1)
+- GitHub Actions workflow for automated PR review using aptu (pinned to `9cdcf9ac` = v0.5.1) with Gemini primary and OpenRouter Mercury-2 fallback
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- GitHub Actions workflow for automated issue triage using [aptu](https://github.com/clouatre-labs/aptu) (`clouatre-labs/aptu@v0.5.1`)
+- GitHub Actions workflow for automated PR review using aptu with Gemini primary and OpenRouter Mercury-2 fallback
+
+### Changed
+
+- Replaced GitHub Copilot code review with aptu-powered PR review; the `copilot_code_review` rule has been removed from the `Protect main branch` ruleset

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,22 @@ All changes go through a pull request; no direct pushes to main are permitted.
 - No unresolved review comments
 - Reviewer approves or all raised issues are addressed
 
+## Automated Review Tooling
+
+This repository uses [aptu](https://github.com/clouatre-labs/aptu) for automated issue triage and pull request review via GitHub Actions.
+
+### Issue triage
+
+Every new issue triggers `.github/workflows/issue-triage.yml`, which runs `aptu issue triage`. The workflow applies type and priority labels. No comment is posted to the issue.
+
+### Pull request review
+
+Every opened or updated pull request triggers `.github/workflows/pr-review.yml`, which runs `aptu pr review`. The review is advisory (`continue-on-error: true`) and never blocks merging. The workflow uses Gemini as the primary provider and OpenRouter Mercury-2 as the fallback.
+
+### Copilot code review
+
+GitHub Copilot code review is intentionally disabled for this repository. The `copilot_code_review` rule has been removed from the `Protect main branch` ruleset (id 13342306). To keep it disabled, ensure the rule is absent from that ruleset; do not re-add it.
+
 ## Branch Protection
 
 See [docs/REPO-STANDARDS.md](docs/REPO-STANDARDS.md) for ruleset configuration, required status checks, signed-commit enforcement, branch protection rationale, and the repo merge strategy.


### PR DESCRIPTION
## Summary

Replaces GitHub Copilot code review with [aptu](https://github.com/clouatre-labs/aptu)-powered automated review, and adds automated issue triage. Both workflows mirror the pattern established in `clouatre-labs/aptu` itself, adapted for external action references. The `copilot_code_review` rule has been removed from the `Protect main branch` ruleset via the GitHub GraphQL API.

## Changes

- `.github/workflows/issue-triage.yml`: New workflow. Triggers on `issues: [opened]`. Runs `clouatre-labs/aptu@v0.5.1` with `no-comment: true` (labels only, no comment noise). Requires `GEMINI_API_KEY` secret.
- `.github/workflows/pr-review.yml`: New workflow. Triggers on `pull_request: [opened, synchronize]` and `workflow_dispatch`. Runs `clouatre-labs/aptu@v0.5.1` with Gemini primary (`gemini-3.1-flash-lite-preview`) and OpenRouter Mercury-2 fallback. `continue-on-error: true` makes the review advisory and non-blocking. Requires `GEMINI_API_KEY` and `OPENROUTER_API_KEY` secrets.
- `CHANGELOG.md`: New file. Documents the new workflows and Copilot replacement under `[Unreleased]`.
- `CONTRIBUTING.md`: New "Automated Review Tooling" section documenting aptu triage/review and confirming that Copilot review is disabled via the ruleset (not via the Settings UI).

## Ruleset change (already applied)

The `copilot_code_review` rule has been removed from the `Protect main branch` ruleset (id 13342306) via the GitHub GraphQL API (`updateRepositoryRuleset` mutation). This was done directly against the default branch outside of this PR, so it is already in effect. No manual Settings UI step is required.

## Test plan

- [x] YAML syntax valid
- [x] Action inputs match validated `action.yml` spec (`clouatre-labs/aptu@v0.5.1`)
- [x] Both actions pinned to commit SHA (not tag)
- [x] Both secrets (`GEMINI_API_KEY`, `OPENROUTER_API_KEY`) already provisioned in repository
- [x] `copilot_code_review` rule confirmed absent from ruleset after mutation
