### PR TITLE
docs(benchmarks): fix tool count and confounds in wave10 experiment design

### DIFF
--- a/docs/benchmarks/wave10/experiment-design.json
+++ b/docs/benchmarks/wave10/experiment-design.json
@@ -4,10 +4,11 @@
   "design": "2x1 (model_tier x edit_profile); baselines from wave9-sml conditions A and C",
   "task": "tsx re-wiring (4 edits to 2 files) -- identical to wave9-sml",
   "randomization_seed": 42,
-  "hypothesis": "edit profile (3 tools) reduces cost and turn count vs full tool set (9 tools, 7348 tokens/turn) for targeted-edit tasks",
+  "hypothesis": "edit profile (3 tools) reduces cost and turn count vs full tool set (7 tools) for targeted-edit tasks",
   "confounds": [
     "binary version: wave9 ran on 0.9.x; wave10 runs on 0.10.1",
-    "tool descriptions improved in 0.10.1 (#732, #729, #763)"
+    "tool descriptions improved in 0.10.1 (#732, #729, #763)",
+    "tool surface reduced from 9 to 7 between wave9 and wave10: analyze_raw removed (#775), edit_rename and edit_insert removed (#782)"
   ],
   "conditions": {
     "E": {


### PR DESCRIPTION
## Summary

Follow-up to #771. PRs #775 and #782 removed three tools (`analyze_raw`, `edit_rename`, `edit_insert`), reducing the full MCP profile from 9 to 7 tools. The wave10 experiment design doc still referenced the old count and included a stale per-turn token figure measured against the old surface.

## Changes

- `docs/benchmarks/wave10/experiment-design.json`: updated hypothesis string from "9 tools" to "7 tools" and dropped the stale `7348 tokens/turn` figure; added a confound entry documenting the tool surface reduction with PR references.

## Why no re-baseline

The wave9 baselines predate the tool removals, so the token counts in `baselines.A` and `baselines.C` do reflect the larger surface. This is now captured as a confound so readers understand the comparison is cross-surface, not a control for it.
