### PR TITLE
chore(release): bump version to 0.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump version to 0.10.5.

## Changes

- `Cargo.toml`: version `0.10.4` → `0.10.5`
- `Cargo.lock`: updated accordingly

## Release notes (to be tagged after merge)

### Features

- **Kotlin call-graph handlers**: `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` are now wired for Kotlin, closing the receiver-pruning gap introduced in #800; extension functions, companion objects, interfaces, and enum classes are handled correctly via the tree-sitter-kotlin-ng grammar (#809)

### Bug Fixes

- **exec_command output loss on timeout**: removed premature `rx.close()` introduced in #804 that could silently discard buffered output lines when a command timed out and the drain task had not yet dropped its sender (#806)
- **Transport crash on startup warning**: tracing output now goes to stderr instead of stdout, preventing `tracing::warn!` lines from corrupting the newline-delimited JSON-RPC stream and triggering `-32603: Transport closed` errors on clients that ran the server before and after the project rename (#808)

### Performance

- **exec_command pipeline simplified**: removed the unconditional 5-second progress-bar task, replaced three `Arc<Mutex<String>>` accumulators locked per output line with a single unbounded channel drained post-exit, and made slot-file writes conditional on overflow (>2 000 lines) instead of always writing on every invocation (#804)

**Full Changelog:** https://github.com/clouatre-labs/aptu-coder/compare/v0.10.4...v0.10.5
