### PR TITLE
docs: add exec_command to all documentation, fix import_lookup comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Rust workspace with two crates:
 - `crates/aptu-coder-core` -- parsing, analysis, formatting, graph, pagination, types
 - `crates/aptu-coder` -- MCP server, tool handlers, logging, metrics
 
-Nine MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family).
+Ten MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family); `exec_command` (exec_* family).
 Rust edition 2024, async with tokio, MCP protocol via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -302,6 +302,25 @@ edit_insert path: src/lib.rs symbol_name: handle_request position: before conten
 edit_insert path: src/types.rs symbol_name: MyStruct position: after content: "\n#[derive(Debug)]\n"
 ```
 
+### `exec_command`
+
+> [!WARNING]
+> This tool executes arbitrary shell commands via `sh -c` (or `$SHELL` if set). The `working_dir` parameter restricts the initial process working directory only -- it does not prevent shell-level escape via `cd` or absolute paths within the command string. Set `open_world_hint=true` in your MCP client configuration to surface this warning.
+
+Run a shell command and return its combined stdout/stderr output. Intended for orchestrator BUILD agents that need to compile, test, or lint without a separate shell tool. Annotations: `destructive_hint=true`, `open_world_hint=true`.
+
+**Required:** `command` *(string)* -- shell command to execute via `sh -c` (or `$SHELL` if set)
+
+**Additional optional:**
+- `timeout_secs` *(integer, default 30)* -- seconds before SIGKILL is sent to the process
+- `working_dir` *(string, optional)* -- initial working directory for the process; path-validated and relative to the server's CWD. Does not restrict shell-level escapes.
+
+```bash
+exec_command command: "cargo test --workspace"
+exec_command command: "cargo clippy -- -D warnings" working_dir: "crates/aptu-coder"
+exec_command command: "cargo build --release" timeout_secs: 120
+```
+
 ## Output Management
 
 For large codebases, two mechanisms prevent context overflow:
@@ -347,7 +366,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 ## Observability
 
-All nine tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for the full schema.
+All ten tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for the full schema.
 
 ## Documentation
 

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -231,7 +231,7 @@ pub struct AnalyzeSymbolParams {
     #[serde(default)]
     pub impl_only: Option<bool>,
 
-    /// Scan directory for files that import the given module path instead of building a call graph. Mutually exclusive with non-empty symbol; returns INVALID_PARAMS if symbol is non-empty.
+    /// When true, find all files in the directory that import the module named by symbol. symbol must be non-empty (it holds the module path to search for). Mutually exclusive with normal call-graph lookup.
     #[serde(default)]
     #[cfg_attr(
         feature = "schemars",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 
 - **Minimize token usage**: Return only structured, relevant context - no prose, no noise
 - **Language-agnostic parsing via tree-sitter**: Support 11 languages (Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C, C++, C#) with a unified query-based extraction system; TypeScript and TSX use distinct grammars (`LANGUAGE_TYPESCRIPT` and `LANGUAGE_TSX`) but share the same queries in `crates/aptu-coder-core/src/languages/typescript.rs`
-- **Nine focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
+- **Ten focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analyze_* family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (edit_* family); `exec_command` (exec_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
 - **Compatible with any MCP orchestrator**: Designed to work with any standards-compliant MCP host
 - **Performance via parallelism**: Use rayon for parallel file processing and ignore crate for efficient .gitignore-aware directory walking
 
@@ -21,14 +21,14 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | Module | File | Responsibility |
 |--------|------|-----------------|
 | `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
-| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` |
+| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`, `exec_command` |
 | `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
 | `schema_helpers` | `crates/aptu-coder-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
 | `metrics` | `crates/aptu-coder/src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
-| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all nine tools |
+| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all ten tools |
 | `traversal` | `crates/aptu-coder-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
 | `types` | `crates/aptu-coder-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
@@ -53,6 +53,7 @@ graph TD
     A --> B7["edit_replace"]
     A --> B8["edit_rename"]
     A --> B9["edit_insert"]
+    A --> B10["exec_command"]
     B1 --> M["walk_directory"]
     M --> N["Parallel Parse rayon"]
     N --> O["ElementExtractor"]
@@ -71,6 +72,7 @@ graph TD
     B7 --> F3["edit_replace_block"]
     B8 --> F4["edit_rename_in_file"]
     B9 --> F5["edit_insert_at_symbol"]
+    B10 --> F6["exec_sh_command"]
     P --> Q["MCP Response"]
     L --> Q
     T --> Q
@@ -80,6 +82,7 @@ graph TD
     F3 --> Q
     F4 --> Q
     F5 --> Q
+    F6 --> Q
 ```
 
 ## Analysis Modes

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -17,11 +17,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the module map, [MCP-BEST-PRACTICES.m
 
 ## 2. Tool Architecture Decisions
 
-### Why Nine Tools Instead of One
+### Why Ten Tools Instead of One
 
 **Principle:** Each tool does one thing well. Non-overlapping interfaces eliminate ambiguous routing. When two tools can satisfy the same request, the model must guess; that is a reliability failure, not a model failure. (See [MCP-BEST-PRACTICES.md](MCP-BEST-PRACTICES.md), section 3.2.)
 
-*Example: This server has nine tools — `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analysis family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (editing family) — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
+*Example: This server has ten tools — `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw` (analysis family); `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` (editing family); `exec_command` (exec family) — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
 
 ```mermaid
 graph TD
@@ -49,12 +49,13 @@ graph TD
 | `edit_replace` | Replace exact text block in a file | AST awareness, directory-wide changes |
 | `edit_rename` | AST-aware rename within a single file | Directory-wide rename, type-aware refactoring |
 | `edit_insert` | Insert content before/after a named identifier | Directory-wide insertion, AST-unaware insertion |
+| `exec_command` | Execute arbitrary shell commands | Output parsing, scripting language support, interactive sessions |
 
-*Table 1: The nine tools, their purpose, and what each intentionally excludes.*
+*Table 1: The ten tools, their purpose, and what each intentionally excludes.*
 
 ### Single Responsibility Trade-off
 
-Splitting into nine tools adds surface area (nine tool descriptions to maintain, nine output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
+Splitting into ten tools adds surface area (ten tool descriptions to maintain, ten output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
 
 ## 3. Designing for Small Models
 
@@ -204,6 +205,7 @@ The annotation posture for this server is stable and locked until new MCP SEPs l
 |---|---|---|---|---|---|
 | `analyze_*` | `true` | `false` | `true` | `false` | Read-only, deterministic, bounded by input path |
 | `edit_*` | `false` | `true` | `false` | `false` | Write-capable, non-idempotent, bounded by input path |
+| `exec_*` | `false` | `true` | `false` | `true` | Executes arbitrary shell commands; open_world_hint surfaces the safety warning to MCP clients |
 
 *Table 4: Tool annotation posture by family. See [ROADMAP.md](ROADMAP.md) for the rationale and SEP tracking references.*
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,7 +17,7 @@ Each line in the JSONL file is one JSON object:
 | Field | Type | Description |
 |---|---|---|
 | `ts` | `u64` | Unix timestamp in milliseconds at handler return |
-| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert` |
+| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `analyze_raw`, `edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`, `exec_command` |
 | `duration_ms` | `u64` | Wall-clock time from handler entry to return |
 | `output_chars` | `usize` | Byte length (`str::len()`) of the final text returned; `0` on error paths |
 | `param_path_depth` | `usize` | `Path::components().count()` on `params.path` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ Current settings are stable and reflect ground truth:
 | `idempotentHint` | `true` | Same input produces same output (verified by #347) |
 | `openWorldHint` | `false` | Results are bounded by the input path |
 
-**Exception:** The four `edit_*` tools (Wave 9) deviate from the default posture. They carry `readOnlyHint=false`, `destructiveHint=true`, and `idempotentHint=false` to accurately reflect their write-capable, non-idempotent nature.
+**Exception:** The four `edit_*` tools (Wave 9) and the `exec_command` tool deviate from the default posture. Write tools (`edit_overwrite`, `edit_replace`, `edit_rename`, and `edit_insert`) carry `readOnlyHint=false`, `destructiveHint=true`, and `idempotentHint=false` to accurately reflect their write-capable, non-idempotent nature. The `exec_command` tool additionally sets `openWorldHint=true` to surface the shell-execution safety warning to MCP clients.
 
 No annotation changes until new MCP SEPs land (tracked in #1913, #1984, #1561, #1560, #1487). Validated against external MCP Blog 2 reference (2026-03-16).
 


### PR DESCRIPTION
## Summary

`exec_command` (tool #10) was added in commit `d825cd0` after the v0.8.0 documentation freeze and was entirely absent from all user-facing documentation. This PR brings all documentation up to date and also fixes an inverted doc comment on the `import_lookup` field in `types.rs` that contradicted both the actual runtime behavior and the existing schemars description.

## Changes

- **README.md** -- Added `exec_command` section with a prominent safety warning, parameter table (`command`, `timeout_secs`, `working_dir`), and example queries matching the existing tool section format.
- **AGENTS.md** -- Updated "Nine MCP tools" to "Ten MCP tools"; added `exec_command` and the `exec_*` family to the project structure description.
- **docs/ARCHITECTURE.md** -- Changed "Nine focused MCP tools" to "Ten focused MCP tools"; added `exec_command` to the `lib` module map row; added `B10` node to the mermaid data flow diagram; fixed the `formatter` module description ("all nine" -> "all ten").
- **docs/DESIGN-GUIDE.md** -- Updated "nine tools" narrative and Table 1 caption to "ten tools"; added `exec_command` row to Table 1; added `exec_*` row to the annotation posture table with correct hints (`readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=true`).
- **docs/OBSERVABILITY.md** -- Added `exec_command` to the tool enum list in the metrics schema table.
- **docs/ROADMAP.md** -- Updated the annotation posture exception note to cover `exec_*` alongside `edit_*`.
- **crates/aptu-coder-core/src/types.rs** -- Fixed inverted `import_lookup` doc comment. The old text said "INVALID_PARAMS if symbol is non-empty" which is the opposite of actual behavior; the correct constraint is that symbol must be non-empty (INVALID_PARAMS when symbol is empty).

## Test plan

- [x] `cargo fmt --check` passes clean
- [x] `cargo clippy -- -D warnings` passes clean
- [x] No "nine tools" references remain in any changed file
- [x] `exec_command` present in all six documentation files
- [x] Security scan: no findings
- [x] GPG signed, DCO signed
