### PR TITLE
docs: remove stale references to analyze_raw, edit_rename, edit_insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 ## Observability
 
-All ten tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full schema.
+All seven tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full schema.
 
 ## Documentation
 

--- a/crates/aptu-coder-core/README.md
+++ b/crates/aptu-coder-core/README.md
@@ -17,7 +17,7 @@ Core library for code structure analysis using tree-sitter.
 - **File analysis** - Functions, classes, and imports with signatures and line ranges
 - **Symbol call graphs** - Callers and callees across a directory with configurable depth
 - **Module index** - Lightweight function and import index (~75% smaller than full file analysis)
-- **Edit operations** - In-file edits: overwrite, exact-block replace, AST-aware rename, before/after insert
+- **Edit operations** - In-file edits: overwrite, exact-block replace
 - **In-memory analysis** - `analyze_str` parses source text directly without a file path; returns the same `FileAnalysisOutput` as `analyze_file`
 - **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Fortran, JavaScript, C/C++, C#
 - **Pagination** - Cursor-based pagination for large outputs

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -44,16 +44,15 @@ graph TD
 | `analyze_file` | Functions with signatures, classes, imports, type references | Call graph traversal, directory walking |
 | `analyze_module` | Minimal function/import index (~75% smaller than `analyze_file`) | Signatures, types, class details, call graphs |
 | `analyze_symbol` | Call graph for a named function/method across a directory | File-level details, directory counts |
-| `analyze_raw` | Raw file content with optional line range | AST parsing, structure extraction |
 | `edit_overwrite` | Create or overwrite a file | AST awareness, incremental updates |
 | `edit_replace` | Replace exact text block in a file | AST awareness, directory-wide changes |
 | `exec_command` | Execute arbitrary shell commands | Output parsing, scripting language support, interactive sessions |
 
-*Table 1: The ten tools, their purpose, and what each intentionally excludes.*
+*Table 1: The seven tools, their purpose, and what each intentionally excludes.*
 
 ### Single Responsibility Trade-off
 
-Splitting into ten tools adds surface area (ten tool descriptions to maintain, ten output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
+Splitting into seven tools adds surface area (seven tool descriptions to maintain, seven output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
 
 ## 3. Designing for Small Models
 


### PR DESCRIPTION
## Summary

Removes stale references to three tools deleted in recent PRs. No logic changes; documentation only.

- `analyze_raw` was removed in #775
- `edit_rename` and `edit_insert` were removed in #782

The current tool surface is seven tools. Several documentation sites still said "ten" or listed `analyze_raw` explicitly.

## Changes

- `README.md`: "All ten tools emit metrics" -> "All seven tools emit metrics"
- `docs/DESIGN-GUIDE.md`: remove `analyze_raw` row from Table 1; update caption and paragraph from "ten tools/descriptions/schemas" to "seven"
- `crates/aptu-coder-core/README.md`: remove "AST-aware rename, before/after insert" from edit capabilities feature bullet

Two untracked files (`goose-tools-scout.json`, `usage-data.json`) were also updated in-place outside the commit (they are not tracked by git):

- `goose-tools-scout.json`: removed two stale `gaps_in_goose` entries referencing `edit_rename` and `edit_insert`; updated `major_difference` note
- `usage-data.json`: added `removed_tools` field so historical usage counts are contextualized

## Test plan

- [ ] `grep -rn 'analyze_raw\|edit_rename\|edit_insert' README.md docs/DESIGN-GUIDE.md crates/aptu-coder-core/README.md` returns no matches
- [ ] `grep -n 'ten tools\|All ten' README.md docs/DESIGN-GUIDE.md` returns no matches
