### PR TITLE
docs: update all markdown for Kotlin, ARM runners, env vars, profile system

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,8 @@ Flag:
 - rmcp, tree-sitter, schemars version assumptions; verify against installed versions
 - Missing `cargo deny check advisories licenses` run when `Cargo.toml` changes
 - New dependency added without justification in the PR description
+- `working_dir` outside the server CWD boundary accepted without error (must be rejected with INVALID_PARAMS)
+- Profile-based tool routing (`APTU_CODER_PROFILE` / `io.clouatre-labs/profile`) bypassed or ignored in tools/list
 - `gh release create` used instead of `git tag -s vX.Y.Z -m "vX.Y.Z"`
 - Tool descriptions or server instructions reference host-specific clients (e.g. "Claude Code", "Cursor")
 - Commit missing GPG signature or DCO sign-off (`-S --signoff`)

--- a/.github/instructions/src-languages.instructions.md
+++ b/.github/instructions/src-languages.instructions.md
@@ -29,3 +29,7 @@ Flag handler functions with signatures that deviate from these types.
 ## Optional fields
 
 `reference_query`, `import_query`, `impl_query`, `impl_trait_query` are `Option<&'static str>`. Use `None` for languages that do not support the concept. Flag `Some("")` (empty string) as a substitute for `None`.
+
+## Kotlin-specific notes
+
+Kotlin registers two extensions: `.kt` (source) and `.kts` (script). Both map to the same `LanguageInfo` entry. When writing Kotlin tree-sitter queries, note that `.kts` files may contain top-level expressions that `.kt` source files do not; queries should not assume a class or object wrapper is always present.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Rust workspace with two crates:
 Seven MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family).
 Rust edition 2024, async with tokio, MCP protocol via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
 
