### PR TITLE
chore(release): bump version to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bumps workspace version to 0.10.4 to ship Kotlin language support and missing call-graph handler implementations across Go, Java, C#, and JavaScript.

## Changes

- `Cargo.toml` -- version bumped from 0.10.3 to 0.10.4
- `Cargo.lock` -- lock file regenerated

## Test plan

- [ ] CI passes (all tests, clippy, fmt)
- [ ] `cargo build` confirms 0.10.4 compiles cleanly
