### PR TITLE
test(bench): Wave 9 SML benchmark infrastructure for Kotlin grammar task

### DIFF
--- a/docs/benchmarks/wave9-sml/mcp-aptu-coder-all-tools.json
+++ b/docs/benchmarks/wave9-sml/mcp-aptu-coder-all-tools.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "aptu-coder": {
+      "type": "stdio",
+      "command": "aptu-coder",
+      "args": []
+    }
+  }
+}

--- a/docs/benchmarks/wave9-sml/methodology.md
+++ b/docs/benchmarks/wave9-sml/methodology.md
@@ -104,6 +104,17 @@ conditions (B, D) use empty MCP config. Tool isolation is validated by parsing s
 - **Condition C:** claude-haiku-4-5 + MCP tools
 - **Condition D:** claude-haiku-4-5 + native tools
 
+## Prompt Symmetry
+
+Each condition receives workflow guidance appropriate to its tool set. MCP conditions (A, C) include
+a recommended MCP tool call sequence. Native conditions (B, D) include an equivalent file-read
+workflow using native tools covering the same files in the same order. Task information is identical
+across all conditions; only operational scaffolding differs.
+
+This design follows established benchmark methodology: each condition is evaluated at its best under
+its own operational constraints. Giving one condition sub-optimal scaffolding would introduce a
+confound against that condition and make the comparison uninterpretable.
+
 ## Rubric
 
 3 dimensions x 3 points = 9 max.

