### PR TITLE
feat(observability): log-trace correlation, W3C trace context, child spans, metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "moka",
  "nix",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rmcp",
@@ -1087,6 +1088,19 @@ dependencies = [
  "pin-project-lite",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "log",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ tree-sitter-typescript = "0.23.2"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-fortran = "0.6.0"
 opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.31", features = ["http-proto", "reqwest-client"] }
+opentelemetry-appender-tracing = { version = "0.31", features = ["log"] }
 tracing-opentelemetry = "0.32"
 
 [profile.release]

--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -170,6 +170,8 @@ pub fn analyze_directory_with_progress(
     let start = Instant::now();
     tracing::debug!(file_count = file_entries.len(), root = %root.display(), "analysis start");
 
+    let _parse_span = tracing::info_span!("ast.parse_batch", count = file_entries.len()).entered();
+
     // Parallel analysis of files
     let analysis_results: Vec<FileInfo> = file_entries
         .par_iter()
@@ -240,6 +242,8 @@ pub fn analyze_directory_with_progress(
         duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
         "analysis complete"
     );
+
+    let _format_span = tracing::info_span!("output.format").entered();
 
     // Format output
     let formatted = format_structure(&entries, &analysis_results, None);

--- a/crates/aptu-coder-core/src/graph.rs
+++ b/crates/aptu-coder-core/src/graph.rs
@@ -424,6 +424,9 @@ impl CallGraph {
                 continue;
             }
 
+            // Child span for graph traversal at this depth level
+            let _traverse_span = tracing::info_span!("graph.traverse", depth = depth).entered();
+
             if let Some(neighbors) = graph_map.get(&current) {
                 for edge in neighbors {
                     let path = &edge.path;

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -38,6 +38,7 @@ which = "8"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
+opentelemetry-appender-tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -84,6 +84,62 @@ pub fn summary_cursor_conflict(summary: Option<bool>, cursor: Option<&str>) -> b
     summary == Some(true) && cursor.is_some()
 }
 
+/// Extract W3C Trace Context from MCP request _meta field and set as parent span context.
+///
+/// Attempts to extract traceparent and tracestate from the request's _meta field.
+/// If successful, calls `set_parent` on the current tracing span so the OTel layer
+/// re-parents it to the caller's trace. This must be called after the `#[instrument]`
+/// span has been entered (i.e., inside the function body) for `set_parent` to take effect.
+/// If extraction fails or _meta is absent, silently proceeds with root context (no panic).
+pub fn extract_and_set_trace_context(meta: Option<&rmcp::model::Meta>) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let Some(meta) = meta else { return };
+
+    let mut propagation_map = std::collections::HashMap::new();
+
+    // Extract traceparent if present
+    if let Some(traceparent) = meta.0.get("traceparent")
+        && let Some(tp_str) = traceparent.as_str()
+    {
+        propagation_map.insert("traceparent".to_string(), tp_str.to_string());
+    }
+
+    // Extract tracestate if present
+    if let Some(tracestate) = meta.0.get("tracestate")
+        && let Some(ts_str) = tracestate.as_str()
+    {
+        propagation_map.insert("tracestate".to_string(), ts_str.to_string());
+    }
+
+    // Only attempt extraction if we have at least traceparent
+    if propagation_map.is_empty() {
+        return;
+    }
+
+    // Extract context via the globally registered propagator (TraceContextPropagator by default)
+    let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&ExtractMap(&propagation_map))
+    });
+
+    // Re-parent the current tracing span (already entered via #[instrument]) to the
+    // extracted OTel context. set_parent is a no-op if the OTel layer is not installed.
+    let _ = tracing::Span::current().set_parent(parent_cx);
+}
+
+/// Helper struct for W3C Trace Context extraction from HashMap
+struct ExtractMap<'a>(&'a std::collections::HashMap<String, String>);
+
+impl<'a> opentelemetry::propagation::Extractor for ExtractMap<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|s| s.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
 #[must_use]
 fn error_meta(
     category: &'static str,
@@ -1087,6 +1143,8 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1249,7 +1307,7 @@ impl CodeAnalyzer {
         Ok(result)
     }
 
-    #[instrument(skip(self, _context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
     #[tool(
         name = "analyze_file",
         title = "Analyze File",
@@ -1266,9 +1324,11 @@ impl CodeAnalyzer {
     async fn analyze_file(
         &self,
         params: Parameters<AnalyzeFileParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1508,6 +1568,8 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1907,7 +1969,7 @@ impl CodeAnalyzer {
         Ok(result)
     }
 
-    #[instrument(skip(self, _context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
     #[tool(
         name = "analyze_module",
         title = "Analyze Module",
@@ -1924,9 +1986,11 @@ impl CodeAnalyzer {
     async fn analyze_module(
         &self,
         params: Parameters<AnalyzeModuleParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2157,7 +2221,7 @@ impl CodeAnalyzer {
         Ok(result)
     }
 
-    #[instrument(skip(self, _context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
     #[tool(
         name = "edit_overwrite",
         title = "Edit Overwrite",
@@ -2174,9 +2238,11 @@ impl CodeAnalyzer {
     async fn edit_overwrite(
         &self,
         params: Parameters<EditOverwriteParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2364,7 +2430,7 @@ impl CodeAnalyzer {
         Ok(result)
     }
 
-    #[instrument(skip(self, _context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
@@ -2381,9 +2447,11 @@ impl CodeAnalyzer {
     async fn edit_replace(
         &self,
         params: Parameters<EditReplaceParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2644,14 +2712,16 @@ impl CodeAnalyzer {
             open_world_hint = true
         )
     )]
-    #[instrument(skip(self, _context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, command = tracing::field::Empty, exit_code = tracing::field::Empty, timed_out = tracing::field::Empty, output_truncated = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, command = tracing::field::Empty, exit_code = tracing::field::Empty, timed_out = tracing::field::Empty, output_truncated = tracing::field::Empty))]
     pub async fn exec_command(
         &self,
         params: Parameters<types::ExecCommandParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let t_start = std::time::Instant::now();
         let params = params.0;
+        // Extract W3C Trace Context from request _meta if present
+        extract_and_set_trace_context(Some(&context.meta));
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -24,6 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize OpenTelemetry (returns None if OTEL_EXPORTER_OTLP_ENDPOINT is unset)
     let otel_provider = otel::init_otel();
+    let log_provider = otel::init_log_appender();
+    let meter_provider = otel::init_meter();
 
     // Create shared peer Arc for logging layer
     // Migrate legacy metrics directory if needed
@@ -41,21 +43,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create MCP logging layer with event sender
     let mcp_logging_layer = McpLoggingLayer::new(event_tx, log_level_filter.clone());
 
-    // Build layered subscriber: fmt + MCP logging + optional OpenTelemetry
-    use opentelemetry::trace::TracerProvider;
+    // Build layered subscriber: fmt + MCP logging + optional OTel tracing + optional log bridge.
+    // tracing_subscriber accepts Option<impl Layer>; None is a no-op, so all combinations
+    // collapse to a single linear chain without branching.
+    use opentelemetry::trace::TracerProvider as _;
 
-    let subscriber = tracing_subscriber::registry()
+    let otel_trace_layer = otel_provider
+        .as_ref()
+        .map(|p| tracing_opentelemetry::layer().with_tracer(p.tracer("aptu-coder")));
+
+    let otel_log_layer = log_provider
+        .as_ref()
+        .map(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new);
+
+    tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .with(mcp_logging_layer);
-
-    if let Some(provider) = &otel_provider {
-        let tracer = provider.tracer("aptu-coder");
-        subscriber
-            .with(tracing_opentelemetry::layer().with_tracer(tracer))
-            .init();
-    } else {
-        subscriber.init();
-    }
+        .with(mcp_logging_layer)
+        .with(otel_trace_layer)
+        .with(otel_log_layer)
+        .init();
 
     // Create metrics channel and spawn writer
     let (metrics_tx, metrics_rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
@@ -67,12 +73,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = serve_server(analyzer, (stdin, stdout)).await?;
     service.waiting().await?;
 
-    // Shutdown OpenTelemetry provider to flush spans
-    #[allow(clippy::collapsible_if)]
-    if let Some(provider) = otel_provider {
-        if let Err(e) = provider.shutdown() {
-            tracing::warn!("Failed to shutdown OpenTelemetry provider: {e}");
-        }
+    // Shutdown OpenTelemetry providers to flush spans, logs, and metrics
+    if let Some(provider) = otel_provider
+        && let Err(e) = provider.shutdown()
+    {
+        tracing::warn!("Failed to shutdown OpenTelemetry trace provider: {e}");
+    }
+
+    if let Some(log_prov) = log_provider
+        && let Err(e) = log_prov.shutdown()
+    {
+        tracing::warn!("Failed to shutdown OpenTelemetry log provider: {e}");
+    }
+
+    if let Some(meter_prov) = meter_provider
+        && let Err(e) = meter_prov.shutdown()
+    {
+        tracing::warn!("Failed to shutdown OpenTelemetry meter provider: {e}");
     }
 
     Ok(())

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -152,6 +152,10 @@ impl MetricsWriter {
 
             if let Ok(mut file) = file {
                 for event in batch {
+                    // Record to OTel metrics if available
+                    record_otel_metrics(&event);
+
+                    // Always write to JSONL as fallback
                     if let Ok(mut json) = serde_json::to_string(&event) {
                         json.push('\n');
                         let _ = file.write_all(json.as_bytes()).await;
@@ -749,4 +753,44 @@ mod tests {
             std::env::remove_var("APTU_CODER_METRICS_EXPORT_FILE");
         }
     }
+}
+
+/// Record a metric event to OTel metrics if the global meter provider is available.
+///
+/// Records:
+/// - Histogram: mcp.server.operation.duration (in milliseconds)
+/// - Counter: mcp.server.tool.calls (incremented by 1)
+///
+/// Labels: gen_ai.tool.name, error.type (or "none" if no error)
+///
+/// Instruments are initialized once via OnceLock to avoid rebuilding them on every call.
+fn record_otel_metrics(event: &MetricEvent) {
+    use opentelemetry::metrics::{Counter, Histogram};
+    use opentelemetry::{KeyValue, global};
+    use std::sync::OnceLock;
+
+    static DURATION_HISTOGRAM: OnceLock<Histogram<f64>> = OnceLock::new();
+    static CALL_COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+
+    let histogram = DURATION_HISTOGRAM.get_or_init(|| {
+        global::meter("aptu-coder")
+            .f64_histogram("mcp.server.operation.duration")
+            .with_unit("ms")
+            .build()
+    });
+
+    let counter = CALL_COUNTER.get_or_init(|| {
+        global::meter("aptu-coder")
+            .u64_counter("mcp.server.tool.calls")
+            .build()
+    });
+
+    let error_type = event.error_type.as_deref().unwrap_or("success");
+    let attributes = [
+        KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
+        KeyValue::new("error.type", error_type.to_string()),
+    ];
+
+    histogram.record(event.duration_ms as f64, &attributes);
+    counter.add(1, &attributes);
 }

--- a/crates/aptu-coder/src/otel.rs
+++ b/crates/aptu-coder/src/otel.rs
@@ -4,8 +4,21 @@
 use opentelemetry::global;
 use opentelemetry_otlp::{Protocol, WithExportConfig};
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::warn;
+
+/// Builds the standard service resource attached to all three signal providers.
+fn service_resource() -> Resource {
+    Resource::builder()
+        .with_attribute(opentelemetry::KeyValue::new("service.name", "aptu-coder"))
+        .with_attribute(opentelemetry::KeyValue::new(
+            "service.version",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .build()
+}
 
 /// Initializes OpenTelemetry with OTLP export if OTEL_EXPORTER_OTLP_ENDPOINT is set.
 ///
@@ -31,23 +44,83 @@ pub fn init_otel() -> Option<SdkTracerProvider> {
         }
     };
 
-    // Create resource with service metadata
-    let resource = Resource::builder()
-        .with_attribute(opentelemetry::KeyValue::new("service.name", "aptu-coder"))
-        .with_attribute(opentelemetry::KeyValue::new(
-            "service.version",
-            env!("CARGO_PKG_VERSION"),
-        ))
-        .build();
-
     // Build provider with batch exporter for async export
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
-        .with_resource(resource)
+        .with_resource(service_resource())
         .build();
 
     // Register globally
     global::set_tracer_provider(provider.clone());
+
+    Some(provider)
+}
+
+/// Initializes OpenTelemetry log appender if OTEL_EXPORTER_OTLP_ENDPOINT is set.
+///
+/// Returns `Some(provider)` if initialization succeeds, or `None` if:
+/// - The env var is unset (noop, zero overhead)
+/// - The exporter fails to build (logs warning, graceful failure)
+///
+/// The provider is returned for use with OpenTelemetryTracingBridge layer.
+pub fn init_log_appender() -> Option<SdkLoggerProvider> {
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+
+    // Build the OTLP log exporter with HTTP proto transport
+    let exporter = match opentelemetry_otlp::LogExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(&endpoint)
+        .build()
+    {
+        Ok(exp) => exp,
+        Err(e) => {
+            warn!("Failed to build OTLP log exporter: {}", e);
+            return None;
+        }
+    };
+
+    // Build provider with batch processor for async export
+    let provider = SdkLoggerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(service_resource())
+        .build();
+
+    Some(provider)
+}
+
+/// Initializes OpenTelemetry metrics SDK if OTEL_EXPORTER_OTLP_ENDPOINT is set.
+///
+/// Returns `Some(provider)` if initialization succeeds, or `None` if:
+/// - The env var is unset (noop, zero overhead)
+/// - The exporter fails to build (logs warning, graceful failure)
+///
+/// The provider is registered globally via `opentelemetry::global::set_meter_provider`.
+pub fn init_meter() -> Option<SdkMeterProvider> {
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+
+    // Build the OTLP metrics exporter with HTTP proto transport
+    let exporter = match opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(&endpoint)
+        .build()
+    {
+        Ok(exp) => exp,
+        Err(e) => {
+            warn!("Failed to build OTLP metrics exporter: {}", e);
+            return None;
+        }
+    };
+
+    // Build provider with periodic reader for async export
+    let provider = SdkMeterProvider::builder()
+        .with_reader(opentelemetry_sdk::metrics::PeriodicReader::builder(exporter).build())
+        .with_resource(service_resource())
+        .build();
+
+    // Register globally
+    global::set_meter_provider(provider.clone());
 
     Some(provider)
 }

--- a/crates/aptu-coder/tests/otel_tests.rs
+++ b/crates/aptu-coder/tests/otel_tests.rs
@@ -73,3 +73,61 @@ fn test_noop_layer_composition_no_panic() {
 
     // Assert: test passes if we get here without panic
 }
+
+#[test]
+#[serial]
+fn test_log_appender_no_env_var_returns_none() {
+    // Arrange: ensure OTEL_EXPORTER_OTLP_ENDPOINT is not set
+    unsafe {
+        env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    // Act: call init_log_appender with no env var
+    let result = aptu_coder::otel::init_log_appender();
+
+    // Assert: should return None (graceful noop when env var unset)
+    assert!(
+        result.is_none(),
+        "init_log_appender should return None when OTEL_EXPORTER_OTLP_ENDPOINT is unset"
+    );
+}
+
+#[test]
+#[serial]
+fn test_traceparent_malformed_no_panic() {
+    // Arrange: malformed traceparent (wrong format, not a valid W3C trace-context header)
+    let mut meta_map = serde_json::Map::new();
+    meta_map.insert(
+        "traceparent".to_string(),
+        serde_json::Value::String("not-a-valid-traceparent".to_string()),
+    );
+    let meta = rmcp::model::Meta(meta_map);
+
+    // Act: call the real extraction function -- must not panic regardless of input
+    aptu_coder::extract_and_set_trace_context(Some(&meta));
+}
+
+#[test]
+#[serial]
+fn test_traceparent_missing_meta_no_panic() {
+    // Act: None meta must be handled silently
+    aptu_coder::extract_and_set_trace_context(None);
+}
+
+#[test]
+#[serial]
+fn test_metrics_histogram_no_env_var() {
+    // Arrange: ensure OTEL_EXPORTER_OTLP_ENDPOINT is not set
+    unsafe {
+        env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    // Act: call init_meter with no env var
+    let result = aptu_coder::otel::init_meter();
+
+    // Assert: should return None (graceful noop when env var unset)
+    assert!(
+        result.is_none(),
+        "init_meter should return None when OTEL_EXPORTER_OTLP_ENDPOINT is unset"
+    );
+}


### PR DESCRIPTION
## Summary

Four observability features from the `observability-v1` milestone, all building on the #814 OTel bridge (merged in #822). Zero overhead when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset.

## Changes

**#815 -- Log-trace correlation (`otel.rs`, `main.rs`)**
Add `opentelemetry-appender-tracing` to forward `tracing` log events as OTel `LogRecord`s. Each log record is automatically annotated with the `trace_id` and `span_id` of the active span, making logs joinable to their trace in any OTel-compatible backend. Controlled by `OTEL_EXPORTER_OTLP_ENDPOINT`; noop when unset.

**#816 -- W3C Trace Context extraction (`lib.rs`)**
Every tool call previously started a fresh root span. Now `traceparent` and `tracestate` are extracted from `params._meta` at the tool dispatch entry point and used as the parent span context via `OpenTelemetrySpanExt::set_parent`, connecting tool traces to the calling agent's distributed trace. Fully defensive: missing, null, or malformed `_meta` silently falls back to a root span -- no panic path.

**#817 -- Child spans for sub-operations (`analyze.rs`, `graph.rs`)**
Add named child spans for the phases inside `analyze_directory` (`ast.parse_batch`, `output.format`) and `analyze_symbol` (`graph.traverse` per depth hop). All spans use `tracing::info_span!(...).entered()` which is a zero-cost no-op when the span level is filtered. Enables P95 latency breakdowns by phase from production traffic.

**#818 -- OTel Metrics SDK (`otel.rs`, `metrics.rs`, `main.rs`)**
Supplement the existing JSONL metrics writer with OTel Metrics SDK recording. Emits `mcp.server.operation.duration` (histogram, milliseconds) and `mcp.server.tool.calls` (counter) with bounded cardinality labels (`gen_ai.tool.name`, `error.type`). Instruments are initialized once via `OnceLock` and reused on every call. The JSONL writer is retained as a local-dev fallback and always writes regardless of OTel state.

## Files changed

- `Cargo.toml` / `crates/aptu-coder/Cargo.toml` -- `opentelemetry-appender-tracing = "0.31"`, `metrics` feature on `opentelemetry_sdk`
- `crates/aptu-coder/src/otel.rs` -- `service_resource()` helper; `init_log_appender()`, `init_meter()`
- `crates/aptu-coder/src/main.rs` -- flat `.with(Option<Layer>)` subscriber chain; meter and log provider shutdown on exit
- `crates/aptu-coder/src/lib.rs` -- `extract_and_set_trace_context()` at all 7 tool dispatch sites
- `crates/aptu-coder/src/metrics.rs` -- OTel meter recording via `OnceLock` instruments alongside JSONL
- `crates/aptu-coder-core/src/analyze.rs` -- child spans for directory analysis phases
- `crates/aptu-coder-core/src/graph.rs` -- child span for graph traversal depth loop
- `crates/aptu-coder/tests/otel_tests.rs` -- 7 tests (3 pre-existing + 4 new)

## Test plan

- [x] 480 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Dependency audit clean (`cargo deny check advisories licenses`)
- [x] Security scan clean (aptu scan_security, 0 findings)
- [x] All 7 tool handlers extract trace context at entry point
- [x] OBSERVABILITY.md never-record policy honored (no command/stdin/stdout/credentials in spans or logs)

Closes #815, #816, #817, #818
