### PR TITLE
fix(exec_command): remove hardcoded default timeout, use None

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -916,7 +916,7 @@ pub struct EditInsertOutput {
 pub struct ExecCommandParams {
     /// Shell command to execute via sh -c (or $SHELL if set).
     pub command: String,
-    /// Timeout in seconds before SIGKILL (default: 30).
+    /// Timeout in seconds before SIGKILL. None = no timeout (default).
     pub timeout_secs: Option<u64>,
     /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
     pub working_dir: Option<String>,

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3091,41 +3091,45 @@ impl CodeAnalyzer {
         let sid = self.session_id.lock().await.clone();
 
         let command = params.command.clone();
-        let timeout_secs = params.timeout_secs.unwrap_or(30);
+        let timeout_secs = params.timeout_secs;
 
         // Acquire peer and progress token for optional progress notifications
         let peer = self.peer.lock().await.clone();
         let progress_token = context.meta.get_progress_token();
 
         // Spawn a progress task that emits every 5s for long-running commands (>10s timeout)
-        let progress_handle: Option<tokio::task::JoinHandle<()>> = if timeout_secs > 10 {
-            if let (Some(token), Some(peer_conn)) = (progress_token.clone(), peer.clone()) {
-                let self_clone = self.clone();
-                Some(tokio::spawn(async move {
-                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
-                    interval.tick().await; // skip the immediate first tick
-                    let mut tick = 0u64;
-                    loop {
-                        interval.tick().await;
-                        tick += 1;
-                        let progress = ((tick * 5) as f64 / timeout_secs as f64).min(0.99);
-                        self_clone
-                            .emit_progress(
-                                Some(peer_conn.clone()),
-                                &token,
-                                progress,
-                                1.0,
-                                "command running".to_string(),
-                            )
-                            .await;
-                    }
-                }))
+        let progress_handle: Option<tokio::task::JoinHandle<()>> =
+            if timeout_secs.is_none_or(|t| t > 10) {
+                if let (Some(token), Some(peer_conn)) = (progress_token.clone(), peer.clone()) {
+                    let self_clone = self.clone();
+                    Some(tokio::spawn(async move {
+                        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+                        interval.tick().await; // skip the immediate first tick
+                        let mut tick = 0u64;
+                        loop {
+                            interval.tick().await;
+                            tick += 1;
+                            let progress = match timeout_secs {
+                                Some(secs) => ((tick * 5) as f64 / secs as f64).min(0.99),
+                                None => 0.0,
+                            };
+                            self_clone
+                                .emit_progress(
+                                    Some(peer_conn.clone()),
+                                    &token,
+                                    progress,
+                                    1.0,
+                                    "command running".to_string(),
+                                )
+                                .await;
+                        }
+                    }))
+                } else {
+                    None
+                }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
         // Spawn the command using tokio::process::Command for proper async handling
         let shell = resolve_shell();
@@ -3202,7 +3206,6 @@ impl CodeAnalyzer {
         };
 
         // Wait for the command with timeout using tokio::select! to race wait against sleep
-        let timeout_duration = std::time::Duration::from_secs(timeout_secs);
         const MAX_BYTES: usize = 50 * 1024;
 
         let stdout_pipe = child.stdout.take();
@@ -3325,7 +3328,13 @@ impl CodeAnalyzer {
                 };
                 (exit_code, false, drain_truncated, ocerr)
             }
-            _ = tokio::time::sleep(timeout_duration) => {
+            _ = async {
+                if let Some(secs) = timeout_secs {
+                    tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            } => {
                 // Wall-clock timeout fired. Kill process; drain task gets EOF and exits.
                 let _ = child.kill().await;
                 let _ = child.wait().await;


### PR DESCRIPTION
## Summary

Removes the hardcoded `timeout_secs` default of 30s from `exec_command`. `None` (no timeout) is now the correct default; callers that need a bound pass `timeout_secs` explicitly.

## Root cause

The 30s default matched goose's MCP client timeout exactly. Long-running commands (git fetch, cargo build) would exhaust the MCP client deadline before the handler returned, triggering a `-32603: request timeout after PT30S` error. This killed the transport, causing all subsequent tool calls in the session to fail with Transport closed.

There is no safe magic number: cold `cargo test` on this codebase takes ~100s; on a large workspace like goose it exceeds 160s. Any hardcoded default silently kills legitimate builds on slower machines or after a dependency bump.

## Changes

- `crates/aptu-coder-core/src/types.rs`: doc comment updated to `None = no timeout (default)`
- `crates/aptu-coder/src/lib.rs`: six targeted changes in `exec_command`:
  - `params.timeout_secs.unwrap_or(30)` removed; `timeout_secs` stays `Option<u64>`
  - progress task guard: `timeout_secs > 10` → `timeout_secs.is_none_or(|t| t > 10)`
  - progress percentage: match on `Option`; returns `0.0` (indeterminate) when `None`
  - `timeout_duration` local removed
  - `tokio::select!` sleep arm replaced with a conditional async block: sleeps for `secs` when `Some`, calls `std::future::pending::<()>()` when `None` so the arm never fires

## Notes

A companion fix raising the goose MCP client timeout from 30s to 300s for the `aptu-coder` extension is in [clouatre/dotfiles#511](https://github.com/clouatre/dotfiles/pull/511). That change fixes the race for the old default; this change removes the race for all future defaults.
