### PR TITLE
fix(analyze_raw): require line range for large files in tool description

### DIFF
--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -55,6 +55,10 @@ pub enum AnalyzeError {
     },
     #[error("path is a directory, not a file: {0}")]
     NotAFile(PathBuf),
+    #[error(
+        "file has {total_lines} lines; provide start_line and end_line, or call analyze_module first to locate the range"
+    )]
+    RangelessLargeFile { total_lines: usize },
 }
 
 /// Result of directory analysis containing both formatted output and file data.
@@ -1487,6 +1491,11 @@ pub fn analyze_raw_range(
             next_start_line: None,
         });
     }
+    /// Files above this line count require explicit start_line/end_line on rangeless calls.
+    const MAX_RANGELESS_LINES: usize = 100;
+    if start_line.is_none() && end_line.is_none() && total > MAX_RANGELESS_LINES {
+        return Err(AnalyzeError::RangelessLargeFile { total_lines: total });
+    }
     let start = start_line.unwrap_or(1).max(1).min(total.max(1));
     let end = end_line.unwrap_or(total).min(total).max(1);
     if start > end {
@@ -2073,5 +2082,24 @@ fn caller_c() { target(); }
             iterations <= 5,
             "should take at most 5 iterations for 10 lines with page_size=3"
         );
+    }
+
+    #[test]
+    fn test_analyze_raw_rangeless_large_file_rejected() {
+        let content = "line\n".repeat(101);
+        let f = make_temp_file(&content);
+        let err = analyze_raw_range(f.path(), None, None).unwrap_err();
+        assert!(matches!(
+            err,
+            AnalyzeError::RangelessLargeFile { total_lines: 101 }
+        ));
+    }
+
+    #[test]
+    fn test_analyze_raw_rangeless_small_file_allowed() {
+        let content = "line\n".repeat(100);
+        let f = make_temp_file(&content);
+        let out = analyze_raw_range(f.path(), None, None).unwrap();
+        assert_eq!(out.total_lines, 100);
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2041,6 +2041,33 @@ impl CodeAnalyzer {
                     )),
                 )));
             }
