### PR TITLE
feat(server): APTU_CODER_PROFILE env var fallback and APTU_CODER_METRICS_EXPORT_FILE shutdown export

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3438,7 +3438,7 @@ impl ServerHandler for CodeAnalyzer {
             .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // Parse client profile from stored metadata and disable tools accordingly.
-        // Profiles: "edit" (4 tools), "analyze" (6 tools), absent/unknown (10 tools).
+        // Profiles: "edit" (3 tools), "analyze" (5 tools), absent/unknown (9 tools).
         // _meta takes precedence over APTU_CODER_PROFILE when both are present.
         let meta_lock = self.profile_meta.lock().await;
         let meta_profile = meta_lock

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3439,13 +3439,21 @@ impl ServerHandler for CodeAnalyzer {
 
         // Parse client profile from stored metadata and disable tools accordingly.
         // Profiles: "edit" (4 tools), "analyze" (6 tools), absent/unknown (10 tools).
+        // _meta takes precedence over APTU_CODER_PROFILE when both are present.
         let meta_lock = self.profile_meta.lock().await;
-        if let Some(meta) = meta_lock.as_ref()
-            && let Some(profile_val) = meta.get("io.clouatre-labs/profile")
-            && let Some(profile) = profile_val.as_str()
-        {
+        let meta_profile = meta_lock
+            .as_ref()
+            .and_then(|m| m.get("io.clouatre-labs/profile"))
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        drop(meta_lock);
+
+        // Resolve the active profile: _meta wins; fall back to env var.
+        let active_profile = meta_profile.or_else(|| std::env::var("APTU_CODER_PROFILE").ok());
+
+        if let Some(ref profile) = active_profile {
             let mut router = self.tool_router.write().await;
-            match profile {
+            match profile.as_str() {
                 "edit" => {
                     // Enable only: edit_replace, edit_overwrite, exec_command
                     router.disable_route("analyze_directory");
@@ -3469,7 +3477,6 @@ impl ServerHandler for CodeAnalyzer {
             // Bind peer notifier after disabling tools to send tools/list_changed notification
             router.bind_peer_notifier(&context.peer);
         }
-        drop(meta_lock);
 
         // Spawn consumer task to drain log events from channel with batching.
         let peer = self.peer.clone();

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3449,7 +3449,7 @@ impl ServerHandler for CodeAnalyzer {
         drop(meta_lock);
 
         // Resolve the active profile: _meta wins; fall back to env var.
-        let active_profile = meta_profile.or_else(|| std::env::var("APTU_CODER_PROFILE").ok());
+        let active_profile = meta_profile.or(std::env::var("APTU_CODER_PROFILE").ok());
 
         if let Some(ref profile) = active_profile {
             let mut router = self.tool_router.write().await;

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -68,13 +68,36 @@ impl MetricsWriter {
         let mut current_date = current_date_str();
         let mut current_file: Option<PathBuf> = None;
 
+        // Accumulate per-tool metrics for export on shutdown (issue #773)
+        let mut tool_counts: std::collections::HashMap<String, (u64, u64)> =
+            std::collections::HashMap::new();
+        let mut export_session_id: Option<String> = None;
+
         loop {
             let mut batch = Vec::new();
             if let Some(event) = self.rx.recv().await {
+                // Accumulate metrics for export
+                let entry = tool_counts.entry(event.tool.to_string()).or_insert((0, 0));
+                entry.0 += 1;
+                entry.1 += event.duration_ms;
+                if export_session_id.is_none() {
+                    export_session_id = event.session_id.clone();
+                }
+
                 batch.push(event);
                 for _ in 0..99 {
                     match self.rx.try_recv() {
-                        Ok(e) => batch.push(e),
+                        Ok(e) => {
+                            // Accumulate metrics for export
+                            let entry = tool_counts.entry(e.tool.to_string()).or_insert((0, 0));
+                            entry.0 += 1;
+                            entry.1 += e.duration_ms;
+                            if export_session_id.is_none() {
+                                export_session_id = e.session_id.clone();
+                            }
+
+                            batch.push(e);
+                        }
                         Err(
                             mpsc::error::TryRecvError::Empty
                             | mpsc::error::TryRecvError::Disconnected,
@@ -135,6 +158,34 @@ impl MetricsWriter {
                     }
                 }
                 let _ = file.flush().await;
+            }
+        }
+
+        // Export metrics summary on shutdown (issue #773)
+        if let Ok(export_path) = std::env::var("APTU_CODER_METRICS_EXPORT_FILE") {
+            let mut tool_calls = Vec::new();
+            let mut total_duration_ms = 0u64;
+            for (tool_name, (count, duration)) in tool_counts {
+                tool_calls.push(serde_json::json!({
+                    "tool": tool_name,
+                    "call_count": count,
+                    "total_duration_ms": duration
+                }));
+                total_duration_ms += duration;
+            }
+            let summary = serde_json::json!({
+                "session_id": export_session_id.unwrap_or_default(),
+                "tool_calls": tool_calls,
+                "total_duration_ms": total_duration_ms
+            });
+            if let Ok(json_str) = serde_json::to_string(&summary)
+                && let Err(e) = tokio::fs::write(&export_path, json_str).await
+            {
+                tracing::warn!(
+                    error = %e,
+                    path = %export_path,
+                    "metrics: failed to write export file"
+                );
             }
         }
     }
@@ -300,7 +351,16 @@ fn migrate_legacy_metrics_dir_impl(home: &str) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
+
+    /// Serializes tests that mutate `APTU_CODER_METRICS_EXPORT_FILE` to prevent parallel
+    /// pollution. Recovers from poison caused by panicking tests.
+    fn metrics_export_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let m = LOCK.get_or_init(|| Mutex::new(()));
+        m.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     #[test]
     fn test_migrate_legacy_only_old_exists() {
@@ -488,5 +548,139 @@ mod tests {
         let serialized = serde_json::to_string(&event).unwrap();
         let json_str = r#"{"ts":1700000000000,"tool":"analyze_file","duration_ms":100,"output_chars":500,"param_path_depth":2,"max_depth":3,"result":"ok","error_type":null,"session_id":"1742468880123-42","seq":5}"#;
         assert_eq!(serialized, json_str);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_export_file_created() {
+        let _guard = metrics_export_lock();
+        // Arrange: create temp dir and set export env var
+        let dir = TempDir::new().unwrap();
+        let export_file = dir.path().join("metrics_export.json");
+        let export_path_str = export_file.to_string_lossy().to_string();
+
+        unsafe {
+            std::env::set_var("APTU_CODER_METRICS_EXPORT_FILE", &export_path_str);
+        }
+
+        // Create metrics writer and send events
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
+        let writer = MetricsWriter::new(rx, Some(dir.path().to_path_buf()));
+
+        // Act: send a few events with session_id
+        tx.send(MetricEvent {
+            ts: unix_ms(),
+            tool: "analyze_directory",
+            duration_ms: 100,
+            output_chars: 50,
+            param_path_depth: 1,
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: Some("test-session-123".to_string()),
+            seq: None,
+            cache_hit: None,
+        })
+        .unwrap();
+        tx.send(MetricEvent {
+            ts: unix_ms(),
+            tool: "analyze_file",
+            duration_ms: 50,
+            output_chars: 100,
+            param_path_depth: 2,
+            max_depth: Some(3),
+            result: "ok",
+            error_type: None,
+            session_id: Some("test-session-123".to_string()),
+            seq: None,
+            cache_hit: None,
+        })
+        .unwrap();
+        drop(tx);
+        writer.run().await;
+
+        // Assert: export file should exist with correct JSON structure
+        assert!(
+            export_file.exists(),
+            "export file should be created at {:?}",
+            export_file
+        );
+        let content = std::fs::read_to_string(&export_file).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(
+            json["session_id"], "test-session-123",
+            "export should contain correct session_id"
+        );
+        assert!(
+            json["tool_calls"].is_array(),
+            "export should contain tool_calls array"
+        );
+        let tool_calls = json["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 2, "should have 2 tool calls");
+        assert!(
+            json["total_duration_ms"].is_number(),
+            "export should contain total_duration_ms"
+        );
+        assert_eq!(
+            json["total_duration_ms"], 150,
+            "total_duration_ms should be sum of all durations"
+        );
+
+        // Cleanup
+        unsafe {
+            std::env::remove_var("APTU_CODER_METRICS_EXPORT_FILE");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metrics_export_env_var_unset() {
+        let _guard = metrics_export_lock();
+        // Arrange: ensure env var is not set
+        unsafe {
+            std::env::remove_var("APTU_CODER_METRICS_EXPORT_FILE");
+        }
+        let dir = TempDir::new().unwrap();
+        // Use a unique marker to ensure we don't pick up files from other tests
+        let marker = "metrics_export_unset_test";
+
+        // Create metrics writer and send events
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
+        let writer = MetricsWriter::new(rx, Some(dir.path().to_path_buf()));
+
+        // Act: send events and run writer
+        tx.send(MetricEvent {
+            ts: unix_ms(),
+            tool: "analyze_directory",
+            duration_ms: 100,
+            output_chars: 50,
+            param_path_depth: 1,
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: Some("test-session-456".to_string()),
+            seq: None,
+            cache_hit: None,
+        })
+        .unwrap();
+        drop(tx);
+        writer.run().await;
+
+        // Assert: no export file should be created
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.contains(marker))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(
+            entries.len(),
+            0,
+            "no export file should be created when env var is unset"
+        );
     }
 }

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -69,7 +69,7 @@ impl MetricsWriter {
         let mut current_file: Option<PathBuf> = None;
 
         // Accumulate per-tool metrics for export on shutdown (issue #773)
-        let mut tool_counts: std::collections::HashMap<String, (u64, u64)> =
+        let mut tool_counts: std::collections::HashMap<&'static str, (u64, u64)> =
             std::collections::HashMap::new();
         let mut export_session_id: Option<String> = None;
 
@@ -77,7 +77,7 @@ impl MetricsWriter {
             let mut batch = Vec::new();
             if let Some(event) = self.rx.recv().await {
                 // Accumulate metrics for export
-                let entry = tool_counts.entry(event.tool.to_string()).or_insert((0, 0));
+                let entry = tool_counts.entry(event.tool).or_insert((0, 0));
                 entry.0 += 1;
                 entry.1 += event.duration_ms;
                 if export_session_id.is_none() {
@@ -89,7 +89,7 @@ impl MetricsWriter {
                     match self.rx.try_recv() {
                         Ok(e) => {
                             // Accumulate metrics for export
-                            let entry = tool_counts.entry(e.tool.to_string()).or_insert((0, 0));
+                            let entry = tool_counts.entry(e.tool).or_insert((0, 0));
                             entry.0 += 1;
                             entry.1 += e.duration_ms;
                             if export_session_id.is_none() {

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -63,6 +63,20 @@ impl MetricsWriter {
         }
     }
 
+    /// Accumulate a metric event into tool_counts and export_session_id.
+    fn accumulate_event(
+        tool_counts: &mut std::collections::HashMap<&'static str, (u64, u64)>,
+        export_session_id: &mut Option<String>,
+        event: &MetricEvent,
+    ) {
+        let entry = tool_counts.entry(event.tool).or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 += event.duration_ms;
+        if export_session_id.is_none() {
+            *export_session_id = event.session_id.clone();
+        }
+    }
+
     pub async fn run(mut self) {
         cleanup_old_files(&self.base_dir).await;
         let mut current_date = current_date_str();
@@ -76,26 +90,12 @@ impl MetricsWriter {
         loop {
             let mut batch = Vec::new();
             if let Some(event) = self.rx.recv().await {
-                // Accumulate metrics for export
-                let entry = tool_counts.entry(event.tool).or_insert((0, 0));
-                entry.0 += 1;
-                entry.1 += event.duration_ms;
-                if export_session_id.is_none() {
-                    export_session_id = event.session_id.clone();
-                }
-
+                Self::accumulate_event(&mut tool_counts, &mut export_session_id, &event);
                 batch.push(event);
                 for _ in 0..99 {
                     match self.rx.try_recv() {
                         Ok(e) => {
-                            // Accumulate metrics for export
-                            let entry = tool_counts.entry(e.tool).or_insert((0, 0));
-                            entry.0 += 1;
-                            entry.1 += e.duration_ms;
-                            if export_session_id.is_none() {
-                                export_session_id = e.session_id.clone();
-                            }
-
+                            Self::accumulate_event(&mut tool_counts, &mut export_session_id, &e);
                             batch.push(e);
                         }
                         Err(

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -163,29 +163,36 @@ impl MetricsWriter {
 
         // Export metrics summary on shutdown (issue #773)
         if let Ok(export_path) = std::env::var("APTU_CODER_METRICS_EXPORT_FILE") {
-            let mut tool_calls = Vec::new();
-            let mut total_duration_ms = 0u64;
-            for (tool_name, (count, duration)) in tool_counts {
-                tool_calls.push(serde_json::json!({
-                    "tool": tool_name,
-                    "call_count": count,
-                    "total_duration_ms": duration
-                }));
-                total_duration_ms += duration;
-            }
-            let summary = serde_json::json!({
-                "session_id": export_session_id.unwrap_or_default(),
-                "tool_calls": tool_calls,
-                "total_duration_ms": total_duration_ms
-            });
-            if let Ok(json_str) = serde_json::to_string(&summary)
-                && let Err(e) = tokio::fs::write(&export_path, json_str).await
-            {
+            if !std::path::Path::new(&export_path).is_absolute() {
                 tracing::warn!(
-                    error = %e,
                     path = %export_path,
-                    "metrics: failed to write export file"
+                    "metrics: APTU_CODER_METRICS_EXPORT_FILE must be an absolute path; skipping export"
                 );
+            } else {
+                let mut tool_calls = Vec::new();
+                let mut total_duration_ms = 0u64;
+                for (tool_name, (count, duration)) in tool_counts {
+                    tool_calls.push(serde_json::json!({
+                        "tool": tool_name,
+                        "call_count": count,
+                        "total_duration_ms": duration
+                    }));
+                    total_duration_ms += duration;
+                }
+                let summary = serde_json::json!({
+                    "session_id": export_session_id.unwrap_or_default(),
+                    "tool_calls": tool_calls,
+                    "total_duration_ms": total_duration_ms
+                });
+                if let Ok(json_str) = serde_json::to_string(&summary)
+                    && let Err(e) = tokio::fs::write(&export_path, json_str).await
+                {
+                    tracing::warn!(
+                        error = %e,
+                        path = %export_path,
+                        "metrics: failed to write export file"
+                    );
+                }
             }
         }
     }
@@ -682,5 +689,64 @@ mod tests {
             0,
             "no export file should be created when env var is unset"
         );
+    }
+
+    #[tokio::test]
+    async fn test_metrics_export_relative_path_rejected() {
+        let _guard = metrics_export_lock();
+        // Arrange: set export env var to a relative path
+        let relative_path = "relative/path/metrics.json";
+        unsafe {
+            std::env::set_var("APTU_CODER_METRICS_EXPORT_FILE", relative_path);
+        }
+
+        let dir = TempDir::new().unwrap();
+        // Use a unique marker to ensure we don't pick up files from other tests
+        let marker = "metrics_export_relative_test";
+
+        // Create metrics writer and send events
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
+        let writer = MetricsWriter::new(rx, Some(dir.path().to_path_buf()));
+
+        // Act: send events and run writer
+        tx.send(MetricEvent {
+            ts: unix_ms(),
+            tool: "analyze_directory",
+            duration_ms: 100,
+            output_chars: 50,
+            param_path_depth: 1,
+            max_depth: None,
+            result: "ok",
+            error_type: None,
+            session_id: Some(marker.to_string()),
+            seq: None,
+            cache_hit: None,
+        })
+        .unwrap();
+        drop(tx);
+        writer.run().await;
+
+        // Assert: no export file should be created for relative path
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.contains("metrics.json"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(
+            entries.len(),
+            0,
+            "no export file should be created for relative path"
+        );
+
+        // Cleanup
+        unsafe {
+            std::env::remove_var("APTU_CODER_METRICS_EXPORT_FILE");
+        }
     }
 }

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -379,8 +379,8 @@ async fn test_profile_env_var_fallback() {
 
     // Assert: env var profile should be applied when _meta is absent.
     assert_eq!(
-        tool_count, 4,
-        "env var profile (edit) should enable exactly 4 tools, got: {:?}",
+        tool_count, 3,
+        "env var profile (edit) should enable exactly 3 tools, got: {:?}",
         tool_names
     );
     assert!(
@@ -418,9 +418,9 @@ async fn test_profile_env_var_ignored_when_meta_present() {
         .collect();
 
     // Assert: _meta profile (analyze) should override the env var (edit).
-    // analyze profile enables 6 tools.
+    // analyze profile enables 5 tools.
     assert_eq!(
-        tool_count, 6,
+        tool_count, 5,
         "_meta profile (analyze) should take precedence over env var, got: {:?}",
         tool_names
     );

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -1,10 +1,18 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex as TokioMutex;
 use tracing_subscriber::filter::LevelFilter;
+
+/// Serializes tests that mutate process-global env vars to prevent parallel pollution.
+/// Uses `unwrap_or_else` to recover from mutex poison caused by panicking tests.
+fn env_var_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let m = LOCK.get_or_init(|| Mutex::new(()));
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
@@ -200,6 +208,7 @@ async fn call_tool_with_profile(profile: Option<&str>, tool_name: &str) -> serde
 
 #[tokio::test]
 async fn test_edit_profile_tool_count() {
+    let _guard = env_var_lock();
     // Arrange: initialize with edit profile
     let resp = call_tools_list_with_profile(Some("edit")).await;
 
@@ -237,6 +246,7 @@ async fn test_edit_profile_tool_count() {
 
 #[tokio::test]
 async fn test_analyze_profile_tool_count() {
+    let _guard = env_var_lock();
     // Arrange: initialize with analyze profile
     let resp = call_tools_list_with_profile(Some("analyze")).await;
 
@@ -282,7 +292,11 @@ async fn test_analyze_profile_tool_count() {
 
 #[tokio::test]
 async fn test_no_profile_tool_count() {
-    // Arrange: initialize with no profile metadata
+    let _guard = env_var_lock();
+    // Arrange: initialize with no profile metadata; env var must be absent.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
+    }
     let resp = call_tools_list_with_profile(None).await;
 
     // Act: extract tool count from response
@@ -299,7 +313,11 @@ async fn test_no_profile_tool_count() {
 
 #[tokio::test]
 async fn test_unknown_profile_tool_count() {
-    // Arrange: initialize with unknown profile string
+    let _guard = env_var_lock();
+    // Arrange: initialize with unknown profile string; env var must be absent.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
+    }
     let resp = call_tools_list_with_profile(Some("unknown_profile")).await;
 
     // Act: extract tool count from response
@@ -316,6 +334,7 @@ async fn test_unknown_profile_tool_count() {
 
 #[tokio::test]
 async fn test_disabled_tool_returns_invalid_params() {
+    let _guard = env_var_lock();
     // Arrange: initialize with edit profile and try to call a disabled tool
     let resp = call_tool_with_profile(Some("edit"), "edit_rename").await;
 
@@ -328,5 +347,85 @@ async fn test_disabled_tool_returns_invalid_params() {
         Some(-32602),
         "calling a disabled tool should return INVALID_PARAMS (-32602), got: {:?}",
         resp
+    );
+}
+
+#[tokio::test]
+async fn test_profile_env_var_fallback() {
+    // Serialize against other env-var-mutating tests.
+    let _guard = env_var_lock();
+
+    // Arrange: set APTU_CODER_PROFILE env var to "edit", initialize with no _meta.
+    unsafe {
+        std::env::set_var("APTU_CODER_PROFILE", "edit");
+    }
+
+    let resp = call_tools_list_with_profile(None).await;
+
+    // Cleanup before any assertion so panics cannot leave the env var set.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
+    }
+
+    // Act: extract tool count from response.
+    let tools = &resp["result"]["tools"];
+    let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
+    let tool_names: Vec<String> = tools
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    // Assert: env var profile should be applied when _meta is absent.
+    assert_eq!(
+        tool_count, 4,
+        "env var profile (edit) should enable exactly 4 tools, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"edit_replace".to_string()),
+        "env var profile should include edit_replace"
+    );
+}
+
+#[tokio::test]
+async fn test_profile_env_var_ignored_when_meta_present() {
+    // Serialize against other env-var-mutating tests.
+    let _guard = env_var_lock();
+
+    // Arrange: set APTU_CODER_PROFILE=edit but initialize with _meta "analyze".
+    // _meta must win.
+    unsafe {
+        std::env::set_var("APTU_CODER_PROFILE", "edit");
+    }
+
+    let resp = call_tools_list_with_profile(Some("analyze")).await;
+
+    // Cleanup before any assertion.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
+    }
+
+    // Act: extract tool count from response.
+    let tools = &resp["result"]["tools"];
+    let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
+    let tool_names: Vec<String> = tools
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    // Assert: _meta profile (analyze) should override the env var (edit).
+    // analyze profile enables 6 tools.
+    assert_eq!(
+        tool_count, 6,
+        "_meta profile (analyze) should take precedence over env var, got: {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"analyze_directory".to_string()),
+        "_meta profile should include analyze_directory"
     );
 }


### PR DESCRIPTION
## Summary

Fixes two independent enhancements in a single branch:

- **#772** -- Add `APTU_CODER_PROFILE` env var as a fallback profile activation mechanism. Clients that cannot pass `_meta` at initialize time (e.g. `claude --mcp-config`) can now set the env var instead. `_meta` always takes precedence when both are present. Unknown values leave all tools enabled (lenient fallback).
- **#773** -- Export a compact per-session metrics summary JSON to `APTU_CODER_METRICS_EXPORT_FILE` on server shutdown. Gives benchmark runners an authoritative server-side tool call count and latency summary without post-processing the full daily JSONL.

Both features are zero-overhead when the respective env var is unset.

## Changes

- `crates/aptu-coder/src/lib.rs` -- Profile activation refactored to an `or_else` chain: parse `_meta` first, fall back to `std::env::var("APTU_CODER_PROFILE")`. Single match block applies to whichever source wins.
- `crates/aptu-coder/src/metrics.rs` -- `MetricsWriter::run()` accumulates per-tool `(call_count, total_duration_ms)` in a `HashMap` during the event drain loop. On channel close (shutdown), if `APTU_CODER_METRICS_EXPORT_FILE` is set, serializes `{ session_id, tool_calls, total_duration_ms }` to the configured path via `tokio::fs::write`. Failures are logged at `warn` level. Adds `OnceLock<Mutex<()>>` serialization guard for env-var-mutating tests. A private `accumulate_event` helper eliminates the duplicated accumulation logic between the `recv` and `try_recv` arms of the batch loop.
- `crates/aptu-coder/tests/profiles.rs` -- Adds `test_profile_env_var_fallback` and `test_profile_env_var_ignored_when_meta_present`. All seven profile tests now acquire a process-global `OnceLock<Mutex<()>>` guard to prevent parallel env-var pollution.

## Test plan

- [ ] All tests pass (`cargo test`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] Formatter clean (`cargo fmt --check`)
- [ ] Security scan: 0 findings
- [ ] `test_profile_env_var_fallback` -- env var set, no `_meta` -> edit profile applied (4 tools)
- [ ] `test_profile_env_var_ignored_when_meta_present` -- env var `edit`, `_meta` `analyze` -> 6 tools (analyze wins)
- [ ] `test_metrics_export_file_created` -- env var set -> file written with correct JSON schema
- [ ] `test_metrics_export_env_var_unset` -- env var absent -> no file written
