### PR TITLE
docs: update observability documentation for observability-v1 stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,24 @@ cargo deny check advisories licenses
 cargo bench
 ```
 
+## Observability
+
+By default, the server operates with noop telemetry providers (zero overhead). Telemetry export is opt-in via environment variables:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` -- Set to an OTLP HTTP endpoint URL (e.g., `http://localhost:4318`) to enable export of traces, logs, and metrics via OTLP/HTTP. When unset, the OpenTelemetry SDK is initialized with noop providers incurring no cost. Exports are asynchronous and do not block tool execution.
+
+- `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` -- Reserved per OpenTelemetry GenAI semantic conventions for opt-in capture of tool arguments and results. aptu-coder does not implement this: individual bounded parameters (path, symbol, depth) are recorded as span attributes instead of serializing the full tool call arguments or results, ensuring credentials and file content are never emitted.
+
+- `XDG_DATA_HOME` -- Base directory for the always-on JSONL metrics channel. The server writes daily-rotated metrics to `$XDG_DATA_HOME/aptu-coder/metrics/` and retains them for 30 days. Defaults to `~/.local/share` if unset.
+
+**Instrumentation:** Each tool invocation is wrapped in a span carrying OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`). W3C Trace Context is extracted from the MCP `_meta` field, allowing MCP clients to propagate their trace context so tool spans become children in a distributed trace.
+
+**Metrics:**
+- JSONL channel: always-on, fire-and-forget, zero latency cost. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the metric record schema and 30-day retention policy.
+- OpenTelemetry: optional, parallel to JSONL. Configured at server init; no runtime reconfiguration.
+
+For span attribute policy and the never-record list, see [OBSERVABILITY.md](OBSERVABILITY.md) at the repository root.
+
 ## API verification (critical)
 
 Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. **Read `crates/aptu-coder/src/lib.rs` before adding or modifying any tool** -- it is the authoritative reference for tool handler patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,4 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - Reference host-specific tools or clients in tool descriptions or server instructions (e.g. Claude Code's Grep, Glob, Read)
 - Use `gh release create` to tag releases; always create a GPG-signed annotated tag and push it to trigger the release workflow
 - Remove `DISABLE_PROMPT_CACHING=1` from server instructions; caching data never read again is detrimental
+- Use relative links in `README.md`; all links must be absolute (`https://github.com/clouatre-labs/aptu-coder/blob/main/...`) so they resolve correctly when README is rendered on crates.io, docs.rs, and other mirrors

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -3,6 +3,16 @@
 This document defines the observability contract for aptu-coder: what is instrumented,
 what is deliberately excluded, and how to configure telemetry export.
 
+## Dual-stream model
+
+aptu-coder emits two independent telemetry streams that operate in parallel:
+
+- **JSONL metrics (always-on):** Daily-rotated files written to `$XDG_DATA_HOME/aptu-coder/metrics/` regardless of any configuration. Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. This stream has zero external dependencies and is always available for local inspection and testing.
+
+- **OpenTelemetry export (opt-in):** Enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Traces, logs, and metrics are exported asynchronously via OTLP/HTTP to any compliant collector (Jaeger, Grafana Tempo, Datadog, etc.). When unset, noop providers are used with zero runtime overhead. This stream is parallel and independent from JSONL.
+
+The two streams have complementary roles: JSONL is the local audit trail and performance baseline; OTel is the distributed tracing signal. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the JSONL schema and rotation policy.
+
 ## Span attribute policy
 
 ### Always record (bounded, no secrets possible)

