### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.9", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.10", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["io-util"] }


### PR DESCRIPTION
## Summary

Bumps version from 0.9.0 to 0.10.0 in preparation for the v0.10.0 release.

## Changes

- `Cargo.toml`: workspace version `0.9.0` → `0.10.0`
- `crates/aptu-coder/Cargo.toml`: `aptu-coder-core` dependency constraint `0.9` → `0.10`

## Release notes preview

### Features

- Add session-scoped tool profiles via `initialize` hint (#751)
- Extend `edit_rename` from single-file to cross-file scope (#757)
- Add `stdin` parameter to `exec_command` (#756)
- Fix `edit_rename` `ToolAnnotations` per MCP 2025-11-25 spec (#754)

### Bug Fixes

- Remove hardcoded 30s default timeout from `exec_command` (#755)
- Switch `edit_overwrite` and `edit_replace` to atomic temp-file-plus-rename writes (#752)

### Documentation

- Remove stale `kind` parameter clause from `edit_rename` tool description (#753)