+            Ok(Err(aptu_coder_core::AnalyzeError::RangelessLargeFile { total_lines })) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "analyze_raw",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type: Some("invalid_params".to_string()),
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                });
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    format!(
+                        "file has {total_lines} lines; provide start_line and end_line, or call analyze_module first to locate the range"
+                    ),
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "call analyze_module to get function line numbers, then retry with start_line and end_line",
+                    )),
+                )));
+            }
             Ok(Err(e)) => {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
                 self.metrics_tx.send(crate::metrics::MetricEvent {

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1927,7 +1927,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_raw",
         title = "Analyze Raw",
-        description = "Raw UTF-8 file content with line numbers; no AST parsing. Returns path, total_lines, start_line, end_line, content, next_start_line (null at EOF; pass as start_line to continue pagination). Use start_line/end_line (1-indexed, inclusive) to read a range; defaults to full file. Fails if directory path supplied; fails on binary or non-UTF-8 files. Use analyze_file or analyze_module for AST-structured output. Example queries: Show lines 100-150 of src/lib.rs.",
+        description = "Raw UTF-8 file content with line numbers; no AST parsing. Returns path, total_lines, start_line, end_line, content, next_start_line (null at EOF; pass as start_line to continue pagination). Omitting start_line/end_line returns the full file; for files over 100 lines use analyze_module first to locate the range. Fails if directory path supplied; fails on binary or non-UTF-8 files. Use analyze_file or analyze_module for AST-structured output. Example queries: Show lines 100-150 of src/lib.rs.",
         output_schema = schema_for_type::<types::AnalyzeRawOutput>(),
         annotations(
             title = "Analyze Raw",

--- a/crates/aptu-coder/tests/mcp_smoke.rs
+++ b/crates/aptu-coder/tests/mcp_smoke.rs
@@ -337,3 +337,112 @@ fn test_mcp_server_exec_command() {
         "Expected valid response for exec_command tool call with id=2"
     );
 }
+
+#[test]
+fn test_analyze_raw_rangeless_large_file_rejected() {
+    let bin = std::env::var("CARGO_BIN_EXE_aptu_coder").unwrap_or_else(|_| {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let workspace_root = std::path::Path::new(manifest_dir)
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("manifest dir has grandparent");
+        workspace_root
+            .join("target/debug/aptu-coder")
+            .to_string_lossy()
+            .to_string()
+    });
+
+    let mut child = std::process::Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn server at {}: {}", bin, e));
+
+    let mut stdin = child.stdin.take().expect("failed to get stdin");
+
+    // Use a file known to exceed 100 lines: src/lib.rs in this workspace.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let workspace_root = std::path::Path::new(manifest_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("manifest dir has grandparent");
+    let large_file = workspace_root
+        .join("crates/aptu-coder/src/lib.rs")
+        .to_string_lossy()
+        .to_string();
+
+    let writer = thread::spawn(move || {
+        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        stdin.write_all(init.as_bytes()).expect("write init");
+        stdin.write_all(b"\n").expect("newline");
+
+        let notif = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
+        stdin.write_all(notif.as_bytes()).expect("write notif");
+        stdin.write_all(b"\n").expect("newline");
+
+        thread::sleep(Duration::from_millis(500));
+
+        let call = format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"analyze_raw","arguments":{{"path":"{}","start_line":null,"end_line":null}}}}}}"#,
+            large_file
+        );
+        stdin.write_all(call.as_bytes()).expect("write call");
+        stdin.write_all(b"\n").expect("newline");
+
+        thread::sleep(Duration::from_millis(3000));
+    });
+
+    let stdout = child.stdout.take().expect("failed to get stdout");
+    let reader = std::io::BufReader::new(stdout);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let reader_thread = thread::spawn(move || {
+        use std::io::BufRead;
+        for line in reader.lines().flatten() {
+            let _ = tx.send(line);
+        }
+    });
+
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    let mut got_response = false;
+
+    while start.elapsed() < timeout && !got_response {
+        match rx.try_recv() {
+            Ok(line) => {
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
+                    if json.get("id") == Some(&serde_json::json!(2)) {
+                        assert!(
+                            json.get("error").is_none(),
+                            "must not be a JSON-RPC protocol error: {}",
+                            line
+                        );
+                        let is_error = json["result"]["isError"].as_bool().unwrap_or(false);
+                        assert!(
+                            is_error,
+                            "rangeless analyze_raw on large file must return isError=true: {}",
+                            line
+                        );
+                        let content = json["result"]["content"][0]["text"].as_str().unwrap_or("");
+                        assert!(
+                            content.contains("analyze_module"),
+                            "error message must mention analyze_module: {}",
+                            content
+                        );
+                        got_response = true;
+                    }
+                }
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+        }
+    }
+
+    let _ = writer.join();
+    let _ = child.wait();
+    let _ = reader_thread.join();
+
+    assert!(got_response, "Did not receive response for id:2");
+}


### PR DESCRIPTION
## Summary

`analyze_raw` was being abused by BUILD agents to binary-search large files in 50-line chunks instead of using `analyze_module`/`analyze_file` first to locate targets. Two complementary fixes: the tool description now steers agents toward the correct pattern; the server enforces it by rejecting rangeless calls on files over 100 lines.

## Changes

- `crates/aptu-coder/src/lib.rs` -- updated `analyze_raw` description; new `RangelessLargeFile` match arm in the handler
- `crates/aptu-coder-core/src/analyze.rs` -- `RangelessLargeFile` error variant; `MAX_RANGELESS_LINES` constant; guard fires before content is allocated
- `crates/aptu-coder/tests/mcp_smoke.rs` -- MCP-layer smoke test for the rejection path
- `crates/aptu-coder-core/src/analyze.rs` -- two unit tests: boundary at 100 (allowed) and 101 (rejected)

## What changed and why

**Description:** "Omitting start_line/end_line returns the full file; for files over 100 lines use analyze_module first to locate the range." Neutral, factual, matches the style of all other tool descriptions.

**Server enforcement (MCP 2025-11-05 compliant):** `analyze_raw_range` in core counts lines and returns `AnalyzeError::RangelessLargeFile { total_lines }` before allocating content. The handler maps this to `isError: true` with an actionable message pointing to `analyze_module`. The constant `MAX_RANGELESS_LINES = 100` is defined in core for maintainability.

Companion to clouatre/dotfiles#515.
