### PR TITLE
chore(release): bump version to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump workspace version to 0.10.3.

## Changes

- `Cargo.toml`: version `0.10.2` -> `0.10.3`
- `Cargo.lock`: workspace version updated

## What's in 0.10.3

- Add `working_dir` parameter to `edit_overwrite` and `edit_replace` (#790)
- `exec_command`: singleflight deduplication, short-TTL cache (10s TTL, `APTU_CODER_EXEC_CACHE_TTL_SECS`), and always-persist slot files with `stdout_path`/`stderr_path` in structured content (#788)
- Document `PathBuf::starts_with` component semantics and add sibling-prefix regression test for `validate_path_in_dir` (#792)
- Remove stale references to `analyze_raw`, `edit_rename`, and `edit_insert` from documentation (#786)

## Test plan

- [ ] Tests pass (`cargo test`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
