### PR TITLE
feat(tools): resource controls for exec_command and Tool.title on all tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ version = "0.8.1"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
+ "nix",
  "rmcp",
  "serde",
  "serde_json",
@@ -171,6 +172,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -701,6 +708,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -932,8 +932,7 @@ impl ExecCommandParams {
             command,
             timeout_secs,
             working_dir,
-            memory_limit_mb: None,
-            cpu_limit_secs: None,
+            ..Default::default()
         }
     }
 }

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -917,6 +917,12 @@ pub struct ExecCommandParams {
     pub timeout_secs: Option<u64>,
     /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
     pub working_dir: Option<String>,
+    /// Cap on virtual address space in megabytes (Linux only; silently accepted but not enforced on macOS).
+    /// None = no limit (default).
+    pub memory_limit_mb: Option<u64>,
+    /// CPU time limit in seconds. Complements timeout_secs (wall-clock). SIGXCPU on soft-limit breach, SIGKILL on hard-limit breach.
+    /// None = no limit (default).
+    pub cpu_limit_secs: Option<u64>,
 }
 
 impl ExecCommandParams {
@@ -926,6 +932,8 @@ impl ExecCommandParams {
             command,
             timeout_secs,
             working_dir,
+            memory_limit_mb: None,
+            cpu_limit_secs: None,
         }
     }
 }
