### PR TITLE
fix(release): bump mcp-publisher to v1.7.8 to fix OIDC audience mismatch

### DIFF
--- a/.github/workflows/publish-registry-manual.yml
+++ b/.github/workflows/publish-registry-manual.yml
@@ -2,6 +2,12 @@ name: Publish to MCP Registry (manual)
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (login only, skip publish)'
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -88,9 +94,9 @@ jobs:
       - name: Install mcp-publisher
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz" \
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.8/mcp-publisher_linux_amd64.tar.gz" \
             -o /tmp/mcp-publisher.tar.gz
-          echo "79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5  /tmp/mcp-publisher.tar.gz" | sha256sum --check
+          echo "48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c  /tmp/mcp-publisher.tar.gz" | sha256sum --check
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
           test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }
           sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher
@@ -103,4 +109,5 @@ jobs:
         run: mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
+        if: ${{ !inputs.dry_run }}
         run: mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,9 +394,9 @@ jobs:
       - name: Install mcp-publisher
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz" \
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.8/mcp-publisher_linux_amd64.tar.gz" \
             -o /tmp/mcp-publisher.tar.gz
-          echo "79bbb73ba048c5906034f73ef6286d7763bd53cf368ea0b358fc593ed360cbd5  /tmp/mcp-publisher.tar.gz" | sha256sum --check
+          echo "48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c  /tmp/mcp-publisher.tar.gz" | sha256sum --check
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
           test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }
           sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher


### PR DESCRIPTION
## Summary

Bumps `mcp-publisher` from v1.5.0 to v1.7.8 in both `release.yml` and `publish-registry-manual.yml`.

The MCP registry server now requires OIDC tokens with audience `https://registry.modelcontextprotocol.io`. The pinned binary (v1.5.0) hardcodes the old audience (`mcp-registry`), causing the `publish-registry` job to fail at login with:

```
failed to validate OIDC token: invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]
```

This has broken every release since v0.7.0 (April 21). The SHA256 for the new binary was verified by local download.

Also adds a `dry_run` input to `publish-registry-manual.yml` (default: `true`) so the OIDC login step can be tested without a live publish.

## Changes

- `.github/workflows/release.yml`: bump `mcp-publisher` URL and SHA256
- `.github/workflows/publish-registry-manual.yml`: same bump; add `dry_run` input; gate `mcp-publisher publish` behind `!dry_run`

## Test plan

- [ ] Merge PR
- [ ] Run **Publish to MCP Registry (manual)** with `dry_run: true` -- `Login via GitHub OIDC` step must pass
- [ ] Re-run with `dry_run: false` to publish v0.8.1 to the registry
