### PR TITLE
docs(analyze_raw): align tool description with analyze_* style pattern

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1889,7 +1889,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_raw",
-        description = "No AST parsing performed; returns raw UTF-8 file content with line numbers. Output fields: path, total_lines, start_line, end_line, content. Accepts any file extension; errors on non-UTF-8 or binary files. Use analyze_file or analyze_module for AST-structured output; use analyze_raw when you need exact text content without semantic overhead. Passing a directory path returns an error. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs; Read the full content of a config file.",
+        description = "Raw UTF-8 file content with line numbers; no AST parsing. Accepts any file extension; errors on non-UTF-8 or binary files. Use analyze_file or analyze_module for AST-structured output. Passing a directory path returns an error. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs; Read a specific block from a config file.",
         output_schema = schema_for_type::<types::AnalyzeRawOutput>(),
         annotations(
             title = "Analyze Raw",


### PR DESCRIPTION
## Summary

Aligns the `analyze_raw` tool description with the noun-phrase, one-directional-steering pattern used by the four other `analyze_*` tools (`analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`).

## Changes

- `crates/aptu-coder/src/lib.rs` -- single string replacement in the `analyze_raw` `#[tool(...)]` annotation

**Before:**
> No AST parsing performed; returns raw UTF-8 file content with line numbers. Output fields: path, total_lines, start_line, end_line, content. Accepts any file extension; errors on non-UTF-8 or binary files. Use analyze_file or analyze_module for AST-structured output; use analyze_raw when you need exact text content without semantic overhead. Passing a directory path returns an error. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs; Read the full content of a config file.

**After:**
> Raw UTF-8 file content with line numbers; no AST parsing. Accepts any file extension; errors on non-UTF-8 or binary files. Use analyze_file or analyze_module for AST-structured output. Passing a directory path returns an error. Example queries: Read the first 50 lines of src/main.rs; Show lines 100-150 of src/lib.rs; Read a specific block from a config file.

**What changed and why:**

- Opener changed from passive-voice negation ("No AST parsing performed; returns...") to a noun phrase ("Raw UTF-8 file content with line numbers; no AST parsing"), matching the other four tools.
- Output fields list removed (`path, total_lines, start_line, end_line, content`). Per `docs/MCP-BEST-PRACTICES.md`, parameter-level detail belongs in parameter descriptions, not the tool description; inlining it consumes selection-time tokens without improving selection accuracy.
- Steering changed from bidirectional ("Use X for Y; use analyze_raw when Z") to one-directional ("Use analyze_file or analyze_module for AST-structured output."), matching the pattern used by `analyze_module` ("Use analyze_file when you need signatures, types, or class details.").
- "Read the full content of a config file" example replaced with "Read a specific block from a config file." The word "full" in an example is a behavioral signal; all other examples across the five tools use line ranges.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` pass
- [x] `cargo build` succeeds
- [x] `git diff --stat` confirms exactly one file changed, one line modified