+## CI runners
+
+All CI jobs run on `ubuntu-24.04-arm` (ARM64). Build, test, lint, and release jobs all target this image.
+
 ## Commands
 
 ```
@@ -50,6 +54,8 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `import_lookup=true` on `analyze_symbol` requires a non-empty `symbol` (the module path to search for); returns INVALID_PARAMS if symbol is empty. Mutually exclusive with normal call-graph lookup.
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
+- `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution; must be within the server CWD.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools; `analyze` disables edit_replace and edit_overwrite.
 
 ## Do not
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AeroDyn integration audit task on Claude Code against [OpenFAST](https://github.
 
 ## Overview
 
-aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports Rust, Python, Go, Java, TypeScript, TSX, Fortran, JavaScript, C/C++, and C#, and integrates with any MCP-compatible orchestrator.
+aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports Rust, Python, Go, Java, Kotlin, TypeScript, TSX, Fortran, JavaScript, C/C++, and C#, and integrates with any MCP-compatible orchestrator.
 
 ## Supported Languages
 
@@ -49,6 +49,7 @@ All languages are enabled by default. Disable individual languages at compile ti
 | TSX | `.tsx` | `lang-tsx` |
 | Go | `.go` | `lang-go` |
 | Java | `.java` | `lang-java` |
+| Kotlin | `.kt`, `.kts` | `lang-kotlin` |
 | Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | `lang-fortran` |
 | JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
 | C | `.c` | `lang-cpp` |
@@ -193,6 +194,11 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `CODE_ANALYZE_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
 | `DISABLE_PROMPT_CACHING` | unset | Set to `1` to disable prompt caching (recommended for single-pass subagent sessions). |
 | `DISABLE_PROMPT_CACHING_HAIKU` | unset | Set to `1` to disable prompt caching for Haiku-specific pipelines only. |
+| `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
+| `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
+| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
+| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
+| `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
 
 ## Observability
 

--- a/crates/aptu-coder-core/README.md
+++ b/crates/aptu-coder-core/README.md
@@ -19,7 +19,7 @@ Core library for code structure analysis using tree-sitter.
 - **Module index** - Lightweight function and import index (~75% smaller than full file analysis)
 - **Edit operations** - In-file edits: overwrite, exact-block replace
 - **In-memory analysis** - `analyze_str` parses source text directly without a file path; returns the same `FileAnalysisOutput` as `analyze_file`
-- **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Fortran, JavaScript, C/C++, C#
+- **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Kotlin, Fortran, JavaScript, C/C++, C#
 - **Pagination** - Cursor-based pagination for large outputs
 - **Caching** - LRU cache for parsed results with mtime-based invalidation
 - **Parallel** - Rayon-based parallel file analysis
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Supported Languages
 
-Rust, Python, TypeScript, TSX, Go, Java, Fortran, JavaScript, C/C++, C#. See the [MCP server README](https://github.com/clouatre-labs/aptu-coder/blob/main/README.md#supported-languages) for the full table with file extensions and feature flags.
+Rust, Python, TypeScript, TSX, Go, Java, Kotlin, Fortran, JavaScript, C/C++, C#. See the [MCP server README](https://github.com/clouatre-labs/aptu-coder/blob/main/README.md#supported-languages) for the full table with file extensions and feature flags.
 
 ## Configuration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@
 ## Design Goals
 
 - **Minimize token usage**: Return only structured, relevant context - no prose, no noise
-- **Language-agnostic parsing via tree-sitter**: Support 11 languages (Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C, C++, C#) with a unified query-based extraction system; TypeScript and TSX use distinct grammars (`LANGUAGE_TYPESCRIPT` and `LANGUAGE_TSX`) but share the same queries in `crates/aptu-coder-core/src/languages/typescript.rs`
+- **Language-agnostic parsing via tree-sitter**: Support 12 languages (Rust, Go, Java, Kotlin, Python, TypeScript, TSX, Fortran, JavaScript, C, C++, C#) with a unified query-based extraction system; TypeScript and TSX use distinct grammars (`LANGUAGE_TYPESCRIPT` and `LANGUAGE_TSX`) but share the same queries in `crates/aptu-coder-core/src/languages/typescript.rs`
 - **Seven focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
 - **Compatible with any MCP orchestrator**: Designed to work with any standards-compliant MCP host
 - **Performance via parallelism**: Use rayon for parallel file processing and ignore crate for efficient .gitignore-aware directory walking
@@ -34,6 +34,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
 | `languages/mod` | `crates/aptu-coder-core/src/languages/mod.rs` | LanguageInfo registry and handler function types |
 | `languages/rust` | `crates/aptu-coder-core/src/languages/rust.rs` | Rust-specific queries and semantic handlers |
+| `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
 | `cache` | `crates/aptu-coder-core/src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
 | `test_detection` | `crates/aptu-coder-core/src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |

--- a/docs/REPO-STANDARDS.md
+++ b/docs/REPO-STANDARDS.md
@@ -23,7 +23,7 @@ This document maps every repo-level artifact to its purpose and the rationale be
 | `Cargo.toml` `[profile.release]` | `opt-level=z`, `lto=true`, `codegen-units=1`, `panic=abort`, `strip=true` for minimal distribution binaries |
 | `Cargo.toml` `[profile.ci]` | Inherits release; `lto=false`, `codegen-units=16` for faster CI builds without sacrificing correctness |
 | `.github/workflows/ci.yml` permissions block | Top-level `permissions:` block on every workflow. Use `contents: read` + `pull-requests: read` for CI workflows; set the minimum required permissions per job, noting that jobs using `actions/checkout` need at least `contents: read`. Required even after the org default was flipped to `read` on 2026-03-25, as defence in depth. |
-| Runner pin (`ubuntu-24.04`) | Pin every job to `ubuntu-24.04` rather than `ubuntu-latest`. `ubuntu-latest` resolves to the newest image mid-cycle and can silently change toolchain versions between runs. |
+| Runner pin (`ubuntu-24.04-arm`) | Pin every job to `ubuntu-24.04-arm` rather than `ubuntu-latest`. `ubuntu-latest` resolves to the newest image mid-cycle and can silently change toolchain versions between runs. |
 
 *Table 1: Repository artifact map and purpose of each file.*
 
@@ -37,7 +37,7 @@ This document maps every repo-level artifact to its purpose and the rationale be
 # CI Result aggregator job -- list every job in 'needs'
 ci-result:
   name: CI Result
-  runs-on: ubuntu-24.04
+  runs-on: ubuntu-24.04-arm
   if: always()
   needs: [changes, commitlint, check-base, format, lint, test, deny, msrv, renovate-check, zizmor]
   steps:
@@ -54,7 +54,7 @@ ci-result:
 
 **Provenance attestation.** `build-and-attest.yml` generates a signed attestation via `actions/attest-build-provenance`. Consumers can verify with `gh attestation verify` before installing. `Cargo.lock` is committed and `cargo deny` enforces license and advisory checks in CI. Build provenance is covered by cosign signing and `actions/attest-build-provenance` (SLSA Build L3).
 
-**Runner pinning to ubuntu-24.04.** `ubuntu-latest` is a moving alias; GitHub advances it to the next LTS image with short notice. Pinning to a specific image (`ubuntu-24.04`) makes toolchain changes explicit and reviewable rather than silent. Renovate keeps the pin current via automated PRs.
+**Runner pinning to ubuntu-24.04-arm.** `ubuntu-latest` is a moving alias; GitHub advances it to the next LTS image with short notice. Pinning to a specific image (`ubuntu-24.04-arm`) makes toolchain changes explicit and reviewable rather than silent. Renovate keeps the pin current via automated PRs.
 
 **Cognitive complexity threshold.** `clippy::cognitive_complexity` is enforced at a threshold of 30 (set in `clippy.toml`); `-D warnings` promotes violations to hard errors in CI. When a function legitimately exceeds the threshold and splitting it would reduce clarity rather than improve it, suppress with an attribute and a mandatory `reason` field:
 
@@ -74,7 +74,7 @@ Do not raise the global threshold to accommodate a single outlier. The `reason` 
 
 1. **GitHub metadata:** Set topics, copy the 11-label taxonomy (names, colors, descriptions), create the two rulesets.
 2. **Templates:** Copy all three issue templates and the PR template; adapt wording to the target domain.
-3. **CI:** Copy `ci.yml`; update path filters; pin runner to `ubuntu-24.04` on every job; add a top-level `permissions` block with `contents: read` and `pull-requests: read`; pass `--profile ci` on `cargo clippy` (not `cargo test`). Set `CI Result` as the sole required status check in the branch ruleset. Copy `.commitlintrc.yml`.
+3. **CI:** Copy `ci.yml`; update path filters; pin runner to `ubuntu-24.04-arm` on every job; add a top-level `permissions` block with `contents: read` and `pull-requests: read`; pass `--profile ci` on `cargo clippy` (not `cargo test`). Set `CI Result` as the sole required status check in the branch ruleset. Copy `.commitlintrc.yml`.
 4. **Release:** Copy `build-and-attest.yml` and `release.yml`; update distribution channel config.
 5. **Cargo profiles:** Copy the `[profile.release]` and `[profile.ci]` blocks verbatim.
 6. **Docs:** Add `ARCHITECTURE.md` for the target repo; link this document and the orchestration guide from README.
@@ -284,7 +284,7 @@ on:
     tags: ["v*.*.*"]
 jobs:
   publish:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     environment: publish
     permissions:
       id-token: write  # required to request an OIDC token

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Wave History
 
 ### [Complete] Wave 1: Core Analysis
-Initial release. Four tools (`analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`), seven languages (Rust, Go, Java, Python, TypeScript, TSX, Fortran), tree-sitter AST extraction, rayon parallelism, .gitignore-aware walk via `ignore` crate. (language support has since grown to 11; see [Supported Languages](../README.md))
+Initial release. Four tools (`analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`), seven languages (Rust, Go, Java, Python, TypeScript, TSX, Fortran), tree-sitter AST extraction, rayon parallelism, .gitignore-aware walk via `ignore` crate. (language support has since grown to 12; see [Supported Languages](../README.md))
 
 ### [Complete] Wave 2: MCP Protocol (milestone 7)
 Summary-first output, `outputSchema` per tool, cursor pagination.


### PR DESCRIPTION
## Summary

Updates all markdown documentation to reflect recent changes: Kotlin as the 12th fully-wired language, ARM64 CI runners, removed tools (`analyze_raw`, `edit_rename`, `edit_insert`), the `working_dir` parameter on edit tools, five new environment variables, and the profile-based tool filtering system. No source code changes.

## Changes

- **README.md** -- Added Kotlin row to Supported Languages table; updated Overview sentence; added `APTU_SHELL`, `APTU_CODER_PROFILE`, `APTU_CODER_EXEC_CACHE_TTL_SECS`, `APTU_CODER_EXEC_CACHE_CAPACITY`, `APTU_CODER_METRICS_EXPORT_FILE` to Environment Variables table
- **AGENTS.md** -- Added `## CI runners` section noting `ubuntu-24.04-arm`; added `working_dir` and profile system notes to Tool parameters section
- **docs/ARCHITECTURE.md** -- Updated language count from 11 to 12; added Kotlin to Design Goals language list; added `languages/kotlin` row to Module Map
- **docs/ROADMAP.md** -- Updated Wave 1 language count note from 11 to 12
- **docs/REPO-STANDARDS.md** -- Updated all runner image references from `ubuntu-24.04` to `ubuntu-24.04-arm` (table row, two YAML examples, prose paragraph, Applying to New Repo step)
- **crates/aptu-coder-core/README.md** -- Added Kotlin to Multi-language feature bullet and Supported Languages note
- **.github/copilot-instructions.md** -- Added `working_dir` boundary and profile-based tool routing flags to the code review checklist
- **.github/instructions/src-languages.instructions.md** -- Added Kotlin-specific notes section (`.kt`/`.kts` dual-extension, top-level expression caveat for `.kts`)

## Test plan

- [x] No stale "11 language" references remain in user-facing docs
- [x] No references to removed tools (`analyze_raw`, `edit_rename`, `edit_insert`) in user-facing docs
- [x] All `runs-on:` lines in REPO-STANDARDS.md use `ubuntu-24.04-arm`
- [x] All 5 new env vars present in README table
- [x] Diff is `.md` files only -- no source code changes
- [x] Security scan clean (no secrets or credentials)
