### PR TITLE
fix(parser): report attribute/decorator start line, not fn/def line

### DIFF
--- a/crates/aptu-coder-core/src/languages/python.rs
+++ b/crates/aptu-coder-core/src/languages/python.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 /// Tree-sitter query for extracting Python elements (functions and classes).
 pub const ELEMENT_QUERY: &str = r"
-(function_definition
-  name: (identifier) @func_name) @function
+[(decorated_definition
+   definition: (function_definition
+     name: (identifier) @func_name)) @function
+ (function_definition
+   name: (identifier) @func_name) @function]
 (class_definition
   name: (identifier) @class_name) @class
 ";

--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -609,23 +609,27 @@ impl SemanticExtractor {
                 }
 
                 if let Some(func_node) = func_node {
-                    // When a plain function_definition is nested inside a template_declaration,
-                    // it is also matched by the explicit template_declaration pattern. Skip it
-                    // here to avoid duplicates; the template_declaration match will emit it.
-                    let parent_is_template = func_node
-                        .parent()
-                        .map(|p| p.kind() == "template_declaration")
+                    // When a plain function_definition is nested inside a template_declaration
+                    // or decorated_definition, it is also matched by the explicit wrapper pattern.
+                    // Skip it here to avoid duplicates; the wrapper match will emit it.
+                    let parent_kind = func_node.parent().map(|p| p.kind());
+                    let parent_is_wrapper = parent_kind
+                        .map(|k| k == "template_declaration" || k == "decorated_definition")
                         .unwrap_or(false);
-                    if func_node.kind() == "function_definition" && parent_is_template {
-                        // Handled by the template_declaration @function match instead.
+                    if func_node.kind() == "function_definition" && parent_is_wrapper {
+                        // Handled by the template_declaration or decorated_definition @function match instead.
                     } else {
-                        // Resolve template_declaration to its inner function_definition for
-                        // declarator/field walks. The captured node may be the template wrapper.
+                        // Resolve template_declaration or decorated_definition to inner function_definition
+                        // for declarator/field walks. The captured node may be a wrapper.
                         let func_def = if func_node.kind() == "template_declaration" {
                             let mut cursor = func_node.walk();
                             func_node
                                 .children(&mut cursor)
                                 .find(|n| n.kind() == "function_definition")
+                                .unwrap_or(func_node)
+                        } else if func_node.kind() == "decorated_definition" {
+                            func_node
+                                .child_by_field_name("definition")
                                 .unwrap_or(func_node)
                         } else {
                             func_node
@@ -657,9 +661,30 @@ impl SemanticExtractor {
                                 .or_else(|| func_def.child_by_field_name("return_type"))
                                 .map(|r| source[r.start_byte()..r.end_byte()].to_string());
 
+                            // Walk backward through contiguous attribute_item siblings
+                            // to find the first attribute line (Rust only).
+                            let first_line = if func_node.kind() == "function_item" {
+                                let mut attrs: Vec<Node> = Vec::new();
+                                let mut sib = func_node.prev_named_sibling();
+                                while let Some(s) = sib {
+                                    if s.kind() == "attribute_item" {
+                                        attrs.push(s);
+                                        sib = s.prev_named_sibling();
+                                    } else {
+                                        break;
+                                    }
+                                }
+                                attrs
+                                    .last()
+                                    .map(|n| n.start_position().row + 1)
+                                    .unwrap_or_else(|| func_node.start_position().row + 1)
+                            } else {
+                                func_node.start_position().row + 1
+                            };
+
                             functions.push(FunctionInfo {
                                 name,
-                                line: func_node.start_position().row + 1,
+                                line: first_line,
                                 end_line: func_node.end_position().row + 1,
                                 parameters: if params.is_empty() {
                                     Vec::new()
@@ -890,7 +915,20 @@ impl SemanticExtractor {
                             method_params = source[node.start_byte()..node.end_byte()].to_string();
                         }
                         "method" => {
-                            method_line = node.start_position().row + 1;
+                            let mut method_attrs: Vec<Node> = Vec::new();
+                            let mut msib = node.prev_named_sibling();
+                            while let Some(s) = msib {
+                                if s.kind() == "attribute_item" {
+                                    method_attrs.push(s);
+                                    msib = s.prev_named_sibling();
+                                } else {
+                                    break;
+                                }
+                            }
+                            method_line = method_attrs
+                                .last()
+                                .map(|n| n.start_position().row + 1)
+                                .unwrap_or_else(|| node.start_position().row + 1);
                             method_end_line = node.end_position().row + 1;
                             method_return_type = node
                                 .child_by_field_name("return_type")

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -4502,3 +4502,147 @@ fn test_large_file_skipped_no_panic() {
         "large file exceeding MAX_FILE_SIZE_BYTES should be excluded from output"
     );
 }
+
+// Test additions for attribute/decorator line reporting
+
+#[cfg(feature = "lang-rust")]
+#[test]
+fn test_rust_function_attribute_line_reported() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "#[instrument]\nfn foo() {}";
+    let result =
+        SemanticExtractor::extract(source, "rust", None).expect("should extract Rust code");
+
+    assert!(
+        !result.functions.is_empty(),
+        "should extract at least one function"
+    );
+    assert_eq!(result.functions[0].name, "foo");
+    assert_eq!(
+        result.functions[0].line, 1,
+        "should report attribute line 1, not fn line 2"
+    );
+}
+
+#[cfg(feature = "lang-rust")]
+#[test]
+fn test_rust_function_no_attribute_unchanged() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "fn foo() {}";
+    let result =
+        SemanticExtractor::extract(source, "rust", None).expect("should extract Rust code");
+
+    assert!(!result.functions.is_empty());
+    assert_eq!(result.functions[0].name, "foo");
+    assert_eq!(
+        result.functions[0].line, 1,
+        "plain function should report its own line"
+    );
+}
+
+#[cfg(feature = "lang-rust")]
+#[test]
+fn test_rust_function_multiple_stacked_attributes() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "#[a]\n#[b]\nfn foo() {}";
+    let result =
+        SemanticExtractor::extract(source, "rust", None).expect("should extract Rust code");
+
+    assert!(!result.functions.is_empty());
+    assert_eq!(result.functions[0].name, "foo");
+    assert_eq!(
+        result.functions[0].line, 1,
+        "should report first attribute line 1, not fn line 3"
+    );
+}
+
+#[cfg(feature = "lang-rust")]
+#[test]
+fn test_rust_impl_method_attribute_line_reported() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "struct Foo;\nimpl Foo {\n  #[attr]\n  fn bar() {}\n}";
+    let result =
+        SemanticExtractor::extract(source, "rust", None).expect("should extract Rust code");
+
+    assert!(!result.classes.is_empty());
+    let class = &result.classes[0];
+    assert!(!class.methods.is_empty());
+    let method = &class.methods[0];
+    assert_eq!(method.name, "bar");
+    assert_eq!(
+        method.line, 3,
+        "method should report attribute line 3, not fn line 4"
+    );
+}
+
+#[cfg(feature = "lang-python")]
+#[test]
+fn test_python_decorated_function_reports_decorator_line() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "@decorator\ndef foo(): pass";
+    let result =
+        SemanticExtractor::extract(source, "python", None).expect("should extract Python code");
+
+    assert!(!result.functions.is_empty());
+    assert_eq!(result.functions[0].name, "foo");
+    assert_eq!(
+        result.functions[0].line, 1,
+        "should report decorator line 1, not def line 2"
+    );
+}
+
+#[cfg(feature = "lang-python")]
+#[test]
+fn test_python_plain_function_reports_def_line() {
+    use aptu_coder_core::parser::SemanticExtractor;
+
+    let source = "def foo(): pass";
+    let result =
+        SemanticExtractor::extract(source, "python", None).expect("should extract Python code");
+
+    assert!(!result.functions.is_empty());
+    assert_eq!(result.functions[0].name, "foo");
+    assert_eq!(
+        result.functions[0].line, 1,
+        "plain function should report its own line"
+    );
+}
+
+#[cfg(feature = "lang-rust")]
+#[test]
+fn test_regression_analyze_raw_attribute_line() {
+    use aptu_coder_core::parser::SemanticExtractor;
+    use std::fs;
+    use std::path::PathBuf;
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let workspace_root = PathBuf::from(&manifest_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .expect("should resolve workspace root");
+
+    let lib_path = workspace_root.join("crates/aptu-coder/src/lib.rs");
+    assert!(lib_path.exists(), "lib.rs should exist at {:?}", lib_path);
+
+    let source = fs::read_to_string(&lib_path).expect("should read lib.rs");
+
+    let result = SemanticExtractor::extract(&source, "rust", None)
+        .expect("should extract Rust code from lib.rs");
+
+    let analyze_raw = result
+        .functions
+        .iter()
+        .find(|f| f.name == "analyze_raw")
+        .expect("should find analyze_raw function");
+
+    assert_eq!(
+        analyze_raw.line, 1889,
+        "analyze_raw should report the first attribute line 1889, not the fn line 1902"
+    );
+}


### PR DESCRIPTION
Resolves #711.

## Summary

`analyze_module` and `analyze_file` reported the `fn`/`async fn` keyword line for Rust functions instead of the first line of the leading attribute block, and reported the `def` keyword line for Python decorated functions instead of the decorator line. This caused agents to spend extra `analyze_raw` round-trips to locate attributes they already knew by name -- in the session that prompted this issue, three `analyze_raw` calls were required to find a string 13 lines above the reported function line.

## Changes

**`crates/aptu-coder-core/src/languages/python.rs`** -- Updated `ELEMENT_QUERY` to use a tree-sitter alternation that captures `decorated_definition` wrapping `function_definition`. The parser now receives the outer `decorated_definition` node, whose `start_position` is the decorator line.

**`crates/aptu-coder-core/src/parser.rs` (`extract_elements`)** -- Extended the parent-is-wrapper skip guard to also exclude `function_definition` nodes whose parent is `decorated_definition`, preventing duplicate matches. Added a backward `prev_named_sibling()` walk for Rust `function_item` nodes that collects contiguous `attribute_item` siblings and reports the earliest one's start line. Functions without attributes are unaffected.

**`crates/aptu-coder-core/src/parser.rs` (`extract_impl_methods`)** -- Applied the same backward `attribute_item` sibling walk for impl method nodes, so methods inside `impl` blocks also report the attribute line rather than the `fn` line.

**`crates/aptu-coder-core/tests/integration_tests.rs`** -- Added seven tests covering all acceptance criteria: Rust single attribute, Rust plain function (unchanged), Rust multiple stacked attributes (outermost reported), Rust impl method with attribute, Python decorated function, Python plain function (unchanged), and a regression test asserting `analyze_raw` in `lib.rs` reports line 1889.

## Test plan

- [x] All tests pass (`cargo test`: 139 integration tests, all suites clean)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)
- [x] Security scan clean (no findings)
- [x] Regression: `analyze_raw` in `crates/aptu-coder/src/lib.rs` reports line 1889 (`#[instrument]`), not line 1902 (`async fn`)
