### PR TITLE
docs(bench): update wave9-sml infra for analyze_raw rangeless restriction

### DIFF
--- a/docs/benchmarks/wave9-sml/methodology.md
+++ b/docs/benchmarks/wave9-sml/methodology.md
@@ -86,6 +86,21 @@ Post-run verification uses five grep checks (no cargo compilation):
 
 All five checks must pass for the run to be scored as correct.
 
+## Conditions
+
+### Edit Profile Constraint
+
+As of PR #763, the `analyze_raw` tool requires explicit `start_line` and `end_line` parameters for files
+exceeding 100 lines. Bare calls (without line ranges) on large files return a server error. The benchmark
+prompts for conditions A and C (MCP tools) have been updated to include explicit line ranges:
+
+- `analyze_raw(path="...mod.rs", start_line=62, end_line=260)` -- covers the get_language_info and get_ts_language functions
+- `analyze_raw(path="...lang.rs", start_line=7, end_line=100)` -- covers EXTENSION_MAP and supported_languages
+
+Additionally, Wave 9 analysis recommends `edit_overwrite` over `edit_replace` for multi-edit small-file tasks,
+as it avoids the overhead of exact-text matching. Conditions A and C prompts have been updated to use
+`edit_overwrite` for all four edits.
+
 ## Rubric
 
 Scoring uses three dimensions, each 0-3 points (max 9 total):

--- a/docs/benchmarks/wave9-sml/methodology.md
+++ b/docs/benchmarks/wave9-sml/methodology.md
@@ -90,8 +90,9 @@ All five checks must pass for the run to be scored as correct.
 
 ### Edit Profile Constraint
 
