### PR TITLE
chore(ci): fix cache collision, add coverage profile, add semver-checks timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: workspace
+          shared-key: workspace-lint
           cache-targets: false
           save-if: true
       - name: Check formatting
@@ -159,7 +159,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: workspace
+          shared-key: workspace-cov
           save-if: true
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
@@ -172,14 +172,17 @@ jobs:
       - name: Coverage
         run: |
           cargo llvm-cov nextest --no-report --all-features \
+            --cargo-profile coverage \
             --workspace \
             -E 'not binary(mcp_smoke)'
           cargo llvm-cov report -p aptu-coder-core \
+            --profile coverage \
             --fail-under-lines 90 \
             --fail-under-regions 80 \
             --lcov --output-path lcov-core.info
           # aptu-coder coverage tracked but not gated (transport/logging/metrics layer)
           cargo llvm-cov report -p aptu-coder \
+            --profile coverage \
             --lcov --output-path lcov-mcp.info || true
 
   deny:
@@ -242,6 +245,7 @@ jobs:
     # This PR renames the crate; no published or git baseline exists for aptu-coder-core yet.
     # Re-enable without continue-on-error after aptu-coder-core is first published on crates.io.
     continue-on-error: true
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,17 +172,14 @@ jobs:
       - name: Coverage
         run: |
           cargo llvm-cov nextest --no-report --all-features \
-            --cargo-profile coverage \
             --workspace \
             -E 'not binary(mcp_smoke)'
           cargo llvm-cov report -p aptu-coder-core \
-            --profile coverage \
             --fail-under-lines 90 \
             --fail-under-regions 80 \
             --lcov --output-path lcov-core.info
           # aptu-coder coverage tracked but not gated (transport/logging/metrics layer)
           cargo llvm-cov report -p aptu-coder \
-            --profile coverage \
             --lcov --output-path lcov-mcp.info || true
 
   deny:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,6 @@ codegen-units = 16
 panic = "unwind"
 strip = false
 
-[profile.coverage]
-inherits = "dev"
-codegen-units = 16
-
 [profile.fuzz]
 inherits = "dev"
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ codegen-units = 16
 panic = "unwind"
 strip = false
 
+[profile.coverage]
+inherits = "dev"
+codegen-units = 16
+
 [profile.fuzz]
 inherits = "dev"
 opt-level = 1


### PR DESCRIPTION
## Summary

Two targeted fixes to the CI workflow that improve cache hit rates and add a missing timeout. The speculative `[profile.coverage]` change was reverted before merge after analysis showed `dev` already uses `codegen-units = 256` by default, making the proposed `codegen-units = 16` strictly slower, not faster.

## Changes

**`.github/workflows/ci.yml`**
- `lint` job: change rust-cache `shared-key` from `workspace` to `workspace-lint`
- `coverage` job: change rust-cache `shared-key` from `workspace` to `workspace-cov`
- `semver-checks` job: add `timeout-minutes: 10` at the job level

## Motivation

**Cache key collision (high impact):** `lint` and `coverage` both used `shared-key: workspace` on the same runner, OS, and toolchain. They build completely different target artifacts (CI profile `opt-level=z` vs. LLVM-instrumented dev). Whichever job saves last overwrites the cache entry the other job needed, making both jobs effectively cold on every run. Separate keys fix this.

**Semver-checks timeout (minor):** Without a timeout, a slow crates.io API response could stall `ci-result` indefinitely. The `continue-on-error: true` guard only helps after the job completes, not while it is waiting.

## What was considered and rejected

A `[profile.coverage]` Cargo profile with `codegen-units = 16` was proposed as a coverage speed improvement. It was reverted: `cargo llvm-cov` uses the `dev` profile by default, which already sets `codegen-units = 256`. Overriding to 16 would reduce parallelism and slow compilation. There is no faster-than-dev profile that is safe for instrumented coverage builds.

## Test plan

- [x] CI green on final commit
- [x] No action SHA pins modified
- [x] No job dependencies (`needs:`) changed
- [x] `ci-result` `needs:` array unchanged
- [x] GPG signed, DCO signed-off
