### PR TITLE
fix(server): redirect tracing fmt layer from stdout to stderr

### DIFF
--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build layered subscriber: fmt + MCP logging
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .with(mcp_logging_layer)
         .init();
 


### PR DESCRIPTION
## Summary

The MCP transport uses newline-delimited JSON over stdio. `tracing_subscriber::fmt::layer()` defaults to writing to stdout. Any tracing event at WARN or higher during startup writes a non-JSON line to stdout, which rmcp fails to parse and immediately closes the transport:

```
Error reading from stream: serde error expected value at line 1 column 1
```

Every subsequent tool call then returns `-32603: Transport closed`.

## Root cause

`migrate_legacy_metrics_dir()` fires `tracing::warn!("Both legacy and new metrics directories exist; not migrating")` when both `~/.local/share/goose-coder` (legacy) and `~/.local/share/aptu-coder` (new) exist. This condition existed on machines that ran the server before and after the project rename. The warn wrote a non-JSON line to stdout, killing the transport before the first tool call completed.

This was observed in session 20260509_56 (and diagnosed via the Goose log at 16:19:17 showing the serde parse error). It was not caused by PR #804.

## Changes

`crates/aptu-coder/src/main.rs`: add `.with_writer(std::io::stderr)` to the `fmt::layer()` call. All tracing output now goes to stderr, which MCP clients do not read.

## Test plan

- [x] `cargo test`: all tests pass
- [x] `cargo clippy -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] Manual smoke test: binary starts, `exec_command("echo alive")` returns `stdout: "alive\n"` with no transport error
