### PR TITLE
chore(release): bump version to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump workspace version to 0.10.2.

## Changes

- `Cargo.toml`: version `0.10.1` -> `0.10.2`
- `Cargo.lock`: workspace version updated

## What's in 0.10.2

- Remove `analyze_raw` tool; agents use `exec_command + sed` for raw file reads (#775)
- `APTU_CODER_PROFILE` env var fallback and `APTU_CODER_METRICS_EXPORT_FILE` shutdown export (#774)
- Wire `parse_timeout_micros` via `QueryCursor` progress_callback (#781)
- Remove `edit_rename` and `edit_insert` from MCP surface; server drops from 9 to 7 tools (#782)
- Fix Python and TypeScript `DEFUSE_QUERY` for destructuring assignments; 10 new def-use tests (#778)
- Wave 10 MCP edit-profile benchmark infrastructure (#771)
- Update protocol version string to 2025-11-25 in test fixtures (#783)
- Fix tool count and confounds in wave10 experiment design (#784)

## Test plan

- [ ] Tests pass (`cargo test`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
