### PR TITLE
feat(lang): wire Kotlin extract_function_name, find_receiver_type, find_method_for_receiver handlers

### DIFF
--- a/crates/aptu-coder-core/src/languages/kotlin.rs
+++ b/crates/aptu-coder-core/src/languages/kotlin.rs
@@ -84,10 +84,91 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
+/// Extract the function name from a Kotlin `function_declaration` node.
+#[must_use]
+pub fn extract_function_name(node: &Node, source: &str, _lang: &str) -> Option<String> {
+    if node.kind() != "function_declaration" {
+        return None;
+    }
+    node.child_by_field_name("name")
+        .and_then(|n| get_node_text(&n, source))
+}
+
+/// Find the receiver type (enclosing class or object) for a Kotlin function.
+///
+/// Returns `None` for top-level functions (including extension functions) and
+/// functions whose only enclosing type is a `companion_object`.
+#[must_use]
+pub fn find_receiver_type(node: &Node, source: &str) -> Option<String> {
+    if node.kind() != "function_declaration" {
+        return None;
+    }
+    let mut current = *node;
+    while let Some(parent) = current.parent() {
+        match parent.kind() {
+            "class_declaration" | "object_declaration" => {
+                return parent
+                    .child_by_field_name("name")
+                    .and_then(|n| get_node_text(&n, source));
+            }
+            _ => {
+                current = parent;
+            }
+        }
+    }
+    None
+}
+
+/// Find the method name when a function lives inside a named type body.
+///
+/// Returns `None` for top-level functions and functions inside `companion_object`
+/// that have no enclosing `class_declaration` or `object_declaration`.
+#[must_use]
+pub fn find_method_for_receiver(
+    node: &Node,
+    source: &str,
+    _depth: Option<usize>,
+) -> Option<String> {
+    if node.kind() != "function_declaration" {
+        return None;
+    }
+    let mut current = *node;
+    let mut in_type_body = false;
+    while let Some(parent) = current.parent() {
+        match parent.kind() {
+            "class_declaration" | "object_declaration" => {
+                in_type_body = true;
+                break;
+            }
+            _ => {
+                current = parent;
+            }
+        }
+    }
+    if !in_type_body {
+        return None;
+    }
+    node.child_by_field_name("name")
+        .and_then(|n| get_node_text(&n, source))
+}
+
 #[cfg(all(test, feature = "lang-kotlin"))]
 mod tests {
     use super::*;
     use tree_sitter::{Parser, StreamingIterator};
+
+    fn find_node<'a>(root: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+        if root.kind() == kind {
+            return Some(root);
+        }
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor) {
+            if let Some(n) = find_node(child, kind) {
+                return Some(n);
+            }
+        }
+        None
+    }
 
     fn parse_kotlin(src: &str) -> tree_sitter::Tree {
         let mut parser = Parser::new();
@@ -382,5 +463,82 @@ mod tests {
             "expected implements Comparable, got {:?}",
             bases
         );
+    }
+
+    #[test]
+    fn test_extract_function_name_free_function() {
+        let src = "fun greet() {}";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let node = find_node(root, "function_declaration").expect("function_declaration not found");
+        let result = extract_function_name(&node, src, "kotlin");
+        assert_eq!(result, Some("greet".to_string()));
+    }
+
+    #[test]
+    fn test_extract_function_name_method_in_class() {
+        let src = "class Foo { fun bar() {} }";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        // find the inner function_declaration (bar), not the class
+        let class_node = find_node(root, "class_declaration").expect("class_declaration not found");
+        let node =
+            find_node(class_node, "function_declaration").expect("function_declaration not found");
+        let result = extract_function_name(&node, src, "kotlin");
+        assert_eq!(result, Some("bar".to_string()));
+    }
+
+    #[test]
+    fn test_find_receiver_type_top_level_returns_none() {
+        let src = "fun greet() {}";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let node = find_node(root, "function_declaration").expect("function_declaration not found");
+        let result = find_receiver_type(&node, src);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_receiver_type_method_in_class() {
+        let src = "class Foo { fun bar() {} }";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let class_node = find_node(root, "class_declaration").expect("class_declaration not found");
+        let node =
+            find_node(class_node, "function_declaration").expect("function_declaration not found");
+        let result = find_receiver_type(&node, src);
+        assert_eq!(result, Some("Foo".to_string()));
+    }
+
+    #[test]
+    fn test_find_receiver_type_extension_function_returns_none() {
+        let src = "fun String.greet() {}";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let node = find_node(root, "function_declaration").expect("function_declaration not found");
+        let result = find_receiver_type(&node, src);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_method_for_receiver_top_level_returns_none() {
+        let src = "fun greet() {}";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let node = find_node(root, "function_declaration").expect("function_declaration not found");
+        let result = find_method_for_receiver(&node, src, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_method_for_receiver_method_in_class() {
+        let src = "class Foo { fun bar() {} }";
+        let tree = parse_kotlin(src);
+        let root = tree.root_node();
+        let class_node = find_node(root, "class_declaration").expect("class_declaration not found");
+        let node =
+            find_node(class_node, "function_declaration").expect("function_declaration not found");
+        let result = find_method_for_receiver(&node, src, None);
+        assert_eq!(result, Some("bar".to_string()));
     }
 }

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -199,9 +199,9 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             impl_query: None,
             impl_trait_query: None,
             defuse_query: Some(kotlin::DEFUSE_QUERY),
-            extract_function_name: None,
-            find_method_for_receiver: None,
-            find_receiver_type: None,
+            extract_function_name: Some(kotlin::extract_function_name),
+            find_method_for_receiver: Some(kotlin::find_method_for_receiver),
+            find_receiver_type: Some(kotlin::find_receiver_type),
             extract_inheritance: Some(kotlin::extract_inheritance),
         }),
         #[cfg(feature = "lang-fortran")]


### PR DESCRIPTION
## Summary

Wires the three call graph handler functions for Kotlin that were deferred to `None` in #649 (PR #800). Without these handlers, `analyze_symbol` call graph mode returns all callers of a symbol name across all types rather than pruning by receiver, producing larger, noisier results and higher token cost per call.

## Changes

- `crates/aptu-coder-core/src/languages/kotlin.rs`: add `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver`, modelled on the proven `java.rs` pattern from PR #799; add `find_node` test helper and seven unit tests covering all AC items
- `crates/aptu-coder-core/src/languages/mod.rs`: replace the three `None` placeholders in the `"kotlin"` arm of `get_language_info()` with `Some(kotlin::extract_function_name)`, `Some(kotlin::find_receiver_type)`, `Some(kotlin::find_method_for_receiver)`

## Implementation notes

`_receiver_type` is a hidden grammar rule in tree-sitter-kotlin-ng 1.1.0, not a named field on `function_declaration` (only `name` is a named field per `node-types.json`). Extension functions at the top level have no enclosing `class_declaration` or `object_declaration`, so the ancestor walk naturally returns `None` without any special field check. `interface` and `enum class` both parse as `class_declaration` in this grammar, so a single match arm covers all three Kotlin constructs. `companion_object` is skipped in ancestor walks by falling through to the `_` arm.

## Test plan

- [x] `cargo test --features lang-kotlin -p aptu-coder-core` -- 214 passed, 0 failed
- [x] `cargo clippy --features lang-kotlin -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] Security scan -- 0 findings
- [x] 178 lines added across 2 files -- within 500-line budget

Closes #801
