### PR TITLE
fix(release): use gh to download mcp-publisher instead of curl

### DIFF
--- a/.github/workflows/publish-registry-manual.yml
+++ b/.github/workflows/publish-registry-manual.yml
@@ -92,10 +92,14 @@ jobs:
             server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.8/mcp-publisher_linux_amd64.tar.gz" \
-            -o /tmp/mcp-publisher.tar.gz
+          gh release download v1.7.8 \
+            --repo modelcontextprotocol/registry \
+            --pattern "mcp-publisher_linux_amd64.tar.gz" \
+            --output /tmp/mcp-publisher.tar.gz
           echo "48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c  /tmp/mcp-publisher.tar.gz" | sha256sum --check
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
           test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,10 +392,14 @@ jobs:
             server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.8/mcp-publisher_linux_amd64.tar.gz" \
-            -o /tmp/mcp-publisher.tar.gz
+          gh release download v1.7.8 \
+            --repo modelcontextprotocol/registry \
+            --pattern "mcp-publisher_linux_amd64.tar.gz" \
+            --output /tmp/mcp-publisher.tar.gz
           echo "48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c  /tmp/mcp-publisher.tar.gz" | sha256sum --check
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
           test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }


### PR DESCRIPTION
## Summary

Replaces `curl` with `gh release download` when fetching the `mcp-publisher` binary in both `release.yml` and `publish-registry-manual.yml`.

## Changes

- `.github/workflows/release.yml` -- `Install mcp-publisher` step
- `.github/workflows/publish-registry-manual.yml` -- `Install mcp-publisher` step

## Rationale

`curl` with a hardcoded URL is inconsistent with every other GitHub asset fetch in these workflows, which use `gh` throughout. `gh release download` uses the already-authenticated `GITHUB_TOKEN`, avoids anonymous API rate limits, and eliminates the manually constructed URL (one less thing to keep in sync with the version pin).

The SHA256 integrity check is unchanged.

## Test plan

- [ ] CI passes (workflow file linting via actionlint)
- [ ] Verified locally: `gh release download v1.7.8 --repo modelcontextprotocol/registry --pattern "mcp-publisher_linux_amd64.tar.gz"` resolves correctly with a valid token
