### PR TITLE
docs(tools): sharpen edit_rename description

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2544,7 +2544,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_rename",
         title = "Edit Rename",
-        description = "Use this instead of edit_replace when renaming a symbol. edit_replace is a text search-and-replace that will incorrectly modify occurrences inside string literals and comments. edit_rename is AST-aware and renames syntactic identifiers only, making it safe for symbol renames. AST-aware rename within a single file. Matches syntactic identifiers only; occurrences in string literals and comments are excluded. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
+        description = "Use this instead of edit_replace when renaming a symbol. edit_replace is a text search-and-replace that will incorrectly modify occurrences inside string literals and comments. edit_rename is AST-aware and renames syntactic identifiers only, making it safe for symbol renames. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
         output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
             title = "Edit Rename",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2544,7 +2544,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_rename",
         title = "Edit Rename",
-        description = "Use this instead of edit_replace when renaming a symbol. edit_replace is a text search-and-replace that will incorrectly modify occurrences inside string literals and comments. edit_rename is AST-aware and renames syntactic identifiers only, making it safe for symbol renames. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
+        description = "AST-aware rename within a single file. Renames syntactic identifiers only; occurrences in string literals and comments are excluded, making it safe for symbol renames where edit_replace would incorrectly match. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
         output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
             title = "Edit Rename",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2544,7 +2544,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_rename",
         title = "Edit Rename",
-        description = "AST-aware rename within a single file. Renames syntactic identifiers only; occurrences in string literals and comments are excluded, making it safe for symbol renames where edit_replace would incorrectly match. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
+        description = "AST-aware rename within a single file. Matches syntactic identifiers only; occurrences in string literals and comments are excluded. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
         output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
             title = "Edit Rename",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2544,7 +2544,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_rename",
         title = "Edit Rename",
-        description = "AST-aware rename within a single file. Matches syntactic identifiers only; occurrences in string literals and comments are excluded. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found; fails if kind parameter supplied (reserved, not yet supported). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
+        description = "Use this instead of edit_replace when renaming a symbol. edit_replace is a text search-and-replace that will incorrectly modify occurrences inside string literals and comments. edit_rename is AST-aware and renames syntactic identifiers only, making it safe for symbol renames. AST-aware rename within a single file. Matches syntactic identifiers only; occurrences in string literals and comments are excluded. Returns path, old_name, new_name, occurrences_renamed. Fails if old_name not found. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: Rename function parse_config to load_config in src/config.rs.",
         output_schema = schema_for_type::<EditRenameOutput>(),
         annotations(
             title = "Edit Rename",


### PR DESCRIPTION
## Summary

Remove the stale `kind` parameter clause from the `edit_rename` tool description. The clause ("fails if kind parameter supplied (reserved, not yet supported)") correctly described the parameter's behaviour but exposed an implementation detail that serves no caller purpose and causes agents to reason unnecessarily about a parameter they should never supply.

## Changes

- `crates/aptu-coder/src/lib.rs`: `edit_rename` description only -- stale clause removed, everything else original

## Deferred scope

The `exec_command` redirect ("prefer `edit_*` tools for file edits") called out in the issue is deferred to #749 (`feat(exec_command): add stdin parameter`). That PR will own the exec_command description update alongside the new `stdin` parameter. A comment is posted on #746 to document the split.

## Test plan

- [x] `cargo build` passes
- [x] Clippy clean
- [x] Format clean
- [x] Security scan clean