@@ -937,6 +945,8 @@ impl Default for ExecCommandParams {
             command: String::new(),
             timeout_secs: None,
             working_dir: None,
+            memory_limit_mb: None,
+            cpu_limit_secs: None,
         }
     }
 }

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -4642,7 +4642,7 @@ fn test_regression_analyze_raw_attribute_line() {
         .expect("should find analyze_raw function");
 
     assert_eq!(
-        analyze_raw.line, 1889,
-        "analyze_raw should report the first attribute line 1889, not the fn line 1902"
+        analyze_raw.line, 1896,
+        "analyze_raw should report the first attribute line 1896, not the fn line 1910"
     );
 }

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+nix = { version = "0.31", features = ["resource"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3080,6 +3080,10 @@ impl CodeAnalyzer {
         {
             let memory_limit_mb = params.memory_limit_mb;
             let cpu_limit_secs = params.cpu_limit_secs;
+            #[cfg(not(target_os = "linux"))]
+            if memory_limit_mb.is_some() {
+                warn!("memory_limit_mb is not enforced on this platform (Linux only)");
+            }
             if memory_limit_mb.is_some() || cpu_limit_secs.is_some() {
                 // SAFETY: pre_exec runs in the forked child process before exec.
                 // nix::sys::resource::setrlimit is a safe Rust API.

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3010,7 +3010,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; use timeout_secs to limit execution time (wall-clock). memory_limit_mb caps virtual address space (Linux only; silently accepted on macOS). cpu_limit_secs limits CPU time (SIGXCPU on soft-limit, SIGKILL on hard-limit). working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; use timeout_secs to limit execution time. working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<types::ShellOutput>(),
         annotations(
             title = "Exec Command",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -69,6 +69,9 @@ use tokio::sync::{Mutex as TokioMutex, mpsc};
 use tracing::{instrument, warn};
 use tracing_subscriber::filter::LevelFilter;
 
+#[cfg(unix)]
+use nix::sys::resource::{Resource, setrlimit};
+
 static GLOBAL_SESSION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 const SIZE_LIMIT: usize = 50_000;
@@ -873,6 +876,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         name = "analyze_directory",
+        title = "Analyze Directory",
         description = "Tree-view of directory with LOC, function/class counts, test markers. Respects .gitignore. Returns per-file stats plus next_cursor for pagination. Fails if summary=true and cursor. For 1000+ files, use max_depth=2-3 and summary=true. git_ref restricts to files changed since a branch/tag/commit. Empty directories return zero counts. Example queries: Analyze the src/ directory to understand module structure; What files are in the tests/ directory and how large are they?",
         output_schema = schema_for_type::<analyze::AnalysisOutput>(),
         annotations(
@@ -1033,6 +1037,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_file",
+        title = "Analyze File",
         description = "Functions, types, classes, and imports from a single source file. Returns functions (name, signature, line range), classes (methods, fields, inheritance), imports; paginate with cursor/page_size. Use fields=[\"functions\",\"classes\",\"imports\"] to limit output sections. Fails if directory path supplied; use analyze_directory instead. Fails if summary=true and cursor. git_ref not supported for single-file analysis. Use analyze_module for lightweight function/import index (~75% smaller). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
         output_schema = schema_for_type::<analyze::FileAnalysisOutput>(),
         annotations(
@@ -1248,6 +1253,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context))]
     #[tool(
         name = "analyze_symbol",
+        title = "Analyze Symbol",
         description = "Call graph for a named symbol across all files in a directory. Returns callers and callees. Modes: call graph (default), import_lookup (files importing a module path), def_use (write/read sites). Fails if file path supplied; fails if impl_only=true on non-Rust directory; fails if import_lookup=true with empty symbol; fails if summary=true and cursor. match_mode controls name matching (exact/insensitive/prefix/contains). git_ref restricts to changed files. Example queries: Find all callers of parse_config; Find all files that import std::collections.",
         output_schema = schema_for_type::<analyze::FocusedAnalysisOutput>(),
         annotations(
@@ -1651,6 +1657,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_module",
+        title = "Analyze Module",
         description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: What functions are defined in src/analyze.rs?",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
@@ -1889,6 +1896,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "analyze_raw",
+        title = "Analyze Raw",
         description = "Raw UTF-8 file content with line numbers; no AST parsing. Returns path, total_lines, start_line, end_line, content. Use start_line/end_line (1-indexed, inclusive) to read a range; defaults to full file. Fails if directory path supplied; fails on binary or non-UTF-8 files. Use analyze_file or analyze_module for AST-structured output. Example queries: Show lines 100-150 of src/lib.rs.",
         output_schema = schema_for_type::<types::AnalyzeRawOutput>(),
         annotations(
@@ -2092,6 +2100,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "edit_overwrite",
+        title = "Edit Overwrite",
         description = "Creates or overwrites a file with UTF-8 content; creates parent directories if needed. Returns path, bytes_written. Fails if directory path supplied. AST-unaware (no language constraint). Use edit_replace for targeted single-block edits; edit_rename/edit_insert for AST-targeted changes. Example queries: Overwrite src/config.rs with updated content.",
         output_schema = schema_for_type::<EditOverwriteOutput>(),
         annotations(
@@ -2270,6 +2279,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "edit_replace",
+        title = "Edit Replace",
         description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). Whitespace-sensitive exact match. Use edit_overwrite to replace the whole file; edit_rename/edit_insert for AST-targeted changes. Example queries: Update the function signature in lib.rs.",
         output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
@@ -2504,6 +2514,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "edit_rename",
+        title = "Edit Rename",
         description = "AST-aware rename within a single file. Matches syntactic identifiers only; occurrences in string literals and comments are excluded. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found; fails if kind parameter supplied (reserved, not yet supported). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
         output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
@@ -2789,6 +2800,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, _context))]
     #[tool(
         name = "edit_insert",
+        title = "Edit Insert",
         description = "Insert content immediately before or after a named identifier in a source file. Returns path, symbol_name, position, byte_offset. position is \"before\" or \"after\"; symbol_name must be an identifier (not a keyword or punctuation). Inserts content verbatim at that token's byte boundary; include leading/trailing newlines as needed. Uses first occurrence if symbol_name appears multiple times. Fails if symbol not found; fails if directory path supplied. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Insert a #[instrument] attribute before the handle_request function.",
         output_schema = schema_for_type::<EditInsertOutput>(),
         annotations(
@@ -2997,7 +3009,8 @@ impl CodeAnalyzer {
 
     #[tool(
         name = "exec_command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; use timeout_secs to limit execution time. working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Example queries: Run the test suite and capture output.",
+        title = "Exec Command",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; use timeout_secs to limit execution time (wall-clock). memory_limit_mb caps virtual address space (Linux only; silently accepted on macOS). cpu_limit_secs limits CPU time (SIGXCPU on soft-limit, SIGKILL on hard-limit). working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<types::ShellOutput>(),
         annotations(
             title = "Exec Command",
@@ -3062,6 +3075,32 @@ impl CodeAnalyzer {
 
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
+
+        #[cfg(unix)]
+        {
+            let memory_limit_mb = params.memory_limit_mb;
+            let cpu_limit_secs = params.cpu_limit_secs;
+            if memory_limit_mb.is_some() || cpu_limit_secs.is_some() {
+                // SAFETY: pre_exec runs in the forked child process before exec.
+                // nix::sys::resource::setrlimit is a safe Rust API.
+                // The unsafe block is required by tokio::process::Command::pre_exec API contract.
+                unsafe {
+                    cmd.pre_exec(move || {
+                        #[cfg(target_os = "linux")]
+                        if let Some(mb) = memory_limit_mb {
+                            let bytes = mb.saturating_mul(1024 * 1024);
+                            setrlimit(Resource::RLIMIT_AS, bytes, bytes)
+                                .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                        }
+                        if let Some(cpu) = cpu_limit_secs {
+                            setrlimit(Resource::RLIMIT_CPU, cpu, cpu)
+                                .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                        }
+                        Ok(())
+                    });
+                }
+            }
+        }
 
         let mut child = match cmd.spawn() {
             Ok(c) => c,

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -475,14 +475,15 @@ async fn test_handler_cpu_limit_kills_spin() {
     }))
     .await;
 
-    // Act & Assert: process should be killed (non-zero exit or error)
+    // Act & Assert: process should be killed by SIGXCPU/SIGKILL.
+    // When killed by a signal, the OS does not produce a numeric exit code, so
+    // exit_code is null in the response. Accept either null (signal kill) or a
+    // non-zero integer (some kernels synthesise 128+signum).
     let sc = &resp["result"]["structuredContent"];
     let exit_code = sc["exit_code"].as_i64();
-    // SIGXCPU (signal 24) or SIGKILL (signal 9) should result in non-zero exit
-    // On some systems, the exit code may be 137 (128 + 9 for SIGKILL) or similar
     assert!(
-        exit_code.is_some() && exit_code != Some(0),
-        "exit code should be non-zero (killed by signal): {sc}"
+        exit_code.is_none() || exit_code != Some(0),
+        "exit code should be null (signal kill) or non-zero: {sc}"
     );
 }
 

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -440,3 +440,66 @@ async fn test_handler_stderr_populated() {
         "stderr missing 'err': {sc}"
     );
 }
+
+#[tokio::test]
+async fn test_handler_resource_limits_none_unchanged() {
+    // Arrange: memory_limit_mb=None and cpu_limit_secs=None -> same behavior as before
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo test",
+        "memory_limit_mb": null,
+        "cpu_limit_secs": null
+    }))
+    .await;
+
+    // Act & Assert: command should complete successfully
+    let sc = &resp["result"]["structuredContent"];
+    assert_eq!(sc["exit_code"], 0, "exit code should be 0: {sc}");
+    assert!(
+        sc["stdout"].as_str().unwrap_or("").contains("test"),
+        "stdout should contain 'test': {sc}"
+    );
+    assert!(
+        !sc["timed_out"].as_bool().unwrap_or(true),
+        "should not timeout: {sc}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn test_handler_cpu_limit_kills_spin() {
+    // Arrange: cpu_limit_secs=1, command spins CPU
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "sh -c 'while true; do :; done'",
+        "cpu_limit_secs": 1,
+        "timeout_secs": 10
+    }))
+    .await;
+
+    // Act & Assert: process should be killed (non-zero exit or error)
+    let sc = &resp["result"]["structuredContent"];
+    let exit_code = sc["exit_code"].as_i64();
+    // SIGXCPU (signal 24) or SIGKILL (signal 9) should result in non-zero exit
+    // On some systems, the exit code may be 137 (128 + 9 for SIGKILL) or similar
+    assert!(
+        exit_code.is_some() && exit_code != Some(0),
+        "exit code should be non-zero (killed by signal): {sc}"
+    );
+}
+
+#[tokio::test]
+async fn test_handler_memory_limit_accepted() {
+    // Arrange: memory_limit_mb=Some(512), simple echo command
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo hello",
+        "memory_limit_mb": 512
+    }))
+    .await;
+
+    // Act & Assert: command should complete normally (limit not triggered)
+    let sc = &resp["result"]["structuredContent"];
+    assert_eq!(sc["exit_code"], 0, "exit code should be 0: {sc}");
+    assert!(
+        sc["stdout"].as_str().unwrap_or("").contains("hello"),
+        "stdout should contain 'hello': {sc}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes two independent issues implemented via parallel BUILD shards.

**Issue #707** adds `memory_limit_mb` and `cpu_limit_secs` resource-control parameters to `exec_command`. Both are `Option<u64>` defaulting to `None`, preserving full backward compatibility. When set, `setrlimit` is applied in the forked child process via `nix::sys::resource::setrlimit` called inside `cmd.pre_exec()`. `RLIMIT_AS` (virtual memory cap) is Linux-only -- macOS XNU silently accepts `setrlimit(RLIMIT_AS)` but does not enforce it; a `warn!` is emitted on non-Linux when the parameter is supplied. `RLIMIT_CPU` (CPU-time seconds) is enforced on all Unix platforms and complements the existing wall-clock `timeout_secs`.

**Issue #724** adds the top-level `Tool.title` field (MCP 2025-11-25) to all 10 tool annotations in `lib.rs`. `Tool.title` and `ToolAnnotations.title` are distinct fields in the spec; the annotations title was already set on every tool, but the top-level field was missing. Both are now populated.

## New dependency: `nix 0.31`

`nix` is added with `features = ["resource"]` only, pulling in solely `nix::sys::resource` (setrlimit/getrlimit). The `nix` crate is MIT-licensed and permitted by `deny.toml`. `cargo deny check` is clean.

## `unsafe` usage

The `unsafe` block wrapping `cmd.pre_exec(...)` is required by the `tokio::process::Command::pre_exec` API contract -- the closure runs in the forked child process before `exec`, which is an inherently unsafe context per the OS process model. `nix::sys::resource::setrlimit` is itself a safe Rust function; the `unsafe` is attributable solely to the post-fork execution environment. A `SAFETY` comment documents this at the call site.

## Changes

- `crates/aptu-coder-core/src/types.rs`: add `memory_limit_mb: Option<u64>` and `cpu_limit_secs: Option<u64>` to `ExecCommandParams`; `new()` uses `..Default::default()` for the new fields
- `crates/aptu-coder/Cargo.toml`: add `nix = { version = "0.31", features = ["resource"] }`
- `crates/aptu-coder/src/lib.rs`: exec handler pre_exec block + `#[cfg(not(target_os = "linux"))] warn!(...)` for memory_limit_mb; `title = "..."` top-level on all 10 `#[tool(...)]` annotations; tool description for `exec_command` unchanged
- `crates/aptu-coder/tests/exec_command.rs`: 3 new tests for resource limit behaviors; CPU-limit test accepts `null` exit_code (signal-killed process has no numeric exit code)
- `crates/aptu-coder-core/tests/integration_tests.rs`: update `test_regression_analyze_raw_attribute_line` expected line number (1889 → 1896) after the 5 `title=` insertions preceding `analyze_raw` shifted its position

## Test plan

- [x] `test_handler_resource_limits_none_unchanged` -- None limits produce identical behavior to baseline (backward compat)
- [x] `test_handler_memory_limit_accepted` -- `memory_limit_mb=Some(512)` accepted without error; simple command completes normally
- [x] `test_handler_cpu_limit_kills_spin` -- `cpu_limit_secs=Some(1)` kills a CPU-spinning process; accepts null or non-zero exit code (Linux only, `#[cfg(target_os = "linux")]`)
- [x] All pre-existing exec_command tests continue to pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check advisories licenses` clean
