### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version from 0.8.0 to 0.8.1 in preparation for the patch release.

All checks pass: `cargo build`, `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo deny check advisories licenses`.
