### PR TITLE
docs: add ROADMAP.md, OBSERVABILITY.md, and PR template span attribute guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,5 @@ Example: "Add Python language support to the analyzer. Implements Overview and F
 - [ ] DCO signed-off: `git commit --signoff`
 - [ ] No scope creep (changes match assigned issue)
 - [ ] No secrets, API keys, or credentials in diff
+- [ ] New span attributes comply with the never-record policy in [OBSERVABILITY.md](../OBSERVABILITY.md) (no command strings, file content, or free-form user input)
 - [ ] I have reviewed every line in this PR and can explain it

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,127 @@
+# Observability
+
+This document defines the observability contract for aptu-coder: what is instrumented,
+what is deliberately excluded, and how to configure telemetry export.
+
+## Span attribute policy
+
+### Always record (bounded, no secrets possible)
+
+These values are safe to record as span attributes and appear in all tool spans.
+
+| Attribute | Type | Source |
+|---|---|---|
+| `gen_ai.system` | `"mcp"` | constant |
+| `gen_ai.operation.name` | `"execute_tool"` | constant |
+| `gen_ai.tool.name` | tool name string | constant per handler |
+| `service.name` | `"aptu-coder"` | `env!("CARGO_PKG_VERSION")` at init |
+| `service.version` | semver string | `env!("CARGO_PKG_VERSION")` at init |
+| `path` | filesystem path | analyze/edit params |
+| `symbol` | symbol name | `analyze_symbol` param |
+| `follow_depth`, `max_depth` | integers | analyze params |
+| `match_mode`, `impl_only`, `import_lookup` | bounded enums/bools | analyze params |
+| `summary`, `git_ref` | bool/optional string | analyze params |
+| `working_dir` | filesystem path | exec_command param |
+| `exit_code` | integer | exec_command result |
+| `timed_out`, `output_truncated` | booleans | exec_command result |
+| `error` | boolean | error paths |
+| `error.type` | error category string | error paths |
+| `cache_hit`, `auto_summary`, `truncated` | booleans | span events |
+
+### Never record
+
+These values must not appear as span attributes, span events, or log fields emitted
+by the server under any configuration, including debug level.
+
+| Value | Reason |
+|---|---|
+| `command` string (exec_command param) | May contain env vars, tokens, passwords, API keys inline |
+| `stdin` content | Explicit user data piped into a process |
+| stdout / stderr content | Returned to client by design; duplicating into spans leaks content to observability backends |
+| `content` (edit_overwrite param) | Arbitrary file content supplied by user |
+| `old_text`, `new_text` (edit_replace params) | Arbitrary file content supplied by user |
+| `gen_ai.tool.call.arguments` as a serialized blob | Captures all parameters including any that may contain secrets |
+| `gen_ai.tool.call.result` as a serialized blob | Captures full tool output |
+
+The OTel GenAI semantic conventions mark `gen_ai.tool.call.arguments` and
+`gen_ai.tool.call.result` as likely to contain sensitive information. The spec
+requires them to be opt-in, gated on
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`. aptu-coder does not
+implement this opt-in: individual bounded parameters (path, symbol, depth) are
+recorded instead of serializing the full argument object.
+
+### PR review checklist
+
+When adding or modifying span attributes, confirm:
+
+- [ ] The value is bounded (enum, integer, boolean, or a path the user explicitly passed as a tool parameter)
+- [ ] The value cannot contain user-supplied free-form content (file content, command output, stdin)
+- [ ] The value cannot contain credentials (tokens, passwords, API keys)
+- [ ] If the value is a string, it has bounded cardinality suitable for use as a metric label
+
+## Enabling telemetry export
+
+By default, no telemetry is exported. The tracing subscriber operates in noop mode
+with zero export overhead.
+
+To export traces via OTLP:
+
+```sh
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 aptu-coder
+```
+
+When this variable is set, spans are exported asynchronously via `BatchSpanProcessor`.
+There is no latency impact on tool call handling.
+
+### Collector-side redaction (recommended for production)
+
+Even with the never-record policy above, deploy an OTel Collector redaction processor
+as a backstop for any future regressions:
+
+```yaml
+processors:
+  redaction:
+    allow_all_keys: true
+    blocked_values:
+      # AWS access keys
+      - "((?:A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})"
+      # GitHub tokens
+      - "(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}"
+      # Bearer tokens
+      - "Bearer [A-Za-z0-9\\-._~+/]+=*"
+      # Generic 32+ char hex secrets
+      - "[0-9a-f]{32,}"
+```
+
+This is a deployment concern, not a codebase change. The SDK-level never-record
+policy is the primary control; the Collector processor is the safety net.
+
+## Log level and MCP client visibility
+
+Logs are forwarded to the MCP client (the calling agent) via the `notifications/message`
+protocol. The default log level forwarded to the client is WARN.
+
+At DEBUG level, some log events include filesystem paths (from cache and analysis
+operations). These are not secrets, but they do reveal filesystem structure including
+home directory paths. Do not set DEBUG level in contexts where log content is stored
+in untrusted systems.
+
+To change the log level at runtime, use the MCP `logging/setLevel` RPC.
+
+## Span events for behavioral decisions
+
+The following decisions are recorded as span events (not attributes) when they occur.
+They carry no value payload, only their occurrence:
+
+| Event | Meaning |
+|---|---|
+| `auto_summary` | Response was auto-summarized due to size |
+| `cache_hit` | Result was served from in-process cache |
+| `truncated` | Output was truncated to fit size limit |
+
+## References
+
+- [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status)
+- [OTel MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)
+- [OTel Collector redaction processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)
+- Observability roadmap: [ROADMAP.md](ROADMAP.md), milestone `observability-v1`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,14 +25,17 @@ This document captures planned work and its rationale. Issues are the authoritat
 
 **Issues (in dependency order):**
 
+Span attribute policy: [OBSERVABILITY.md](OBSERVABILITY.md). Every PR adding span attributes must comply with the never-record list defined there. The policy issue (#820) is a prerequisite for all attribute enrichment work.
+
 | Issue | Title | Tier | Depends on |
 |---|---|---|---|
-| #812 | enrich tool spans with GenAI semantic attributes and error recording | 1 | - |
-| #813 | emit behavioral decisions as span events | 1 | - |
+| #820 | define span attribute policy and never-record list | 0 (prerequisite) | - |
+| #812 | enrich tool spans with GenAI semantic attributes and error recording | 1 | #820 |
+| #813 | emit behavioral decisions as span events | 1 | #820 |
 | #814 | add tracing-opentelemetry bridge with conditional OTLP export | 2 (keystone) | - |
-| #815 | add log-trace correlation via opentelemetry-appender-tracing | 2 | #814 |
-| #816 | extract W3C Trace Context from MCP params._meta | 2 | #814 |
-| #817 | add child spans for sub-operations in analyze_symbol and analyze_directory | 3 | #814 |
+| #815 | add log-trace correlation via opentelemetry-appender-tracing | 2 | #814, #820 |
+| #816 | extract W3C Trace Context from MCP params._meta | 2 | #814, #820 |
+| #817 | add child spans for sub-operations in analyze_symbol and analyze_directory | 3 | #814, #820 |
 | #818 | migrate JSONL metrics to OTel Metrics SDK | 3 | #814 |
 
 **Spec reference:** [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status, May 2026), [MCP-specific OTel conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,65 @@
+# Roadmap
+
+This document captures planned work and its rationale. Issues are the authoritative source of truth for scope and status; this file provides the strategic narrative.
+
+## Active milestones
+
+### observability-v1
+
+**Goal:** Replace benchmark waves as the primary tool for runtime performance investigation. Give contributors and users the ability to answer "what happened and why" without grepping session logs.
+
+**Background:** aptu-coder uses the `tracing` crate throughout, but spans carry zero semantic attributes and are never exported. The custom JSONL metrics system records `duration_ms` and `error_type` per tool call but these are file-local, not correlated with spans or logs, and not queryable across sessions. When a tool call fails or performs unexpectedly in production, the only recourse is to dig through goose or Claude session logs -- a slow, manual process.
+
+**What changes:**
+
+- All 7 tool handlers gain GenAI semantic convention attributes (`gen_ai.operation.name`, `gen_ai.tool.name`, `gen_ai.system`) and key parameters as span fields, so any span is fully self-describing.
+- Behavioral decisions (`auto_summary`, `cache_hit`, `truncated`) become span events, making them queryable without touching log files.
+- Error recording lands on spans: error type, status, and exception events at every error return path.
+- A `tracing-opentelemetry` bridge wires the existing `#[instrument]` spans to OTLP export, gated on `OTEL_EXPORTER_OTLP_ENDPOINT`. When the variable is unset (the default), overhead is zero: spans are created but never exported. When set, a `BatchSpanProcessor` handles export asynchronously with no hot-path latency.
+- `opentelemetry-appender-tracing` forwards log events as OTel `LogRecord`s, injecting `trace_id` and `span_id` automatically. Every `info!` and `error!` callsite gains trace correlation without code changes.
+- W3C Trace Context is extracted from MCP `params._meta` (`traceparent`, `tracestate`) and used as the parent span context, connecting tool spans to the calling agent's trace (goose session, Claude turn).
+- Child spans for sub-operations inside `analyze_symbol` and `analyze_directory` (parse, AST query, call graph traversal, pagination, formatting) expose P95 breakdowns by sub-operation from real traffic.
+- JSONL metrics migrate to the OTel Metrics SDK, emitting `mcp.server.operation.duration` (the standard MCP histogram) and per-tool counters. The JSONL writer is retained as a local-dev fallback.
+
+**Performance commitment:** zero overhead when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset. Span creation with a noop provider costs ~6.6 µs; for a tool call taking tens of milliseconds this is irrelevant. All export is asynchronous (BatchSpanProcessor, background thread). Benchmarks must not regress.
+
+**Issues (in dependency order):**
+
+| Issue | Title | Tier | Depends on |
+|---|---|---|---|
+| #812 | enrich tool spans with GenAI semantic attributes and error recording | 1 | - |
+| #813 | emit behavioral decisions as span events | 1 | - |
+| #814 | add tracing-opentelemetry bridge with conditional OTLP export | 2 (keystone) | - |
+| #815 | add log-trace correlation via opentelemetry-appender-tracing | 2 | #814 |
+| #816 | extract W3C Trace Context from MCP params._meta | 2 | #814 |
+| #817 | add child spans for sub-operations in analyze_symbol and analyze_directory | 3 | #814 |
+| #818 | migrate JSONL metrics to OTel Metrics SDK | 3 | #814 |
+
+**Spec reference:** [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status, May 2026), [MCP-specific OTel conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/).
+
+---
+
+### openssf-gold
+
+Track criteria needed to achieve the OpenSSF Best Practices Gold badge (project 12275). See milestone for individual issues.
+
+### wave-9
+
+Editing tools: five MCP tools (`read_file`, `write_file`, `edit_file`, `rename_symbol`, `insert_at_symbol`) completing the read-analyze-write loop. Phase 1 (mechanical, no AST) then Phase 2 (AST-backed). Closes with a benchmark.
+
+---
+
+## Backlog
+
+### Language support
+
+- Swift grammar support (issue #648, good first issue)
+
+### Tooling
+
+- Remove `analyze_module` pending usage data review (issue #780)
+
+### Benchmarks
+
+- Go interface dispatch analysis (issue #661)
+- `analyze_symbol` def-use micro-benchmark (issue #660)


### PR DESCRIPTION
## Summary

Adds ROADMAP.md documenting all active milestones and backlog, OBSERVABILITY.md defining the span attribute policy, and a PR template guard to enforce the never-record list on every future contribution.

## Related Issues

- Closes #820 (span attribute policy)
- Establishes prerequisite for #812, #813, #815, #816, #817, #818

## Changes

- Added `ROADMAP.md`: strategic narrative for observability-v1, wave-9, openssf-gold milestones and backlog
- Added `OBSERVABILITY.md`: always-record list, never-record list, Collector redaction processor config, OTLP setup notes, MCP client log level guidance
- Updated `.github/PULL_REQUEST_TEMPLATE.md`: added span attribute policy checklist item
- Updated `ROADMAP.md`: added #820 as tier-0 prerequisite, reference to OBSERVABILITY.md, full issue dependency table

## Test Plan

- Docs only, no code changes
- Verified Markdown renders correctly
- Verified issue cross-references resolve

## Verification Checklist

- [ ] Tests pass: `cargo test`
- [ ] Clippy clean: `cargo clippy -- -D warnings`
- [ ] Formatted: `cargo fmt --check`
- [ ] No `unwrap()`, `expect()`, `println!`, or `eprintln!` in library code
- [ ] No hallucinated APIs (verified against Cargo.lock and crate docs)
- [ ] Commit GPG signed: `git commit -S`
- [ ] DCO signed-off: `git commit --signoff`
- [ ] No scope creep (changes match assigned issue)
- [ ] No secrets, API keys, or credentials in diff
- [ ] New span attributes comply with the never-record policy in [OBSERVABILITY.md](../OBSERVABILITY.md) (no command strings, file content, or free-form user input)
- [ ] I have reviewed every line in this PR and can explain it
