### PR TITLE
fix(edit): document starts_with component semantics in validate_path_in_dir

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -314,7 +314,13 @@ fn validate_path_in_dir(
         canonical_base.join(&suffix)
     };
 
-    // Verify the resolved path is within working_dir
+    // Verify the resolved path is within working_dir.
+    // PathBuf::starts_with compares path *components*, not raw bytes, so
+    // a sibling directory whose name shares our prefix (e.g. "/work_evil"
+    // when the allowed root is "/work") is correctly rejected -- this is
+    // the exact prefix-confusion vector exploited in CVE-2025-53110 against
+    // @modelcontextprotocol/server-filesystem.  Do not replace this check
+    // with a string-level prefix comparison.
     if !canonical_path.starts_with(&canonical_working_dir) {
         return Err(ErrorData::new(
             rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -4121,6 +4127,38 @@ mod tests {
             stdout_str.contains("hi"),
             "stdout should contain echo output: {}",
             stdout_str
+        );
+    }
+
+    #[test]
+    fn test_validate_path_in_dir_rejects_sibling_prefix() {
+        // Arrange: create a parent temp dir, then two subdirs:
+        //   allowed/   -- the working_dir
+        //   allowed_sibling/  -- a sibling whose name shares the prefix
+        // This mirrors CVE-2025-53110: "/work_evil" must not match "/work".
+        let cwd = std::env::current_dir().expect("should get cwd");
+        let parent = tempfile::TempDir::new_in(&cwd).expect("should create parent temp dir");
+        let allowed = parent.path().join("allowed");
+        let sibling = parent.path().join("allowed_sibling");
+        std::fs::create_dir_all(&allowed).expect("should create allowed dir");
+        std::fs::create_dir_all(&sibling).expect("should create sibling dir");
+
+        // Act: ask for a file inside the sibling dir, using a path that
+        // traverses from allowed/ into allowed_sibling/
+        let result = validate_path_in_dir("../allowed_sibling/secret.txt", false, &allowed);
+
+        // Assert: must be rejected even though "allowed_sibling" starts with "allowed"
+        assert!(
+            result.is_err(),
+            "validate_path_in_dir must reject a path resolving to a sibling directory \
+             sharing the working_dir name prefix (CVE-2025-53110 pattern)"
+        );
+        let err = result.unwrap_err();
+        let msg = err.message.to_lowercase();
+        assert!(
+            msg.contains("outside") || msg.contains("working"),
+            "Error should mention 'outside' or 'working', got: {}",
+            err.message
         );
     }
 }


### PR DESCRIPTION
## Summary

`validate_path_in_dir` uses `PathBuf::starts_with` to bound-check the resolved target path against the canonical working directory. The check is already correct -- Rust's `PathBuf::starts_with` compares path *components*, not raw bytes, so a sibling directory whose name shares the allowed-root prefix (e.g. `/work_evil` when the root is `/work`) is correctly rejected. However, this is non-obvious and undocumented, leaving future reviewers at risk of replacing it with a byte-level string comparison and silently introducing the CVE-2025-53110 prefix-confusion pattern.

This PR applies Option B from the issue: add a comment documenting the component-level semantics and CVE reference, and add a regression test for the sibling-directory scenario.

## Changes

- `crates/aptu-coder/src/lib.rs`: add explanatory comment above the `starts_with` boundary check in `validate_path_in_dir` documenting `PathBuf` component semantics and the CVE-2025-53110 reference
- `crates/aptu-coder/src/lib.rs`: add `test_validate_path_in_dir_rejects_sibling_prefix` -- constructs `allowed/` and `allowed_sibling/` inside a shared parent temp dir, then asserts that `../allowed_sibling/secret.txt` is rejected when `working_dir` is `allowed/`

No behavioral change. Zero new dependencies.

## Test plan

- [x] Tests pass: 227 tests (cargo test)
- [x] Linter clean: cargo clippy -- -D warnings
- [x] Formatter clean: cargo fmt --check
- [x] Security scan clean
- [x] Commit GPG signed and DCO signed-off

Closes #791
