### PR TITLE
fix(exec_command): remove premature rx.close() that dropped all output

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2873,7 +2873,6 @@ async fn run_exec_impl(
         }
     };
 
-    rx.close();
     let mut lines: Vec<(bool, String)> = Vec::new();
     while let Some(item) = rx.recv().await {
         lines.push(item);


### PR DESCRIPTION
## Summary

PR #804 refactored `run_exec_impl` to collect output via an mpsc channel instead of `Arc<TokioMutex<String>>` accumulators. The drain task holds `tx` and sends lines into the channel; the caller drains `rx` after the `select!` block. PR #804 introduced `rx.close()` immediately after `select!`.

## Hazard removed

On the normal path, `select!` fires when `drain_task` completes -- `tx` is already dropped and all lines are buffered before `rx.close()` is called. `rx.close()` does not discard buffered messages, so there is no data loss on the normal path.

On the timeout path, however, `drain_task.abort()` cancels the task at the next tokio yield point -- it does not synchronously drop `tx`. Between `abort()` and `rx.close()`, the drain task may still hold `tx` and have pending sends. `rx.close()` would cause those sends to return `Err`, silently dropping any output that arrived between the kill signal and task cancellation.

The `rx.close()` call was redundant in all cases (EOF is signaled naturally when `tx` drops) and introduced a genuine data-loss hazard on the timeout path.

## What this does not fix

The `-32603: Transport closed` failures observed in sessions 20260509_56 and 20260509_58 were caused by a separate issue: `tracing_subscriber::fmt::layer()` writing tracing output to stdout, which corrupts the JSON-RPC stream. That is addressed in PR #808.

## Changes

- `crates/aptu-coder/src/lib.rs`: remove the single `rx.close()` call introduced by #804

## Test plan

- [x] Tests pass (`cargo test`: 468 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)

## Related

Introduced by #804. PR #808 fixes the actual transport crash observed in production.
