### PR TITLE
fix(tools): atomic writes for edit_overwrite and edit_replace

### DIFF
--- a/crates/aptu-coder-core/Cargo.toml
+++ b/crates/aptu-coder-core/Cargo.toml
@@ -45,6 +45,7 @@ base64 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio-util = { workspace = true }
+tempfile = { workspace = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-cpp = { workspace = true, optional = true }

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -6,6 +6,7 @@ use crate::types::{
     EditInsertOutput, EditOverwriteOutput, EditRenameOutput, EditReplaceOutput, InsertPosition,
 };
 use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -46,6 +47,20 @@ pub enum EditError {
 
 const IDENTIFIER_QUERY: &str = "(identifier) @name";
 
+fn write_file_atomic(path: &Path, content: &str) -> Result<(), EditError> {
+    let parent = path.parent().ok_or_else(|| {
+        EditError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path has no parent directory",
+        ))
+    })?;
+    let mut temp_file = NamedTempFile::new_in(parent)?;
+    use std::io::Write;
+    temp_file.write_all(content.as_bytes())?;
+    temp_file.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
 pub fn edit_overwrite_content(
     path: &Path,
     content: &str,
@@ -58,7 +73,7 @@ pub fn edit_overwrite_content(
     {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, content)?;
+    write_file_atomic(path, content)?;
     Ok(EditOverwriteOutput {
         path: path.display().to_string(),
         bytes_written: content.len(),
@@ -92,7 +107,7 @@ pub fn edit_replace_block(
     let bytes_before = content.len();
     let updated = content.replacen(old_text, new_text, 1);
     let bytes_after = updated.len();
-    std::fs::write(path, &updated)?;
+    write_file_atomic(path, &updated)?;
     Ok(EditReplaceOutput {
         path: path.display().to_string(),
         bytes_before,


### PR DESCRIPTION
## Summary

Switch `edit_overwrite` and `edit_replace` from direct `fs::write` to an atomic temp-file-plus-rename pattern. A partial write followed by a crash or signal no longer leaves the target file in a corrupt intermediate state.

## Changes

- `crates/aptu-coder-core/src/edit.rs`: add private `write_file_atomic(path, content)` helper; replace `fs::write` in `edit_overwrite_content` and `edit_replace_block`
- `crates/aptu-coder-core/Cargo.toml`: add `tempfile` to crate dependencies (already a workspace dependency)

## Implementation notes

`NamedTempFile::new_in(path.parent())` guarantees the temp file is on the same filesystem as the target, so the final `persist()` rename is always atomic. Cross-device errors and other `persist()` failures map through `EditError::Io` via `#[from]` and surface as `internal_error` to the caller. No new error variants, no public API changes.

Scope is `edit_overwrite` and `edit_replace` only per the issue. `edit_rename` and `edit_insert` are unchanged.

## Test plan

- [x] All existing tests pass (`cargo test -p aptu-coder-core`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Security scan clean
