### PR TITLE
chore(tests): update protocol version string to 2025-11-25

### DIFF
--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -40,7 +40,7 @@ async fn call_exec_command_raw(params: serde_json::Value) -> serde_json::Value {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-11-25",
             "capabilities": {},
             "clientInfo": {"name": "test-client", "version": "0.1.0"}
         }

--- a/crates/aptu-coder/tests/mcp_smoke.rs
+++ b/crates/aptu-coder/tests/mcp_smoke.rs
@@ -30,7 +30,7 @@ fn test_mcp_server_responds_to_tools_call() {
     let mut stdin = child.stdin.take().expect("failed to get stdin");
 
     // Send initialize message
-    let init_msg = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+    let init_msg = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
     stdin
         .write_all(init_msg.as_bytes())
         .expect("failed to write");
@@ -125,7 +125,7 @@ fn test_mcp_server_recovers_after_tool_error() {
 
     // Writer thread: pace messages to avoid EOF race with the server's async reader.
     let writer = thread::spawn(move || {
-        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
         stdin.write_all(init.as_bytes()).expect("write init");
         stdin.write_all(b"\n").expect("newline");
 
@@ -242,7 +242,7 @@ fn test_mcp_server_exec_command() {
 
     // Writer thread: pace messages to avoid EOF race with the server's async reader.
     let writer = thread::spawn(move || {
-        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
         stdin.write_all(init.as_bytes()).expect("write init");
         stdin.write_all(b"\n").expect("newline");
 

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -44,7 +44,7 @@ async fn call_tools_list_with_profile(profile: Option<&str>) -> serde_json::Valu
 
     // Step 1: Send initialize request with optional profile in _meta
     let mut init_params = serde_json::json!({
-        "protocolVersion": "2024-11-05",
+        "protocolVersion": "2025-11-25",
         "capabilities": {},
         "clientInfo": {"name": "test-client", "version": "0.1.0"}
     });
@@ -132,7 +132,7 @@ async fn call_tool_with_profile(profile: Option<&str>, tool_name: &str) -> serde
 
     // Step 1: Send initialize request with optional profile in _meta
     let mut init_params = serde_json::json!({
-        "protocolVersion": "2024-11-05",
+        "protocolVersion": "2025-11-25",
         "capabilities": {},
         "clientInfo": {"name": "test-client", "version": "0.1.0"}
     });


### PR DESCRIPTION
## Summary

Update the hardcoded `protocolVersion` string in test fixtures from `2024-11-05` to `2025-11-25`, which is the latest MCP protocol version and matches `ProtocolVersion::LATEST` in rmcp 1.6.0.

The value is cosmetic in these tests (none of them assert on the negotiated version), but keeping it current avoids confusion.

## Changes

- `crates/aptu-coder/tests/exec_command.rs` -- 1 occurrence
- `crates/aptu-coder/tests/mcp_smoke.rs` -- 3 occurrences
- `crates/aptu-coder/tests/profiles.rs` -- 2 occurrences

## Test plan

- [ ] Tests pass (no logic changed, pure string update)
- [ ] Linter clean
