### PR TITLE
feat(tools): fix edit_rename ToolAnnotations per MCP 2025-11-25 spec

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2549,8 +2549,8 @@ impl CodeAnalyzer {
         annotations(
             title = "Edit Rename",
             read_only_hint = false,
-            destructive_hint = true,
-            idempotent_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
             open_world_hint = false
         )
     )]
@@ -4306,6 +4306,63 @@ mod tests {
             "Resolved path should be within CWD: {:?} should start with {:?}",
             path,
             canonical_cwd
+        );
+    }
+
+    #[test]
+    fn test_tool_annotations() {
+        // Arrange: get tool list via static method
+        let tools = CodeAnalyzer::list_tools();
+
+        // Act: find specific tools by name
+        let edit_rename = tools.iter().find(|t| t.name == "edit_rename");
+        let analyze_directory = tools.iter().find(|t| t.name == "analyze_directory");
+        let exec_command = tools.iter().find(|t| t.name == "exec_command");
+
+        // Assert: edit_rename has correct annotations
+        let edit_rename_tool = edit_rename.expect("edit_rename tool should exist");
+        let edit_rename_annot = edit_rename_tool
+            .annotations
+            .as_ref()
+            .expect("edit_rename should have annotations");
+        assert_eq!(
+            edit_rename_annot.destructive_hint,
+            Some(false),
+            "edit_rename destructive_hint should be false"
+        );
+        assert_eq!(
+            edit_rename_annot.idempotent_hint,
+            Some(true),
+            "edit_rename idempotent_hint should be true"
+        );
+
+        // Assert: analyze_directory has correct annotations
+        let analyze_dir_tool = analyze_directory.expect("analyze_directory tool should exist");
+        let analyze_dir_annot = analyze_dir_tool
+            .annotations
+            .as_ref()
+            .expect("analyze_directory should have annotations");
+        assert_eq!(
+            analyze_dir_annot.read_only_hint,
+            Some(true),
+            "analyze_directory read_only_hint should be true"
+        );
+        assert_eq!(
+            analyze_dir_annot.destructive_hint,
+            Some(false),
+            "analyze_directory destructive_hint should be false"
+        );
+
+        // Assert: exec_command has correct annotations
+        let exec_cmd_tool = exec_command.expect("exec_command tool should exist");
+        let exec_cmd_annot = exec_cmd_tool
+            .annotations
+            .as_ref()
+            .expect("exec_command should have annotations");
+        assert_eq!(
+            exec_cmd_annot.open_world_hint,
+            Some(true),
+            "exec_command open_world_hint should be true"
         );
     }
 }

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -35,10 +35,9 @@ fn test_all_tools_have_correct_annotations() {
             .as_ref()
             .unwrap_or_else(|| panic!("tool {} is missing annotations", name));
 
-        // edit_overwrite, edit_replace, edit_rename, edit_insert, and exec_command are destructive; others are read-only
+        // edit_overwrite, edit_replace, edit_insert, and exec_command are destructive; edit_rename is idempotent; others are read-only
         if name == "edit_overwrite"
             || name == "edit_replace"
-            || name == "edit_rename"
             || name == "edit_insert"
             || name == "exec_command"
         {
@@ -58,6 +57,25 @@ fn test_all_tools_have_correct_annotations() {
                 annotations.idempotent_hint,
                 Some(false),
                 "tool {} must have idempotent_hint=false",
+                name
+            );
+        } else if name == "edit_rename" {
+            assert_eq!(
+                annotations.read_only_hint,
+                Some(false),
+                "tool {} must have read_only_hint=false",
+                name
+            );
+            assert_eq!(
+                annotations.destructive_hint,
+                Some(false),
+                "tool {} must have destructive_hint=false",
+                name
+            );
+            assert_eq!(
+                annotations.idempotent_hint,
+                Some(true),
+                "tool {} must have idempotent_hint=true",
                 name
             );
         } else {


### PR DESCRIPTION
## Summary

Fix the single incorrect `ToolAnnotations` value in the codebase: `edit_rename` had `destructive_hint=true` and `idempotent_hint=false`, both wrong per the MCP 2025-11-25 spec. All other nine tools already had correct values.

## Rationale

Per the MCP spec:

- `destructiveHint`: true if the tool may cause data loss or corruption. `edit_rename` renames syntactic identifiers -- a reversible structural transformation with no data loss. Correct value: `false`.
- `idempotentHint`: true if repeated calls with identical arguments produce the same observable state. Renaming X to Y on a file already containing Y leaves the file unchanged. Correct value: `true`.

The previous values (`destructive=true, idempotent=false`) were semantically inverted.

## Changes

- `crates/aptu-coder/src/lib.rs`: flip `edit_rename` annotation values; add `test_tool_annotations` unit test
- `crates/aptu-coder/tests/annotations.rs`: update `test_all_tools_have_correct_annotations` to reflect corrected `edit_rename` semantics

## Test plan

- [x] `test_tool_annotations` passes (verifies `edit_rename`, `analyze_directory`, `exec_command` hints)
- [x] `test_all_tools_have_correct_annotations` updated and passes
- [x] All 73 tests pass (`cargo test -p aptu-coder`)
- [x] Clippy clean
- [x] Format clean
- [x] Security scan clean

## Merge order

This PR touches `lib.rs`. PR #753 (docs/746) also touches `lib.rs` in a non-overlapping region. Either can merge first; the other will need a trivial rebase.
