### PR TITLE
ci: add codeql advanced setup for actions language only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (actions)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (actions)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          languages: actions
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          category: /language:actions


### PR DESCRIPTION
## Summary

Adds `codeql.yml` with `language: actions` exclusively to suppress GitHub's automatic dynamic CodeQL workflow.

The dynamic workflow (`dynamic/github-code-scanning/codeql`) kept running `Analyze (python)` and `Analyze (rust)` despite this being a Rust-only project with no explicit CodeQL setup. GitHub auto-triggers this on public repos when it detects eligible language files. The Python scan was triggered by benchmark scripts under `docs/benchmarks/`; the Rust scan added 8-15 min per run with zero value over `cargo clippy -D warnings`.

Per GitHub docs, an active advanced setup takes precedence over default setup and stops the dynamic workflow entirely.

## Changes

- `.github/workflows/codeql.yml` -- new file, 40 lines

## What this scans

- `actions` only: scans `.github/workflows/*.yml` for injection vulnerabilities (~1 min/run)
- Rust: not scanned (covered by clippy)
- Python: not scanned (benchmark scripts, not production code)

Triggered only on `.github/workflows/**` changes -- no minutes burned on Rust code pushes.

## Test plan

- [ ] PR CI passes
- [ ] After merge, dynamic `Analyze (python)` and `Analyze (rust)` jobs no longer appear in Actions
- [ ] `Analyze (actions)` job completes in under 2 minutes
