### PR TITLE
chore(deps): bump tree-sitter-rust to 0.24.2 and tree-sitter-c-sharp to 0.23.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 schemars = { version = "1", features = ["derive"] }
 tempfile = "=3.27.0"
 criterion = { version = "=0.8.2", features = ["html_reports"] }
-tree-sitter-rust = "0.24.0"
+tree-sitter-rust = "0.24.2"
 tree-sitter-go = "0.25.0"
 tree-sitter-cpp = "0.23.4"
-tree-sitter-c-sharp = "0.23.1"
+tree-sitter-c-sharp = "0.23.5"
 tree-sitter-java = "0.23.5"
 tree-sitter-python = "0.25.0"
 tree-sitter-typescript = "0.23.2"


### PR DESCRIPTION
## Summary

Patch bumps two grammar crates to their latest available versions following a full language implementation audit (session 735ea66e0487).

- `tree-sitter-rust` 0.24.0 -> 0.24.2 (patch)
- `tree-sitter-c-sharp` 0.23.1 -> 0.23.5 (minor)

All other grammar crates (`tree-sitter-go`, `tree-sitter-python`, `tree-sitter-java`, `tree-sitter-typescript`, `tree-sitter-javascript`, `tree-sitter-fortran`, `tree-sitter-cpp`) are already at their latest versions and were not touched.

## Changes

- `Cargo.toml`: version constraints updated for both crates
- `Cargo.lock`: resolved to new checksums

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` -- 460+ tests pass across all language features
- [x] `cargo clippy -- -D warnings` clean
- [x] No grammar-breaking changes: both bumps are patch/minor with no query node kind regressions