-As of PR #763, the `analyze_raw` tool requires explicit `start_line` and `end_line` parameters for files
-exceeding 100 lines. Bare calls (without line ranges) on large files return a server error. The benchmark
+As of PR #763, the `analyze_raw` tool requires explicit `start_line` and `end_line` parameters for code
+files (recognized language extension) exceeding 100 lines. Bare calls (without line ranges) on large code
+files return a server error. Non-code files (Markdown, JSON, TOML, plain text) are exempt (PR #767). The benchmark
 prompts for conditions A and C (MCP tools) have been updated to include explicit line ranges:
 
 - `analyze_raw(path="...mod.rs", start_line=62, end_line=260)` -- covers the get_language_info and get_ts_language functions

--- a/docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md
@@ -12,12 +12,12 @@ FORBIDDEN TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch, and any tools not li
 
 Recommended call sequence:
 
-1. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs")` -- find the typescript arms in get_language_info and get_ts_language to use as template
-2. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", old_text="...", new_text="...")` -- add tsx arm to get_language_info (after typescript arm)
-3. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", old_text="...", new_text="...")` -- add tsx arm to get_ts_language (after typescript arm)
-4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs")` -- find the typescript entries in EXTENSION_MAP and supported_languages
-5. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", old_text="...", new_text="...")` -- add tsx extension mapping
-6. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", old_text="...", new_text="...")` -- add tsx to supported_languages
+1. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", start_line=62, end_line=260)` -- find the typescript arms in get_language_info and get_ts_language to use as template
+2. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", content="...")` -- add tsx arm to get_language_info (after typescript arm)
+3. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", content="...")` -- add tsx arm to get_ts_language (after typescript arm)
+4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", start_line=7, end_line=100)` -- find the typescript entries in EXTENSION_MAP and supported_languages
+5. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", content="...")` -- add tsx extension mapping
+6. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", content="...")` -- add tsx to supported_languages
 
 Do not run `cargo test`, `cargo build`, or any other build commands. The benchmark infrastructure will verify
 the re-wiring externally after you complete your implementation.

--- a/docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md
@@ -12,12 +12,12 @@ FORBIDDEN TOOLS: Bash, Glob, Grep, Read, Write, ToolSearch, and any tools not li
 
 Recommended call sequence:
 
-1. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs")` -- find the typescript arms in get_language_info and get_ts_language to use as template
-2. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", old_text="...", new_text="...")` -- add tsx arm to get_language_info (after typescript arm)
-3. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", old_text="...", new_text="...")` -- add tsx arm to get_ts_language (after typescript arm)
-4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs")` -- find the typescript entries in EXTENSION_MAP and supported_languages
-5. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", old_text="...", new_text="...")` -- add tsx extension mapping
-6. `edit_replace(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", old_text="...", new_text="...")` -- add tsx to supported_languages
+1. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", start_line=62, end_line=260)` -- find the typescript arms in get_language_info and get_ts_language to use as template
+2. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", content="...")` -- add tsx arm to get_language_info (after typescript arm)
+3. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/languages/mod.rs", content="...")` -- add tsx arm to get_ts_language (after typescript arm)
+4. `analyze_raw(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", start_line=7, end_line=100)` -- find the typescript entries in EXTENSION_MAP and supported_languages
+5. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", content="...")` -- add tsx extension mapping
+6. `edit_overwrite(path="REPO_PATH_PLACEHOLDER/crates/aptu-coder-core/src/lang.rs", content="...")` -- add tsx to supported_languages
 
 Do not run `cargo test`, `cargo build`, or any other build commands. The benchmark infrastructure will verify
 the re-wiring externally after you complete your implementation.

--- a/docs/benchmarks/wave9-sml/results/schema-weights.json
+++ b/docs/benchmarks/wave9-sml/results/schema-weights.json
@@ -1,6 +1,6 @@
 {
   "benchmark": "wave9-sml",
-  "generated_at": "2026-05-06",
+  "generated_at": "2026-05-07",
   "tokenizer": "cl100k_base",
   "tokenizer_note": "cl100k_base (tiktoken) is an approximation. Claude uses its own internal tokenizer, which is not publicly available. cl100k_base is the closest publicly available proxy and typically agrees within \u00b15% on English/code text.",
   "server_version": "aptu-coder (from PATH)",
@@ -56,10 +56,10 @@
     {
       "name": "analyze_raw",
       "tokens_name": 2,
-      "tokens_desc": 85,
+      "tokens_desc": 127,
       "tokens_input_schema": 168,
       "tokens_output_schema": 143,
-      "tokens_total": 398
+      "tokens_total": 440
     },
     {
       "name": "edit_rename",
@@ -87,16 +87,16 @@
     }
   ],
   "totals": {
-    "full_set_tokens": 7285,
+    "full_set_tokens": 7327,
     "server_instructions_tokens": 182,
-    "full_set_plus_instructions": 7467,
+    "full_set_plus_instructions": 7509,
     "edit_profile_tools": [
       "analyze_raw",
       "edit_overwrite",
       "edit_replace",
       "exec_command"
     ],
-    "edit_profile_tokens": 1430,
+    "edit_profile_tokens": 1472,
     "edit_profile_savings": 5855,
     "analyze_profile_tools": [
       "analyze_directory",


### PR DESCRIPTION
## Summary

PR #763 made bare `analyze_raw` calls on files over 100 lines a server error (`RangelessLargeFile`). Both target files in the Wave 9 SML benchmark exceed the threshold (`mod.rs` at 302 lines, `lang.rs` at 153 lines), which means conditions A and C would immediately fail on any re-run against the current server. This PR fixes the benchmark infrastructure to match current server behavior and applies the `edit_overwrite` recommendation from the Wave 9 analysis.

## Changes

- `docs/benchmarks/wave9-sml/prompts/condition-a-mcp-sonnet.md` -- replace bare `analyze_raw` calls with explicit `start_line`/`end_line` ranges (`mod.rs` 62-260, `lang.rs` 7-100); switch `edit_replace` to `edit_overwrite`
- `docs/benchmarks/wave9-sml/prompts/condition-c-mcp-haiku.md` -- same changes as condition A
- `docs/benchmarks/wave9-sml/results/schema-weights.json` -- update `analyze_raw` `tokens_desc` 85->127 (matches current tool description after #763); recalculate `tokens_total` 398->440, `full_set_tokens` 7285->7327, `edit_profile_tokens` 1430->1472; bump `generated_at` to 2026-05-07
- `docs/benchmarks/wave9-sml/methodology.md` -- add note on `analyze_raw` rangeless restriction (PR #763) and `edit_overwrite` preference for multi-edit small-file tasks

## Why edit_overwrite instead of edit_replace

The Wave 9 analysis (`results/analysis.md`, section 3) identified that `edit_replace` caused Haiku to add 2-3 verification-loop turns (re-reads between edits to confirm the prior edit applied). For a 2-file, 4-edit task with files under 350 lines, `edit_overwrite` is more token-efficient and eliminates the loop. The analysis was approved as part of the Wave 9 review; this PR applies the recommendation to the prompts.

## Test plan

- [ ] No source code or test files modified (docs/benchmarks/ only)
- [ ] `git diff --stat` shows 4 files, all under `docs/benchmarks/wave9-sml/`
- [ ] Security scan clean
