### PR TITLE
docs(analyze_symbol): rewrite tool description and param docs per MCP best practices

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -231,12 +231,12 @@ pub struct AnalyzeSymbolParams {
     #[serde(default)]
     pub impl_only: Option<bool>,
 
-    /// When true, find all files in the directory that import the module named by symbol. symbol must be non-empty (it holds the module path to search for). Mutually exclusive with normal call-graph lookup.
+    /// Find all files in the directory that import the module path given in symbol (e.g., std::collections). Requires symbol to be non-empty. Mutually exclusive with def_use and normal call-graph lookup. When set, follow_depth, impl_only, and match_mode are ignored.
     #[serde(default)]
     #[cfg_attr(
         feature = "schemars",
         schemars(
-            description = "When true, find all files in the directory that import the module named by symbol. symbol must be non-empty (it holds the module path to search for). Mutually exclusive with normal symbol lookup."
+            description = "Find all files in the directory that import the module path given in symbol (e.g., std::collections). Requires symbol to be non-empty. Mutually exclusive with def_use and normal call-graph lookup. When set, follow_depth, impl_only, and match_mode are ignored."
         )
     )]
     pub import_lookup: Option<bool>,
@@ -251,7 +251,7 @@ pub struct AnalyzeSymbolParams {
     )]
     pub git_ref: Option<String>,
 
-    /// Extract definition and use sites (write/read locations) for the symbol. When true, def_use_sites will be populated in the response. Default: false.
+    /// Extract write/read sites for the symbol. First call returns empty def_use_sites and a cursor; paginate with that cursor to retrieve results. Mutually exclusive with import_lookup. Default: false.
     #[serde(default)]
     pub def_use: Option<bool>,
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1248,7 +1248,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         name = "analyze_symbol",
-        description = "Call graph for a named function/method across all files in a directory to trace usage. Returns direct callers and callees. Unknown symbols return error; symbols with no callers/callees return empty chains. Use import_lookup=true with symbol set to the module path to find all files that import a given module path instead of tracing a call graph. When def_use is true, returns write and read sites for the symbol in def_use_sites; write sites include assignments and initializations, read sites include all references, augmented assignments appear as kind write_read. Passing a file path returns INVALID_PARAMS. summary=true and cursor are mutually exclusive. Example queries: Find all callers of the parse_config function; Trace the call chain for MyClass.process_request up to 2 levels deep; Show only trait impl callers of the write method; Find all files that import std::collections",
+        description = "Call graph for a named symbol across all files in a directory. Returns callers and callees. Modes: call graph (default), import_lookup (files importing a module path), def_use (write/read sites). Passing a file path returns INVALID_PARAMS. Example queries: Find all callers of parse_config; Trace MyClass.process_request up to 2 levels deep; Show only trait impl callers of the write method; Find all files that import std::collections",
         output_schema = schema_for_type::<analyze::FocusedAnalysisOutput>(),
         annotations(
             title = "Analyze Symbol",


### PR DESCRIPTION
## Summary

Rewrites the `analyze_symbol` tool description and two parameter doc-comments following the MCP-BEST-PRACTICES Description Scope principle (section 4.1.1): tool description carries selection signal only; parameter descriptions carry constraint and usage detail.

The previous description inlined mode constraints, ignored-parameter lists, and pagination behavior into the tool description -- detail the model only needs after tool selection, not during it. This burned tokens on every tool-listing call without improving routing accuracy.

## Changes

- `crates/aptu-coder/src/lib.rs`: tool description trimmed to what/when/examples (~64 tokens, down from ~140). Modes listed as named options; constraints removed.
- `crates/aptu-coder-core/src/types.rs`: `import_lookup` -- both `///` doc-comment and `schemars(description=...)` override updated with full constraint detail (mutual exclusivity, ignored params). `def_use` -- doc-comment updated with pagination cursor behavior.

Caveman compression applied throughout to match sibling tool style (`analyze_file`, `analyze_module`).

## Test plan

- [x] Tests pass (394 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Security scan clean (gitleaks: no leaks found)
- [x] No logic, behavior, or schema changes -- string literals only

Closes #720