--- a/README.md
+++ b/README.md
@@ -199,10 +199,21 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
 | `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OpenTelemetry OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables export of traces, logs, and metrics via OTLP/HTTP. When unset, noop providers are used with zero overhead. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset | Reserved per OpenTelemetry GenAI semantic conventions. Capture of tool arguments and results as serialized blobs is not implemented by design (bounded individual parameters are recorded instead). |
+| `XDG_DATA_HOME` | `~/.local/share` | Base directory for daily-rotated JSONL metrics files. The server writes to `$XDG_DATA_HOME/aptu-coder/metrics/` and retains files for 30 days. Defaults to `~/.local/share` if unset. |
 
 ## Observability
 
-All seven tools emit metrics to daily-rotated JSONL files at `$XDG_DATA_HOME/aptu-coder/` (fallback: `~/.local/share/aptu-coder/`). Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full schema.
+The server emits two parallel, independent telemetry streams.
+
+**JSONL metrics (always-on)** are written daily-rotated to `$XDG_DATA_HOME/aptu-coder/metrics/` (fallback: `~/.local/share/aptu-coder/metrics/`) regardless of configuration. Each record captures tool name, duration, output size, and result status. Files are retained for 30 days. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full schema.
+
+**OpenTelemetry export (opt-in)** is enabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is set to an OTLP HTTP endpoint URL. When set, the server initializes OpenTelemetry trace, log, and meter providers and exports asynchronously via OTLP/HTTP. When unset, noop providers are used with zero runtime overhead.
+
+Each tool invocation is wrapped in a span carrying OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`). W3C Trace Context is extracted from the MCP `_meta` field on each call, allowing MCP clients to propagate their trace context so tool spans appear as children in a distributed trace.
+
+For the span attribute policy, the never-record list, and details on what is instrumented, see [OBSERVABILITY.md](OBSERVABILITY.md) at the repository root.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -190,17 +190,17 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 | Variable | Default | Description |
 |---|---|---|
-| `CODE_ANALYZE_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
+| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
+| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
+| `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
+| `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
+| `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
 | `CODE_ANALYZE_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
+| `CODE_ANALYZE_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
 | `DISABLE_PROMPT_CACHING` | unset | Set to `1` to disable prompt caching (recommended for single-pass subagent sessions). |
 | `DISABLE_PROMPT_CACHING_HAIKU` | unset | Set to `1` to disable prompt caching for Haiku-specific pipelines only. |
-| `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
-| `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
-| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
-| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
-| `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OpenTelemetry OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables export of traces, logs, and metrics via OTLP/HTTP. When unset, noop providers are used with zero overhead. |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset | Reserved per OpenTelemetry GenAI semantic conventions. Capture of tool arguments and results as serialized blobs is not implemented by design (bounded individual parameters are recorded instead). |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset | Reserved per OpenTelemetry GenAI semantic conventions for opt-in capture of full tool arguments and results as blobs. aptu-coder does not implement this: raw file content, command output, and stdin are never recorded. Individual bounded parameters (path, symbol, depth) are recorded as span attributes instead. |
 | `XDG_DATA_HOME` | `~/.local/share` | Base directory for daily-rotated JSONL metrics files. The server writes to `$XDG_DATA_HOME/aptu-coder/metrics/` and retains files for 30 days. Defaults to `~/.local/share` if unset. |
 
 ## Observability
@@ -213,7 +213,7 @@ The server emits two parallel, independent telemetry streams.
 
 Each tool invocation is wrapped in a span carrying OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`). W3C Trace Context is extracted from the MCP `_meta` field on each call, allowing MCP clients to propagate their trace context so tool spans appear as children in a distributed trace.
 
-For the span attribute policy, the never-record list, and details on what is instrumented, see [OBSERVABILITY.md](OBSERVABILITY.md) at the repository root.
+For the span attribute policy, the never-record list, and details on what is instrumented, see [OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/OBSERVABILITY.md) at the repository root.
 
 ## Documentation
 

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -147,7 +147,13 @@ graph TD
 
 *Code Snippet 2: Illustrative metric record shape. See [OBSERVABILITY.md](OBSERVABILITY.md) for the normative field list and schema.*
 
