### PR TITLE
ci: switch all runners to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     outputs:
       code: ${{ steps.filter.outputs.code }}
       workflows: ${{ steps.filter.outputs.workflows }}
@@ -53,7 +53,7 @@ jobs:
 
   commitlint:
     name: Lint Commits
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   check-base:
     name: Check Branch Base
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -108,7 +108,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -144,7 +144,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 15
@@ -184,7 +184,7 @@ jobs:
 
   deny:
     name: Audit Dependencies
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     timeout-minutes: 10
@@ -200,7 +200,7 @@ jobs:
 
   msrv:
     name: MSRV Check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -221,7 +221,7 @@ jobs:
 
   zizmor:
     name: zizmor
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     needs: changes
     timeout-minutes: 10
     if: needs.changes.outputs.workflows == 'true' || github.event_name != 'pull_request'
@@ -237,7 +237,7 @@ jobs:
 
   semver-checks:
     name: semver checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     if: github.event_name == 'pull_request'
     # This PR renames the crate; no published or git baseline exists for aptu-coder-core yet.
     # Re-enable without continue-on-error after aptu-coder-core is first published on crates.io.
@@ -263,7 +263,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm64
     if: always()
     needs: [changes, commitlint, check-base, lint, coverage, deny, msrv, zizmor, semver-checks]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     outputs:
       code: ${{ steps.filter.outputs.code }}
       workflows: ${{ steps.filter.outputs.workflows }}
@@ -53,7 +53,7 @@ jobs:
 
   commitlint:
     name: Lint Commits
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   check-base:
     name: Check Branch Base
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
@@ -108,7 +108,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -144,7 +144,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 15
@@ -184,7 +184,7 @@ jobs:
 
   deny:
     name: Audit Dependencies
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     timeout-minutes: 10
@@ -200,7 +200,7 @@ jobs:
 
   msrv:
     name: MSRV Check
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request') && github.actor != 'renovate[bot]'
     timeout-minutes: 10
@@ -221,7 +221,7 @@ jobs:
 
   zizmor:
     name: zizmor
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: changes
     timeout-minutes: 10
     if: needs.changes.outputs.workflows == 'true' || github.event_name != 'pull_request'
@@ -237,7 +237,7 @@ jobs:
 
   semver-checks:
     name: semver checks
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: github.event_name == 'pull_request'
     # This PR renames the crate; no published or git baseline exists for aptu-coder-core yet.
     # Re-enable without continue-on-error after aptu-coder-core is first published on crates.io.
@@ -263,7 +263,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: always()
     needs: [changes, commitlint, check-base, lint, coverage, deny, msrv, zizmor, semver-checks]
     steps:


### PR DESCRIPTION
## Summary

Switch all CI runners from `ubuntu-24.04` to `ubuntu-24.04-arm`. The blocker was `wagoid/commitlint-github-action` (Docker, amd64-only image), which was replaced by a native `npx commitlint` step in #768. All remaining actions were verified ARM-safe before this PR.

## Verification

Each action checked before switching:

| Action | Method | ARM verdict |
|---|---|---|
| `zizmorcore/zizmor-action` | OCI manifest index inspected via GHCR API | `linux/arm64` layer confirmed |
| `dorny/paths-filter` | Node.js composite | arch-agnostic |
| `dtolnay/rust-toolchain` | Shell composite | arch-agnostic |
| `Swatinem/rust-cache` | Node.js | arch-agnostic |
| `taiki-e/install-action` | Publishes arm64 binaries for nextest, llvm-cov, cargo-deny | confirmed |
| `obi1kenobi/cargo-semver-checks-action` | Publishes arm64 binaries | confirmed |
| `actions/checkout`, `actions/cache`, `actions/setup-node` | Node.js | arch-agnostic |

Note: the correct label for the free GitHub-hosted arm64 runner on public repos is `ubuntu-24.04-arm`, not `ubuntu-24.04-arm64`. The latter is a paid larger runner label requiring explicit org provisioning.

## Changes

Single mechanical substitution: `ubuntu-24.04` -> `ubuntu-24.04-arm` across all 10 `runs-on` lines in `ci.yml`. No logic changes.

## Expected impact

- ~37% lower runner cost (GitHub pricing for arm64 vs x86-64)
- ~10-15% faster Rust compilation (native silicon, better memory bandwidth for LLVM)

## Test plan

- [ ] CI passes on this PR (exercises all jobs on arm64)
- [ ] zizmor job completes (Docker arm64 image pull succeeds)
- [ ] coverage job completes (llvm-cov arm64 binary resolves via taiki-e)