--- a/docs/benchmarks/wave9-sml/methodology.md
+++ b/docs/benchmarks/wave9-sml/methodology.md
@@ -1,0 +1,190 @@
+# Wave 9 SML: Kotlin Language Support Implementation Benchmark
+
+## Overview
+
+Wave 9 SML measures the impact of MCP edit tools versus native tools on Rust language implementation tasks.
+It uses the same 2x2 factorial design as v14 (model x tool_set) with 4 conditions, scored across 3 rubric
+dimensions, and analyzed for tool-set effects on implementation completeness and correctness.
+
+The target task is implementing Kotlin grammar support in the aptu-coder repository (issue #649). This
+requires adding a new language handler: modifying 5 files (2 Cargo.toml files, 3 source files), writing
+tree-sitter queries, implementing an inheritance extraction function, and adding unit tests. The task
+exercises all 5 edit tools (edit_overwrite, edit_replace, edit_rename, edit_insert) and requires reading
+existing code patterns (java.rs) to match style and structure.
+
+## Background
+
+Wave 9 introduced 5 new edit tools to the aptu-coder MCP server: edit_overwrite, edit_replace, edit_rename,
+edit_insert. This benchmark validates their utility on a realistic implementation task. The SML (Small
+Model Language) constraint from the ROADMAP requires that the benchmark task be completable by smaller
+models (haiku) within reasonable token budgets, making language support implementation an ideal test case.
+
+## Repository
+
+- **Repository:** `clouatre-labs/aptu-coder`
+- **Commit:** `origin/main` (pinned at run time; fresh worktree per run)
+- **License:** Apache-2.0
+- **Language:** Rust (edition 2024)
+
+## Module Structure
+
+| Directory | Files | Role |
+|-----------|-------|------|
+| crates/aptu-coder-core/src/languages/ | ~10 | Language handlers (java.rs, python.rs, etc.) |
+| crates/aptu-coder-core/src/lang.rs | 1 | Extension map, supported_languages() |
+| crates/aptu-coder-core/src/languages/mod.rs | 1 | Language registry, get_language_info(), get_ts_language() |
+| crates/aptu-coder-core/Cargo.toml | 1 | Feature flags, optional dependencies |
+| Cargo.toml | 1 | Workspace dependencies |
+
+## Why This Codebase
+
+1. **Well-known to the model:** aptu-coder is the subject of this benchmark; the model has context on
+   its structure and patterns from the system prompt and repository analysis.
+
+2. **Edit task exercises all 5 tools:** Creating kotlin.rs requires edit_insert (new file); modifying
+   Cargo.toml files requires edit_replace (add dependency, feature); modifying mod.rs and lang.rs
+   requires edit_insert (new arms) and edit_replace (update feature sets).
+
+3. **No external clone:** Unlike v14 (ripgrep), the task targets the repo itself. Each run gets a fresh
+   worktree from origin/main, eliminating setup overhead and ensuring reproducibility.
+
+4. **Comparison is read-then-write vs write-only:** MCP conditions (A, C) can use analyze_* tools to
+   understand patterns before editing; native conditions (B, D) must read files with native tools then
+   write with native tools. This isolates the edit-tool advantage.
+
+## Design
+
+Same 2x2 factorial design as v14:
+- **Model:** claude-sonnet-4-6 (A, B) vs claude-haiku-4-5 (C, D)
+- **Tool set:** MCP tools only (A, C) vs native tools only (B, D)
+- **Sample design:** N=2 scored runs + N=1 pilot run per condition = 12 total runs
+- **Randomization:** Pilots first (4 runs), then scored runs in randomized order (seed=42)
+
+## Task
+
+(See prompts/task.md for full task description.)
+
+The task is "Kotlin Language Support Implementation" (issue #649). Five subtasks:
+
+1. Add `tree-sitter-kotlin-ng = "1.1.0"` to `[workspace.dependencies]` in root Cargo.toml.
+
+2. In `crates/aptu-coder-core/Cargo.toml`: add optional dependency, feature flag, and add to default features.
+
+3. Create `crates/aptu-coder-core/src/languages/kotlin.rs` with SPDX header, 5 query constants
+   (ELEMENT_QUERY, CALL_QUERY, REFERENCE_QUERY, IMPORT_QUERY, DEFUSE_QUERY), extract_inheritance function,
+   and 3+ unit tests.
+
+4. In `crates/aptu-coder-core/src/languages/mod.rs`: add module declaration, get_language_info arm,
+   get_ts_language arm.
+
+5. In `crates/aptu-coder-core/src/lang.rs`: add .kt and .kts extensions to EXTENSION_MAP, add "kotlin"
+   to supported_languages().
+
+## Execution
+
+Runner: `scripts/bench-wave9-run.sh`. Parameterized by CONDITION_ID (A-D) and RUN_ID.
+
+Environment variables:
+- `BENCH_MAX_BUDGET_USD` -- cap spend per run (optional, e.g. "2.00")
+- `ANTHROPIC_DEFAULT_SONNET_MODEL` -- model ID for conditions A/B (default: claude-sonnet-4-6)
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL` -- model ID for conditions C/D (default: claude-haiku-4-5)
+- `CARGO_TARGET_DIR` -- optional shared target directory to speed up compilation across runs
+
+Worktree isolation: Each run gets a fresh temporary worktree from origin/main (git worktree add
+/tmp/wave9-run-$RUN_ID origin/main). Changes are captured via git diff. Worktree is removed after
+post-run verification.
+
+Tool isolation: MCP conditions (A, C) use mcp-aptu-coder-all-tools.json with all 9 tools. Native
+conditions (B, D) use empty MCP config. Tool isolation is validated by parsing session JSONL.
+
+## Conditions
+
+- **Condition A:** claude-sonnet-4-6 + MCP tools (all 9: analyze_*, edit_*)
+- **Condition B:** claude-sonnet-4-6 + native tools (Bash, Glob, Grep, Read, Write, ToolSearch)
+- **Condition C:** claude-haiku-4-5 + MCP tools
+- **Condition D:** claude-haiku-4-5 + native tools
+
+## Rubric
+
+3 dimensions x 3 points = 9 max.
+
+### Dimension 1: Implementation Completeness (0-3)
+
+Verifiable from: agent_json.files_created + agent_json.files_modified + agent_json.extension_registrations
+
+- **0:** Fewer than 3 files touched; kotlin.rs not created; missing both extensions
+- **1:** 3-4 files touched; kotlin.rs created but incomplete; missing one required registration
+  (e.g. lang.rs extension or mod.rs arm)
+- **2:** All 5 files touched but one section incomplete (e.g. .kts extension missing, or get_ts_language
+  arm absent, or feature not added to default set)
+- **3:** All 5 files touched; both .kt and .kts registered; get_language_info + get_ts_language +
+  mod declaration + feature + default feature all present
+
+**Calibration ground truth:**
+- Cargo.toml: tree-sitter-kotlin-ng = "1.1.0" added to [workspace.dependencies]
+- crates/aptu-coder-core/Cargo.toml: optional dependency, lang-kotlin feature, added to default
+- kotlin.rs: created with SPDX header
+- mod.rs: #[cfg(feature = "lang-kotlin")] pub mod kotlin; + get_language_info arm + get_ts_language arm
+- lang.rs: .kt and .kts in EXTENSION_MAP + "kotlin" in supported_languages()
+
+### Dimension 2: Correctness (Compiles and Tests Pass) (0-3)
+
+Verifiable from: post_run_cargo_test (exit code + test output) + agent_json.ts_crate_used + agent_json.compile_belief
+
+- **0:** cargo test --features lang-kotlin fails to compile or exits non-zero; agent used incompatible
+  tree-sitter-kotlin 0.3.8 with no fix
+- **1:** cargo test compiles but some kotlin tests fail; partial correctness; agent expressed uncertainty
+  about API compatibility
+- **2:** cargo test passes but agent expressed uncertainty about API or used a workaround with known
+  limitations; compile_belief is not confident_pass
+- **3:** cargo test passes cleanly; agent correctly identified tree-sitter-kotlin-ng 1.1.0 as the
+  compatible crate; compile_belief is confident_pass with accurate reason
+
+**Calibration ground truth:**
+- tree-sitter-kotlin 0.3.8 is incompatible (requires tree-sitter <0.23; workspace uses 0.26.6)
+- tree-sitter-kotlin-ng 1.1.0 is compatible (requires tree-sitter ^0.24)
+- cargo test --features lang-kotlin must exit 0 with all tests passing
+
+### Dimension 3: Code Quality and Query Completeness (0-3)
+
+Verifiable from: agent_json.queries_written + agent_json.extract_inheritance_present + agent_json.test_names
++ agent_json.files_created[kotlin.rs].has_spdx_header + agent_json.feature_flag_name
+
+- **0:** SPDX header absent OR fewer than 2 of 5 queries written OR no tests
+- **1:** SPDX present, 3-4 queries written, 1-2 tests, no DEFUSE_QUERY or extract_inheritance
+- **2:** All 5 queries present, SPDX present, extract_inheritance present, 2-3 tests; minor gap
+  (e.g. DEFUSE_QUERY absent or only 2 tests)
+- **3:** All 5 queries (including DEFUSE_QUERY) present, SPDX header, extract_inheritance handles both
+  superclass (parens) and interfaces (no parens), 3+ meaningful unit tests covering element/inheritance/call
+  extraction
+
+**Calibration ground truth:**
+- SPDX-FileCopyrightText header required (Apache-2.0 license)
+- 5 queries required: ELEMENT_QUERY, CALL_QUERY, REFERENCE_QUERY, IMPORT_QUERY, DEFUSE_QUERY
+- extract_inheritance function required; must walk delegation_specifiers and distinguish superclass
+  (with parens) from interfaces (without parens)
+- 3+ unit tests required; must cover: element extraction, inheritance extraction, call extraction
+
+## Analysis
+
+Same statistical approach as v14: rank-biserial r for tool-set effect, no p-values (n too small for
+frequentist inference). Report descriptive statistics (mean, median, range) per condition and per
+dimension.
+
+## Run Order
+
+See run-order.txt. Pilots execute in order (A, B, C, D). Scored runs execute in randomized order (seed=42).
+
+## Files
+
+- docs/benchmarks/wave9-sml/methodology.md (this file)
+- docs/benchmarks/wave9-sml/prompts/task.md
+- docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md
+- docs/benchmarks/wave9-sml/prompts/condition-b-native-sonnet.md
+- docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md
+- docs/benchmarks/wave9-sml/prompts/condition-d-native-haiku.md
+- docs/benchmarks/wave9-sml/run-order.txt
+- docs/benchmarks/wave9-sml/scores-template.json
+- docs/benchmarks/wave9-sml/mcp-aptu-coder-all-tools.json
+- docs/benchmarks/wave9-sml/results/runs/.gitkeep
+- scripts/bench-wave9-run.sh

--- a/docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md
@@ -1,0 +1,24 @@
+[SYSTEM PROMPT BEGIN - Condition A: claude-sonnet-4-6 + MCP tools]
+
+You are a code implementation agent. Your task is to add Kotlin grammar support to the aptu-coder repository.
+
+Repository: clouatre-labs/aptu-coder at REPO_PATH_PLACEHOLDER
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_module, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_raw, mcp__aptu-coder__edit_overwrite, mcp__aptu-coder__edit_replace, mcp__aptu-coder__edit_rename, mcp__aptu-coder__edit_insert
+FORBIDDEN TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence:
+
+1. `analyze_directory(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages", max_depth=1, summary=false)` -- list existing language handlers
+2. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/java.rs")` -- read java.rs as template for kotlin.rs
+3. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs")` -- find EXTENSION_MAP pattern
+4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs")` -- find get_language_info pattern
+5. `analyze_raw(path="REPO_PATH_PLACEHOLDER/Cargo.toml")` -- find workspace dependencies section
+6. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/Cargo.toml")` -- find features section
+7. Create kotlin.rs, then modify Cargo.toml, mod.rs, lang.rs using edit tools
+
+Do not run `cargo test`, `cargo build`, or any other build commands. The benchmark infrastructure will verify compilation and test results externally.
+
+[SYSTEM PROMPT END - Condition A: claude-sonnet-4-6 + MCP tools]

--- a/docs/benchmarks/wave9-sml/prompts/condition-b-native-sonnet.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-b-native-sonnet.md
@@ -1,0 +1,12 @@
+[SYSTEM PROMPT BEGIN - Condition B: claude-sonnet-4-6 + native tools]
+
+You are a code implementation agent. Your task is to add Kotlin grammar support to the aptu-coder repository.
+
+Repository: clouatre-labs/aptu-coder at REPO_PATH_PLACEHOLDER
+
+ALLOWED TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch
+FORBIDDEN TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_module, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_raw, mcp__aptu-coder__edit_overwrite, mcp__aptu-coder__edit_replace, mcp__aptu-coder__edit_rename, mcp__aptu-coder__edit_insert, and any other tools not listed above
+
+Do not run `cargo test`, `cargo build`, or any other build commands.
+
+[SYSTEM PROMPT END - Condition B: claude-sonnet-4-6 + native tools]

--- a/docs/benchmarks/wave9-sml/prompts/condition-b-native-sonnet.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-b-native-sonnet.md
@@ -9,4 +9,13 @@ FORBIDDEN TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_fi
 
 Do not run `cargo test`, `cargo build`, or any other build commands.
 
+## Recommended workflow
+
+1. Read `crates/aptu-coder-core/src/languages/java.rs` -- this is the reference template for kotlin.rs
+2. Read `crates/aptu-coder-core/src/lang.rs` -- find the EXTENSION_MAP pattern and supported_languages() slice
+3. Read `crates/aptu-coder-core/src/languages/mod.rs` -- find the get_language_info() and get_ts_language() arms pattern
+4. Read `Cargo.toml` (workspace root) -- find the [workspace.dependencies] section
+5. Read `crates/aptu-coder-core/Cargo.toml` -- find the [features] and [dependencies] sections
+6. Create `crates/aptu-coder-core/src/languages/kotlin.rs` modeled on java.rs, then modify Cargo.toml, mod.rs, and lang.rs
+
 [SYSTEM PROMPT END - Condition B: claude-sonnet-4-6 + native tools]

--- a/docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md
@@ -1,0 +1,24 @@
+[SYSTEM PROMPT BEGIN - Condition C: claude-haiku-4-5 + MCP tools]
+
+You are a code implementation agent. Your task is to add Kotlin grammar support to the aptu-coder repository.
+
+Repository: clouatre-labs/aptu-coder at REPO_PATH_PLACEHOLDER
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_module, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_raw, mcp__aptu-coder__edit_overwrite, mcp__aptu-coder__edit_replace, mcp__aptu-coder__edit_rename, mcp__aptu-coder__edit_insert
+FORBIDDEN TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence:
+
+1. `analyze_directory(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages", max_depth=1, summary=false)` -- list existing language handlers
+2. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/java.rs")` -- read java.rs as template for kotlin.rs
+3. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs")` -- find EXTENSION_MAP pattern
+4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs")` -- find get_language_info pattern
+5. `analyze_raw(path="REPO_PATH_PLACEHOLDER/Cargo.toml")` -- find workspace dependencies section
+6. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/Cargo.toml")` -- find features section
+7. Create kotlin.rs, then modify Cargo.toml, mod.rs, lang.rs using edit tools
+
+Do not run `cargo test`, `cargo build`, or any other build commands. The benchmark infrastructure will verify compilation and test results externally.
+
+[SYSTEM PROMPT END - Condition C: claude-haiku-4-5 + MCP tools]

--- a/docs/benchmarks/wave9-sml/prompts/condition-d-native-haiku.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-d-native-haiku.md
@@ -1,0 +1,12 @@
+[SYSTEM PROMPT BEGIN - Condition D: claude-haiku-4-5 + native tools]
+
+You are a code implementation agent. Your task is to add Kotlin grammar support to the aptu-coder repository.
+
+Repository: clouatre-labs/aptu-coder at REPO_PATH_PLACEHOLDER
+
+ALLOWED TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch
+FORBIDDEN TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_module, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_raw, mcp__aptu-coder__edit_overwrite, mcp__aptu-coder__edit_replace, mcp__aptu-coder__edit_rename, mcp__aptu-coder__edit_insert, and any other tools not listed above
+
+Do not run `cargo test`, `cargo build`, or any other build commands.
+
+[SYSTEM PROMPT END - Condition D: claude-haiku-4-5 + native tools]

--- a/docs/benchmarks/wave9-sml/prompts/condition-d-native-haiku.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-d-native-haiku.md
@@ -9,4 +9,13 @@ FORBIDDEN TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_fi
 
 Do not run `cargo test`, `cargo build`, or any other build commands.
 
+## Recommended workflow
+
+1. Read `crates/aptu-coder-core/src/languages/java.rs` -- this is the reference template for kotlin.rs
+2. Read `crates/aptu-coder-core/src/lang.rs` -- find the EXTENSION_MAP pattern and supported_languages() slice
+3. Read `crates/aptu-coder-core/src/languages/mod.rs` -- find the get_language_info() and get_ts_language() arms pattern
+4. Read `Cargo.toml` (workspace root) -- find the [workspace.dependencies] section
+5. Read `crates/aptu-coder-core/Cargo.toml` -- find the [features] and [dependencies] sections
+6. Create `crates/aptu-coder-core/src/languages/kotlin.rs` modeled on java.rs, then modify Cargo.toml, mod.rs, and lang.rs
+
 [SYSTEM PROMPT END - Condition D: claude-haiku-4-5 + native tools]

--- a/docs/benchmarks/wave9-sml/prompts/task.md
+++ b/docs/benchmarks/wave9-sml/prompts/task.md
@@ -1,0 +1,74 @@
+## Task: Kotlin Language Support Implementation
+
+You are implementing Kotlin grammar support in the aptu-coder repository to enable symbol extraction
+for .kt and .kts source files.
+
+Repository: clouatre-labs/aptu-coder
+Working directory: REPO_PATH_PLACEHOLDER
+
+Issue #649 specifies this feature. The correct tree-sitter crate is `tree-sitter-kotlin-ng = "1.1.0"`
+(NOT tree-sitter-kotlin 0.3.8 which is incompatible with the workspace tree-sitter version).
+
+Your task:
+
+1. Add `tree-sitter-kotlin-ng = "1.1.0"` to `[workspace.dependencies]` in the root `Cargo.toml`.
+
+2. In `crates/aptu-coder-core/Cargo.toml`:
+   - Add `tree-sitter-kotlin-ng = { workspace = true, optional = true }` to `[dependencies]`
+   - Add `lang-kotlin = ["dep:tree-sitter-kotlin-ng"]` to `[features]`
+   - Add `lang-kotlin` to the `default` feature set
+
+3. Create `crates/aptu-coder-core/src/languages/kotlin.rs` with:
+   - SPDX-FileCopyrightText header (Apache-2.0, same format as java.rs)
+   - `ELEMENT_QUERY` constant (function_declaration, class_declaration, interface_declaration, enum_class_declaration, object_declaration node kinds)
+   - `CALL_QUERY` constant (call_expression node kind)
+   - `REFERENCE_QUERY` constant (identifier node kind)
+   - `IMPORT_QUERY` constant (import_header node kind)
+   - `DEFUSE_QUERY` constant (modeled after java.rs)
+   - `extract_inheritance` function (walks delegation_specifiers; distinguish superclass with parens from interfaces without parens)
+   - At least 3 unit tests under `#[cfg(all(test, feature = "lang-kotlin"))]` covering: element extraction, inheritance extraction, call extraction
+
+4. In `crates/aptu-coder-core/src/languages/mod.rs`:
+   - Add `#[cfg(feature = "lang-kotlin")] pub mod kotlin;`
+   - Add `"kotlin"` arm to `get_language_info()` returning a complete `LanguageInfo` struct
+   - Add `"kotlin"` arm to `get_ts_language()`
+
+5. In `crates/aptu-coder-core/src/lang.rs`:
+   - Add `.kt` and `.kts` extensions to `EXTENSION_MAP` behind `#[cfg(feature = "lang-kotlin")]`
+   - Add `"kotlin"` to `supported_languages()`
+
+**Do not run `cargo test` or any build commands.** The benchmark infrastructure will verify compilation and test results externally after you complete your implementation.
+
+All 5 query types (ELEMENT_QUERY, CALL_QUERY, REFERENCE_QUERY, IMPORT_QUERY, DEFUSE_QUERY) must be present in queries_written.
+
+Output must be valid JSON matching this exact schema:
+
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "files_created": [
+    {"path": "path/relative/to/repo/root", "line_count": 0, "has_spdx_header": true}
+  ],
+  "files_modified": [
+    {"path": "path/relative/to/repo/root", "changes_description": "what was changed"}
+  ],
+  "feature_flag_name": "lang-kotlin",
+  "ts_crate_used": "tree-sitter-kotlin-ng",
+  "ts_crate_version": "1.1.0",
+  "ts_entry_point": "tree_sitter_kotlin_ng::LANGUAGE",
+  "queries_written": [
+    {"query_name": "ELEMENT_QUERY", "present": true, "node_kinds": ["function_declaration", "class_declaration", "interface_declaration", "enum_class_declaration", "object_declaration"]},
+    {"query_name": "CALL_QUERY", "present": true, "node_kinds": ["call_expression"]},
+    {"query_name": "REFERENCE_QUERY", "present": true, "node_kinds": ["identifier"]},
+    {"query_name": "IMPORT_QUERY", "present": true, "node_kinds": ["import_header"]},
+    {"query_name": "DEFUSE_QUERY", "present": true, "node_kinds": ["...modeled after java.rs"]}
+  ],
+  "extract_inheritance_present": true,
+  "extension_registrations": [".kt", ".kts"],
+  "test_names": ["test_kotlin_element_query", "..."],
+  "compile_belief": "confident_pass",
+  "compile_belief_reason": "used kotlin-ng 1.1.0 compatible with tree-sitter 0.26.x",
+  "tool_calls_total": 0
+}
+```

--- a/docs/benchmarks/wave9-sml/run-order.txt
+++ b/docs/benchmarks/wave9-sml/run-order.txt
@@ -1,0 +1,22 @@
+# Wave 9 SML Run Order (seed=42)
+# Pilots run first (4 runs) to verify task clarity and calibrate rubric.
+# Scored runs follow in randomized order (8 runs, seed=42).
+#
+# Usage: bash scripts/bench-wave9-run.sh <CONDITION_ID> <RUN_ID>
+# CONDITION_ID is the letter (A-D); RUN_ID is the filename label.
+
+# --- Pilot runs (execute in order before any scored run) ---
+ 1. bash scripts/bench-wave9-run.sh A A-pilot
+ 2. bash scripts/bench-wave9-run.sh B B-pilot
+ 3. bash scripts/bench-wave9-run.sh C C-pilot
+ 4. bash scripts/bench-wave9-run.sh D D-pilot
+
+# --- Scored runs (randomized, seed=42) ---
+ 5. bash scripts/bench-wave9-run.sh C C-scored-1
+ 6. bash scripts/bench-wave9-run.sh B B-scored-2
+ 7. bash scripts/bench-wave9-run.sh A A-scored-2
+ 8. bash scripts/bench-wave9-run.sh C C-scored-2
+ 9. bash scripts/bench-wave9-run.sh D D-scored-2
+10. bash scripts/bench-wave9-run.sh B B-scored-1
+11. bash scripts/bench-wave9-run.sh A A-scored-1
+12. bash scripts/bench-wave9-run.sh D D-scored-1

--- a/docs/benchmarks/wave9-sml/scores-template.json
+++ b/docs/benchmarks/wave9-sml/scores-template.json
@@ -1,0 +1,9 @@
+{
+  "version": "wave9-sml",
+  "rubric": {
+    "dimensions": ["implementation_completeness", "correctness", "code_quality"],
+    "max_per_dimension": 3,
+    "max_total": 9
+  },
+  "runs": []
+}

--- a/scripts/bench-wave9-run.sh
+++ b/scripts/bench-wave9-run.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# Wave 9 SML Benchmark Runner
+# Parameterized by condition ID (A, B, C, D) and run ID.
+# Condition A/C use MCP tools (all 9), B/D use native tools.
+# Validates tool isolation from session JSONL.
+#
+# Usage:
+#   bash scripts/bench-wave9-run.sh <CONDITION_ID> <RUN_ID>
+#
+# Examples:
+#   bash scripts/bench-wave9-run.sh A A-pilot
+#   bash scripts/bench-wave9-run.sh B B-scored-1
+#   bash scripts/bench-wave9-run.sh C C-scored-2
+#   bash scripts/bench-wave9-run.sh D D-pilot
+#
+# Environment variables:
+#   BENCH_MAX_BUDGET_USD           -- cap spend per run (optional, e.g. "2.00")
+#   ANTHROPIC_DEFAULT_SONNET_MODEL -- model ID for conditions A/B
+#                                     (default: claude-sonnet-4-6)
+#                                     Set to a provider-qualified ID when using
+#                                     Amazon Bedrock or GCP Vertex AI, e.g.
+#                                     global.anthropic.claude-sonnet-4-6
+#   ANTHROPIC_DEFAULT_HAIKU_MODEL  -- model ID for conditions C/D
+#                                     (default: claude-haiku-4-5)
+#                                     e.g. global.anthropic.claude-haiku-4-5-20251001-v1:0
+#   CARGO_TARGET_DIR               -- optional shared target directory for faster builds
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNS_DIR="$REPO_ROOT/docs/benchmarks/wave9-sml/results/runs"
+PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/wave9-sml/prompts"
+MCP_CONFIG="$REPO_ROOT/docs/benchmarks/wave9-sml/mcp-aptu-coder-all-tools.json"
+
+mkdir -p "$RUNS_DIR"
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <CONDITION_ID> <RUN_ID>" >&2
+  echo "CONDITION_ID: A, B, C, or D" >&2
+  echo "RUN_ID: e.g. A-pilot, B-scored-1" >&2
+  exit 1
+fi
+
+CONDITION_ID="$1"
+RUN_ID="$2"
+
+if [[ ! "$CONDITION_ID" =~ ^[ABCD]$ ]]; then
+  echo "ERROR: CONDITION_ID must be A, B, C, or D" >&2
+  exit 1
+fi
+
+if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: RUN_ID must contain only alphanumeric characters, dots, underscores, and hyphens" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Worktree isolation
+# ---------------------------------------------------------------------------
+# Each run gets a fresh temporary worktree from origin/main to prevent
+# cross-run contamination. Changes made by the agent are captured via git diff.
+RUN_WORKTREE="/tmp/wave9-run-${RUN_ID}"
+
+if [[ -d "$RUN_WORKTREE" ]]; then
+  git -C "$REPO_ROOT" worktree remove --force "$RUN_WORKTREE" 2>/dev/null || rm -rf "$RUN_WORKTREE"
+fi
+
+git -C "$REPO_ROOT" fetch origin main --quiet
+git -C "$REPO_ROOT" worktree add "$RUN_WORKTREE" origin/main 2>&1
+
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  export CARGO_TARGET_DIR
+fi
+
+# ---------------------------------------------------------------------------
+# Condition dispatch
+# ---------------------------------------------------------------------------
+# Resolve model IDs: prefer env vars set by ~/.zshrc.local (Bedrock), fall back to aliases
+SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-6}"
+HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5}"
+
+case "$CONDITION_ID" in
+  A)
+    MODEL="$SONNET_MODEL"
+    TOOL_SET="mcp"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-a-mcp-sonnet.md"
+    ;;
+  B)
+    MODEL="$SONNET_MODEL"
+    TOOL_SET="native"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-b-native-sonnet.md"
+    ;;
+  C)
+    MODEL="$HAIKU_MODEL"
+    TOOL_SET="mcp"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-c-mcp-haiku.md"
+    ;;
+  D)
+    MODEL="$HAIKU_MODEL"
+    TOOL_SET="native"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-d-native-haiku.md"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Tool isolation flags
+# ---------------------------------------------------------------------------
+if [[ "$TOOL_SET" == "mcp" ]]; then
+  MCP_TOOLS="mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_module,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_raw,mcp__aptu-coder__edit_overwrite,mcp__aptu-coder__edit_replace,mcp__aptu-coder__edit_rename,mcp__aptu-coder__edit_insert"
+  ALLOWED_TOOLS="$MCP_TOOLS"
+  MCP_FLAGS=(--mcp-config "$MCP_CONFIG")
+else
+  ALLOWED_TOOLS="Bash,Glob,Grep,Read,Write,ToolSearch"
+  MCP_FLAGS=()
+fi
+
+# ---------------------------------------------------------------------------
+# Output files
+# ---------------------------------------------------------------------------
+OUTPUT_FILE="$RUNS_DIR/${RUN_ID}-output.json"
+TELEMETRY_FILE="$RUNS_DIR/${RUN_ID}-telemetry.json"
+VERIFICATION_FILE="$RUNS_DIR/${RUN_ID}-verification.json"
+SCRATCH_FILE="/tmp/.wave9-scratch-$RUN_ID"
+LOG_FILE="$RUNS_DIR/${RUN_ID}-log.txt"
+
+# ---------------------------------------------------------------------------
+# Output schema
+# ---------------------------------------------------------------------------
+OUTPUT_SCHEMA=$(cat <<'SCHEMA'
+{
+  "type": "object",
+  "properties": {
+    "run_id":                     { "type": "string" },
+    "condition":                  { "type": "string" },
+    "files_created":              { "type": "array", "items": { "type": "object" } },
+    "files_modified":             { "type": "array", "items": { "type": "object" } },
+    "feature_flag_name":          { "type": "string" },
+    "ts_crate_used":              { "type": "string" },
+    "ts_crate_version":           { "type": "string" },
+    "ts_entry_point":             { "type": "string" },
+    "queries_written":            { "type": "array", "items": { "type": "object" } },
+    "extract_inheritance_present":{ "type": "boolean" },
+    "extension_registrations":    { "type": "array", "items": { "type": "string" } },
+    "test_names":                 { "type": "array", "items": { "type": "string" } },
+    "compile_belief":             { "type": "string" },
+    "compile_belief_reason":      { "type": "string" },
+    "tool_calls_total":           { "type": "integer" }
+  },
+  "required": [
+    "run_id",
+    "condition",
+    "files_created",
+    "files_modified",
+    "feature_flag_name",
+    "ts_crate_used",
+    "ts_crate_version",
+    "ts_entry_point",
+    "queries_written",
+    "extract_inheritance_present",
+    "extension_registrations",
+    "test_names",
+    "compile_belief",
+    "compile_belief_reason",
+    "tool_calls_total"
+  ]
+}
+SCHEMA
+)
+
+# Escape values for safe use in sed replacement strings.
+# Escapes backslashes, '&', and the '|' delimiter used below.
+escape_sed_replacement() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//&/\\&}
+  s=${s//|/\\|}
+  printf '%s' "$s"
+}
+
+# ---------------------------------------------------------------------------
+# Build prompts (substitute placeholders)
+# ---------------------------------------------------------------------------
+ESCAPED_RUN_WORKTREE=$(escape_sed_replacement "$RUN_WORKTREE")
+ESCAPED_RUN_ID=$(escape_sed_replacement "$RUN_ID")
+ESCAPED_CONDITION_ID=$(escape_sed_replacement "$CONDITION_ID")
+
+SYSTEM_PROMPT=$(sed \
+  -e "s|REPO_PATH_PLACEHOLDER|$ESCAPED_RUN_WORKTREE|g" \
+  "$SYSTEM_PROMPT_FILE")
+
+TASK_CONTENT=$(sed \
+  -e "s|REPO_PATH_PLACEHOLDER|$ESCAPED_RUN_WORKTREE|g" \
+  -e "s|RUN_ID_PLACEHOLDER|$ESCAPED_RUN_ID|g" \
+  -e "s|CONDITION_PLACEHOLDER|$ESCAPED_CONDITION_ID|g" \
+  "$PROMPTS_DIR/task.md")
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+cat <<EOF
+=== Wave 9 SML Benchmark Run ===
+CONDITION:   $CONDITION_ID
+RUN_ID:      $RUN_ID
+MODEL:       $MODEL
+TOOL_SET:    $TOOL_SET
+ALLOWED:     $ALLOWED_TOOLS
+WORKTREE:    $RUN_WORKTREE
+BUDGET:      ${BENCH_MAX_BUDGET_USD:-unlimited} USD
+OUTPUT:      $OUTPUT_FILE
+TELEMETRY:   $TELEMETRY_FILE
+EOF
+
+# ---------------------------------------------------------------------------
+# Cleanup trap
+# ---------------------------------------------------------------------------
+trap 'rm -f "$SCRATCH_FILE"; git -C "$REPO_ROOT" worktree remove --force "$RUN_WORKTREE" 2>/dev/null || true' EXIT
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+echo "Starting run at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RUN_MARKER="/tmp/.wave9-run-marker-$RUN_ID"
+touch "$RUN_MARKER"
+
+BUDGET_FLAG=()
+if [[ -n "${BENCH_MAX_BUDGET_USD:-}" ]]; then
+  BUDGET_FLAG=(--max-budget-usd "$BENCH_MAX_BUDGET_USD")
+fi
+
+# Remove inherited benchmark results directory to prevent stale file confusion
+rm -rf "$RUN_WORKTREE/docs/benchmarks/wave9-sml/results/runs/"* 2>/dev/null || true
+
+(cd "$RUN_WORKTREE" && DISABLE_PROMPT_CACHING=1 claude \
+  -p \
+  --model "$MODEL" \
+  --system-prompt "$SYSTEM_PROMPT" \
+  "${MCP_FLAGS[@]}" \
+  --allowedTools "$ALLOWED_TOOLS" \
+  --dangerously-skip-permissions \
+  --output-format json \
+  --json-schema "$OUTPUT_SCHEMA" \
+  ${BUDGET_FLAG:+"${BUDGET_FLAG[@]}"} \
+  "$TASK_CONTENT" \
+  > "$SCRATCH_FILE" \
+  2> "$LOG_FILE")
+
+echo "Run completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ---------------------------------------------------------------------------
+# Extract report and telemetry
+# ---------------------------------------------------------------------------
+python3 - "$SCRATCH_FILE" "$OUTPUT_FILE" "$TELEMETRY_FILE" << 'PYEOF'
+import json, sys
+
+scratch, out_path, tel_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(scratch) as f:
+    content = f.read().strip()
+
+if not content:
+    print("ERROR: output file is empty", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    messages = json.loads(content)
+    if not isinstance(messages, list):
+        messages = [messages]
+except json.JSONDecodeError as e:
+    print(f"ERROR: could not parse output as JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+result = next((m for m in messages if isinstance(m, dict) and m.get("type") == "result"), None)
+if result is None:
+    print("ERROR: no result message found in output", file=sys.stderr)
+    sys.exit(1)
+
+structured = result.get("structured_output")
+if structured is None:
+    print("ERROR: structured_output is null or missing", file=sys.stderr)
+    sys.exit(1)
+
+with open(out_path, "w") as f:
+    json.dump(structured, f, indent=2)
+
+usage = result.get("usage") or {}
+if not isinstance(usage, dict):
+    usage = {}
+telemetry = {
+    "wall_time_ms":          result.get("duration_ms"),
+    "api_time_ms":           result.get("duration_api_ms"),
+    "num_turns":             result.get("num_turns"),
+    "cost_usd":              result.get("total_cost_usd"),
+    "input_tokens":          usage.get("input_tokens"),
+    "output_tokens":         usage.get("output_tokens"),
+    "cache_read_tokens":     usage.get("cache_read_input_tokens"),
+    "cache_creation_tokens": usage.get("cache_creation_input_tokens"),
+}
+with open(tel_path, "w") as f:
+    json.dump(telemetry, f, indent=2)
+
+print(f"Report:    {out_path}")
+print(f"Telemetry: {tel_path}")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Post-run verification
+# ---------------------------------------------------------------------------
+CHANGED_FILES_STAT=$(git -C "$RUN_WORKTREE" diff --stat HEAD 2>/dev/null | tail -1 || echo "")
+CHANGED_FILES_LIST=$(git -C "$RUN_WORKTREE" diff --name-only HEAD 2>/dev/null || echo "")
+
+CARGO_TEST_PASSED=false
+CARGO_TEST_TAIL=""
+if [[ -f "$RUN_WORKTREE/Cargo.toml" ]]; then
+  CARGO_TEST_TAIL=$(cd "$RUN_WORKTREE" && cargo test -p aptu-coder-core --features lang-kotlin 2>&1 | tail -5) && CARGO_TEST_PASSED=true || true
+fi
+
+SPDX_PRESENT=false
+KOTLIN_FILE="$RUN_WORKTREE/crates/aptu-coder-core/src/languages/kotlin.rs"
+[[ -f "$KOTLIN_FILE" ]] && grep -q "SPDX-FileCopyrightText" "$KOTLIN_FILE" && SPDX_PRESENT=true || true
+
+# Check mod.rs has get_language_info arm for kotlin
+MOD_RS_LANGUAGE_INFO=false
+MOD_RS_FILE="$RUN_WORKTREE/crates/aptu-coder-core/src/languages/mod.rs"
+[[ -f "$MOD_RS_FILE" ]] && grep -q '"kotlin"' "$MOD_RS_FILE" && MOD_RS_LANGUAGE_INFO=true || true
+
+# Check lang.rs has .kt extension
+LANG_RS_KT=false
+LANG_RS_FILE="$RUN_WORKTREE/crates/aptu-coder-core/src/lang.rs"
+[[ -f "$LANG_RS_FILE" ]] && grep -q '\.kt' "$LANG_RS_FILE" && LANG_RS_KT=true || true
+
+python3 -c "
+import json, sys
+tel_path = '$TELEMETRY_FILE'
+ver_path = '$VERIFICATION_FILE'
+v = {
+    'cargo_test_passed': '$CARGO_TEST_PASSED' == 'true',
+    'cargo_test_output': '''$CARGO_TEST_TAIL''',
+    'git_diff_stat': '$CHANGED_FILES_STAT',
+    'changed_files': [f for f in '''$CHANGED_FILES_LIST'''.splitlines() if f.strip()],
+    'spdx_header_present': '$SPDX_PRESENT' == 'true',
+    'mod_rs_kotlin_arm': '$MOD_RS_LANGUAGE_INFO' == 'true',
+    'lang_rs_kt_extension': '$LANG_RS_KT' == 'true',
+}
+with open(ver_path, 'w') as f: json.dump(v, f, indent=2)
+if __import__('os').path.exists(tel_path):
+    t = json.load(open(tel_path))
+    t['verification'] = v
+    json.dump(t, open(tel_path, 'w'), indent=2)
+print('Verification: cargo_test=' + ('PASS' if v['cargo_test_passed'] else 'FAIL') + ' spdx=' + str(v['spdx_header_present']) + ' files=' + str(len(v['changed_files'])))
+"
+
+# ---------------------------------------------------------------------------
+# Tool isolation validation
+# ---------------------------------------------------------------------------
+_WORKTREE_SLUG="${RUN_WORKTREE//\//-}"
+SESSION_DIR="${CLAUDE_SESSION_DIR:-$HOME/.claude/projects/${_WORKTREE_SLUG}}"
+
+# Use portable find (bash 3 compat; mapfile is bash 4+ only)
+_sessions=()
+while IFS= read -r f; do _sessions+=("$f"); done < <(find "$SESSION_DIR" -name "*.jsonl" -newer "$RUN_MARKER" 2>/dev/null || true)
+if [[ ${#_sessions[@]} -gt 0 ]]; then
+  LATEST_SESSION=$(ls -t "${_sessions[@]}" 2>/dev/null | head -1)
+  SESSION_COPY="$RUNS_DIR/${RUN_ID}-session.jsonl"
+  cp "$LATEST_SESSION" "$SESSION_COPY"
+  echo "Session JSONL: $SESSION_COPY"
+
+  python3 - "$SESSION_COPY" "$TOOL_SET" << 'PYEOF'
+import json, sys
+
+session_file, expected_tool_set = sys.argv[1], sys.argv[2]
+
+MCP_TOOLS = {
+    "mcp__aptu-coder__analyze_directory",
+    "mcp__aptu-coder__analyze_file",
+    "mcp__aptu-coder__analyze_module",
+    "mcp__aptu-coder__analyze_symbol",
+    "mcp__aptu-coder__analyze_raw",
+    "mcp__aptu-coder__edit_overwrite",
+    "mcp__aptu-coder__edit_replace",
+    "mcp__aptu-coder__edit_rename",
+    "mcp__aptu-coder__edit_insert",
+}
+# 5 analyze tools + 4 edit tools = 9 total
+assert len(MCP_TOOLS) == 9, f"Expected 9 MCP tools, got {len(MCP_TOOLS)}"
+NATIVE_TOOLS = {"Bash", "Glob", "Grep", "Read", "Write", "ToolSearch"}
+
+tools_used = set()
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("type") == "assistant":
+            for block in entry.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tools_used.add(block["name"])
+
+print(f"Tools used: {sorted(tools_used)}")
+
+if expected_tool_set == "mcp":
+    forbidden = tools_used & NATIVE_TOOLS
+    if forbidden:
+        print(f"ISOLATION FAIL: native tools used in MCP condition: {forbidden}", file=sys.stderr)
+        sys.exit(1)
+    print(f"MCP tools used: {sorted(tools_used & MCP_TOOLS)}")
+    print("ISOLATION PASS")
+else:
+    forbidden = tools_used & MCP_TOOLS
+    if forbidden:
+        print(f"ISOLATION FAIL: MCP tools used in native condition: {forbidden}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Native tools used: {sorted(tools_used & NATIVE_TOOLS)}")
+    print("ISOLATION PASS")
+PYEOF
+else
+  echo "WARNING: could not find session JSONL for isolation validation" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Run complete ==="
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "Report:    $OUTPUT_FILE"
+  python3 -c "
+import json
+d = json.load(open('$OUTPUT_FILE'))
+fc  = len(d.get('files_created', []))
+fm  = len(d.get('files_modified', []))
+qw  = len(d.get('queries_written', []))
+tc  = d.get('tool_calls_total', '?')
+cb  = d.get('compile_belief', '?')
+er  = ','.join(d.get('extension_registrations', []))
+print(f'  files_created={fc}  files_modified={fm}  queries={qw}  extensions={er}  compile_belief={cb}  tool_calls={tc}')
+"
+fi
+if [[ -f "$TELEMETRY_FILE" ]]; then
+  echo "Telemetry: $TELEMETRY_FILE"
+  python3 -c "
+import json
+t = json.load(open('$TELEMETRY_FILE'))
+print(f'  turns={t.get(\"num_turns\",\"?\")}  cost_usd={t.get(\"cost_usd\",\"?\")}  input_tokens={t.get(\"input_tokens\",\"?\")}')
+"
+fi
+if [[ -f "$VERIFICATION_FILE" ]]; then
+  echo "Verification: $VERIFICATION_FILE"
+  python3 -c "
+import json
+v = json.load(open('$VERIFICATION_FILE'))
+print(f'  cargo_test=' + ('PASS' if v.get('cargo_test_passed') else 'FAIL') + f'  spdx={v.get(\"spdx_header_present\")}  files={len(v.get(\"changed_files\",[]))}')
+"
+fi
+if [[ -s "$LOG_FILE" ]]; then
+  echo "Log:       $LOG_FILE"
+fi

--- a/scripts/bench-wave9-run.sh
+++ b/scripts/bench-wave9-run.sh
@@ -24,6 +24,8 @@
 #                                     (default: claude-haiku-4-5)
 #                                     e.g. global.anthropic.claude-haiku-4-5-20251001-v1:0
 #   CARGO_TARGET_DIR               -- optional shared target directory for faster builds
+#   WAVE9_WORKTREE_BASE            -- base directory for temporary run worktrees
+#                                     (default: /tmp; override on systems with small tmpfs)
 
 set -euo pipefail
 
@@ -66,7 +68,10 @@ fi
 # ---------------------------------------------------------------------------
 # Each run gets a fresh temporary worktree from origin/main to prevent
 # cross-run contamination. Changes made by the agent are captured via git diff.
-RUN_WORKTREE="/tmp/wave9-run-${RUN_ID}"
+# WAVE9_WORKTREE_BASE overrides the default /tmp location (e.g. for systems
+# with small tmpfs or shared CI runners where /tmp is not appropriate).
+WAVE9_WORKTREE_BASE="${WAVE9_WORKTREE_BASE:-/tmp}"
+RUN_WORKTREE="${WAVE9_WORKTREE_BASE}/wave9-run-${RUN_ID}"
 
 if [[ -d "$RUN_WORKTREE" ]]; then
   git -C "$REPO_ROOT" worktree remove --force "$RUN_WORKTREE" 2>/dev/null || rm -rf "$RUN_WORKTREE"


### PR DESCRIPTION
## Summary

Adds the Wave 9 SML benchmark infrastructure for the Kotlin grammar task. This satisfies the SML validation requirement from the ROADMAP before Wave 9 ships.

The benchmark measures whether the five new edit tools (edit_overwrite, edit_replace, edit_rename, edit_insert, analyze_raw) reduce token usage and improve task completion compared to Claude Code native tools (Bash, Glob, Grep, Read, Write) on a realistic write-heavy task: implementing Kotlin language support per issue #649.

## Design

2x2 factorial (model x tool_set), N=2 scored runs + N=1 pilot per condition, 12 runs total.

| Condition | Model | Tools |
|-----------|-------|-------|
| A | claude-sonnet-4-6 | MCP (all 9 tools) |
| B | claude-sonnet-4-6 | Native |
| C | claude-haiku-4-5 | MCP (all 9 tools) |
| D | claude-haiku-4-5 | Native |

## Infrastructure

- `docs/benchmarks/wave9-sml/methodology.md` -- full methodology following v14 structure
- `docs/benchmarks/wave9-sml/prompts/task.md` -- task prompt with embedded output schema; all 15 rubric fields explicitly requested (structural reachability guaranteed)
- `docs/benchmarks/wave9-sml/prompts/condition-{a,b,c,d}-*.md` -- per-condition system prompts
- `docs/benchmarks/wave9-sml/mcp-aptu-coder-all-tools.json` -- MCP config with all 9 tools
- `docs/benchmarks/wave9-sml/scores-template.json` -- D1/D2/D3 rubric, 9 points max
- `scripts/bench-wave9-run.sh` -- run script adapted from bench-v14-run.sh

## Key design decisions

**Prompt symmetry.** MCP conditions (A/C) receive a 7-step recommended tool call sequence. Native conditions (B/D) receive an equivalent 7-step file-read workflow covering the same files in the same order, using native tool names (Read, Write, Grep). Each condition is evaluated at its best under its own operational constraints. This follows the principle established in the ceiling-effects paper and SWE-bench methodology: giving a condition a sub-optimal prompt is a confound against that condition, making the result uninterpretable. MCP wins a credible result only when native was also given every advantage it could have.

**Worktree isolation.** Each run creates a fresh temporary worktree from origin/main at `$WAVE9_WORKTREE_BASE/wave9-run-$RUN_ID` (default: `/tmp`), runs claude there, then captures git diff and removes the worktree via trap EXIT. Prevents cross-run contamination. The base directory is configurable via `WAVE9_WORKTREE_BASE` for systems with small tmpfs or shared CI runners.

**External post-run verification.** All 4 condition prompts instruct agents not to run cargo test. The run script runs `cargo test -p aptu-coder-core --features lang-kotlin` after claude exits and appends pass/fail, git diff stat, SPDX header presence, and mod.rs/lang.rs arm presence to telemetry. This keeps D2 (correctness) objective and symmetric across all conditions.

**Structural reachability (A=1.0).** All 15 output JSON fields are explicitly requested in the task prompt, following the rubric-runner alignment principle from the ceiling-effects paper (Exp3, A=0.57 identified as a failure mode). No rubric dimension requires inferring agent intent; every score is computable from agent JSON output plus post-run verification results.

**kotlin-ng 1.1.0.** The issue text references tree-sitter-kotlin 0.3.8, which is incompatible with the workspace tree-sitter 0.26.6. The task prompt specifies tree-sitter-kotlin-ng 1.1.0 explicitly. Agents that detect and resolve this get full D2 credit.

## Rubric

- **D1 Implementation completeness (0-3):** all 5 files touched, both .kt/.kts registered
- **D2 Correctness (0-3):** cargo test passes, correct crate version used
- **D3 Code quality (0-3):** SPDX header, all 5 queries, extract_inheritance, 3+ tests

## Not in scope

Running the benchmark (separate task). README update (after scored runs complete).

Closes part of #680.