-The writer task is isolated from the tool execution path. If disk I/O is slow or the JSONL file is locked, the channel grows; the tool call is unaffected. See [OBSERVABILITY.md](OBSERVABILITY.md) for the full implementation including daily rotation, 30-day retention, and testability via `base_dir` injection.
+The writer task is isolated from the tool execution path. If disk I/O is slow or the JSONL file is locked, the channel grows; the tool call is unaffected.
+
+**OpenTelemetry bridge:** When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the server additionally initializes OpenTelemetry trace, log, and meter providers and exports via OTLP/HTTP. When unset, noop providers incur zero overhead. Both channels (JSONL and OTel) operate independently: JSONL is always-on audit trail and performance baseline; OTel is opt-in distributed tracing.
+
+**W3C Trace Context extraction:** The MCP `_meta` field can carry W3C Trace Context (`traceparent` header). The server extracts this on every tool call and propagates it as the span parent, allowing tool spans to appear as children in the client's distributed trace. This enables end-to-end tracing across MCP client → server → downstream collectors.
+
+**Span attributes:** Span attributes follow OpenTelemetry GenAI semantic conventions (gen_ai.system, gen_ai.operation.name, gen_ai.tool.name) and include only bounded, safe-to-record values (tool name, path, symbol, parameters, result status, error category). Secrets, file content, command output, and stdin are never recorded. See [OBSERVABILITY.md](OBSERVABILITY.md) for the full span attribute policy and never-record list.
 
 ## 6. Benchmark-Driven Development
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,5 +1,15 @@
 # Observability
 
+## Overview
+
+This document covers two parallel telemetry streams and their implementation details.
+
+- **JSONL Metrics** (always-on): Daily-rotated audit trail with tool name, duration, output size, and result status. Files retained for 30 days. Implementation details below.
+
+- **OpenTelemetry Export** (opt-in): When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, traces, logs, and metrics are exported asynchronously via OTLP/HTTP. Noop providers when unset; zero overhead. Parallel and independent from JSONL.
+
+For span attribute policy, the never-record list, and trace context propagation details, see [OBSERVABILITY.md](../OBSERVABILITY.md) at the repository root.
+
 ## Channel Pattern
 
 The metrics channel mirrors the `McpLoggingLayer` pattern exactly:


### PR DESCRIPTION
## Summary

aptu-coder shipped an observability-v1 milestone that added an OpenTelemetry stack (traces, logs, metrics via OTLP/HTTP) alongside the existing always-on JSONL metrics channel. The code landed but documentation had not caught up. This PR closes that gap.

No code changes. No version pins in prose.

## Changes

**`README.md`**
- Env var table alphabetized (APTU_* > CODE_* > DISABLE_* > OTEL_* > XDG_*)
- Added `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`, and `XDG_DATA_HOME` entries with accurate descriptions
- `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` explicitly states raw file content, command output, and stdin are never recorded
- Observability section rewritten from JSONL-only to dual-stream model (JSONL + OTel) with W3C trace context explanation
- All links are now absolute GitHub URLs (resolves correctly on crates.io, docs.rs, and mirrors)

**`OBSERVABILITY.md`** (root)
- New "Dual-stream model" section at the top explaining JSONL (always-on) vs OTel export (opt-in) and their complementary roles
- Cross-reference to `docs/OBSERVABILITY.md` for JSONL schema and rotation policy

**`AGENTS.md`**
- New `## Observability` subsection: env vars, what is instrumented, span attributes, metrics strategy
- New "Do not" bullet: relative links are prohibited in `README.md`; absolute GitHub URLs required for crates.io and docs.rs rendering
- Edited in-place via `edit_replace` (hardlink preserved)

**`docs/DESIGN-GUIDE.md`**
- Section 5 expanded from JSONL-only fire-and-forget to cover the OTel bridge pattern, W3C Trace Context extraction from MCP `_meta`, and span attribute policy with cross-reference to root `OBSERVABILITY.md`

**`docs/OBSERVABILITY.md`**
- New Overview section clarifying the dual-stream model
- Cross-reference to root `OBSERVABILITY.md` for span attribute policy and never-record list

## Test plan

- [x] No version pins in any changed file (grep for `0.31`, `0.32`, specific semver strings: clean)
- [x] All OTEL_* var names verified against code (`OTEL_EXPORTER_OTLP_ENDPOINT` confirmed in `otel.rs`; `XDG_DATA_HOME` confirmed in `metrics.rs`)
- [x] No relative links remain in `README.md`
- [x] Cross-references verified: all linked sections exist in their target files
- [x] Security scan clean: no secrets, credentials, or PII; references to "never record" correctly document security posture
- [x] Linter/formatter: n/a (docs only)
