### PR TITLE
chore: complete rename from code-analyze-mcp to aptu-coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 | Variable | Default | Description |
 |---|---|---|
+| `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
 | `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
 | `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
+| `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
 | `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
 | `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
-| `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
-| `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
 | `DISABLE_PROMPT_CACHING` | unset | Set to `1` to disable prompt caching (recommended for single-pass subagent sessions). |
 | `DISABLE_PROMPT_CACHING_HAIKU` | unset | Set to `1` to disable prompt caching for Haiku-specific pipelines only. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OpenTelemetry OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables export of traces, logs, and metrics via OTLP/HTTP. When unset, noop providers are used with zero overhead. |

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
 | `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
 | `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
-| `CODE_ANALYZE_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
-| `CODE_ANALYZE_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
+| `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
+| `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
 | `DISABLE_PROMPT_CACHING` | unset | Set to `1` to disable prompt caching (recommended for single-pass subagent sessions). |
 | `DISABLE_PROMPT_CACHING_HAIKU` | unset | Set to `1` to disable prompt caching for Haiku-specific pipelines only. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OpenTelemetry OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables export of traces, logs, and metrics via OTLP/HTTP. When unset, noop providers are used with zero overhead. |

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -185,6 +185,13 @@ impl AnalysisCache {
         });
     }
 
+    /// Returns the configured file-cache capacity.
+    /// Exposed for testing across crate boundaries; not part of the stable API.
+    #[doc(hidden)]
+    pub fn file_capacity(&self) -> usize {
+        self.file_capacity
+    }
+
     /// Invalidate all cache entries for a given file path.
     /// Removes all entries regardless of modification time or analysis mode.
     #[instrument(skip(self), fields(path = ?path))]
@@ -312,5 +319,39 @@ mod tests {
         // Assert: both entries should be removed
         assert!(cache.get(&key1).is_none());
         assert!(cache.get(&key2).is_none());
+    }
+
+    // Mutex serialises the two dir-cache-capacity tests to prevent env var races.
+    static DIR_CACHE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_dir_cache_capacity_default() {
+        let _guard = DIR_CACHE_ENV_LOCK.lock().unwrap();
+
+        // Arrange: ensure the env var is not set
+        unsafe { std::env::remove_var("APTU_CODER_DIR_CACHE_CAPACITY") };
+
+        // Act
+        let cache = AnalysisCache::new(100);
+
+        // Assert: default dir capacity is 20
+        assert_eq!(cache.dir_capacity, 20);
+    }
+
+    #[test]
+    fn test_dir_cache_capacity_from_env() {
+        let _guard = DIR_CACHE_ENV_LOCK.lock().unwrap();
+
+        // Arrange
+        unsafe { std::env::set_var("APTU_CODER_DIR_CACHE_CAPACITY", "7") };
+
+        // Act
+        let cache = AnalysisCache::new(100);
+
+        // Cleanup before assertions to minimise env pollution window
+        unsafe { std::env::remove_var("APTU_CODER_DIR_CACHE_CAPACITY") };
+
+        // Assert
+        assert_eq!(cache.dir_capacity, 7);
     }
 }

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -93,12 +93,12 @@ pub struct AnalysisCache {
 
 impl AnalysisCache {
     /// Create a new cache with the specified file capacity.
-    /// The directory cache capacity is read from the `CODE_ANALYZE_DIR_CACHE_CAPACITY`
+    /// The directory cache capacity is read from the `APTU_CODER_DIR_CACHE_CAPACITY`
     /// environment variable (default: 20).
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         let file_capacity = capacity.max(1);
-        let dir_capacity: usize = std::env::var("CODE_ANALYZE_DIR_CACHE_CAPACITY")
+        let dir_capacity: usize = std::env::var("APTU_CODER_DIR_CACHE_CAPACITY")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(20);

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -4285,4 +4285,32 @@ mod tests {
             err.message
         );
     }
+
+    #[test]
+    fn test_file_cache_capacity_default() {
+        // Arrange: ensure the env var is not set
+        unsafe { std::env::remove_var("APTU_CODER_FILE_CACHE_CAPACITY") };
+
+        // Act
+        let analyzer = make_analyzer();
+
+        // Assert: default file cache capacity is 100
+        assert_eq!(analyzer.cache.file_capacity(), 100);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_file_cache_capacity_from_env() {
+        // Arrange
+        unsafe { std::env::set_var("APTU_CODER_FILE_CACHE_CAPACITY", "42") };
+
+        // Act
+        let analyzer = make_analyzer();
+
+        // Cleanup before assertions to minimise env pollution window
+        unsafe { std::env::remove_var("APTU_CODER_FILE_CACHE_CAPACITY") };
+
+        // Assert
+        assert_eq!(analyzer.cache.file_capacity(), 42);
+    }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -501,7 +501,7 @@ impl CodeAnalyzer {
         event_rx: mpsc::UnboundedReceiver<LogEvent>,
         metrics_tx: crate::metrics::MetricsSender,
     ) -> Self {
-        let file_cap: usize = std::env::var("CODE_ANALYZE_FILE_CACHE_CAPACITY")
+        let file_cap: usize = std::env::var("APTU_CODER_FILE_CACHE_CAPACITY")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(100);

--- a/docs/benchmarks/v12/mcp-aptu-coder-only.json
+++ b/docs/benchmarks/v12/mcp-aptu-coder-only.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "code-analyze": {
+    "aptu-coder": {
       "type": "stdio",
-      "command": "code-analyze-mcp",
+      "command": "aptu-coder",
       "args": []
     }
   }

--- a/docs/benchmarks/v13/mcp-aptu-coder-only.json
+++ b/docs/benchmarks/v13/mcp-aptu-coder-only.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "code-analyze": {
+    "aptu-coder": {
       "type": "stdio",
-      "command": "code-analyze-mcp",
+      "command": "aptu-coder",
       "args": []
     }
   }

--- a/docs/benchmarks/v13/methodology.md
+++ b/docs/benchmarks/v13/methodology.md
@@ -44,7 +44,7 @@ scientific HPC code, where:
 | `modules/inflowwind/src/` | 21 | Inflow wind field computation |
 | `modules/elastodyn/src/` | 5 | Structural dynamics |
 
-### Why this codebase highlights code-analyze-mcp
+### Why this codebase highlights aptu-coder
 
 1. **Name collision problem.** Every physics module exports `CalcOutput` and `UpdateStates`. A grep for
    `subroutine CalcOutput` returns hits in all 20+ modules. `analyze_symbol` with a scoped path returns
@@ -140,11 +140,11 @@ analysis task itself.
 **Orchestrator:** goose (calls `bench-v13-run.sh` for each run in sequence; reads telemetry and
 report JSON after each run completes)
 **Tool isolation:**
-- MCP conditions (A, C): `--mcp-config docs/benchmarks/v13/mcp-code-analyze-only.json --strict-mcp-config --allowedTools "mcp__code-analyze__analyze_directory,mcp__code-analyze__analyze_file,mcp__code-analyze__analyze_symbol,mcp__code-analyze__analyze_module"`
+- MCP conditions (A, C): `--mcp-config docs/benchmarks/v13/mcp-code-analyze-only.json --strict-mcp-config --allowedTools "mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module"`
 - Native conditions (B, D): `--mcp-config <empty> --strict-mcp-config --allowedTools "Bash,Glob,Grep,Read,Write,ToolSearch"`
 
 `--strict-mcp-config` prevents Claude Code from loading any MCP servers not listed in the config
-file. The empty config for native conditions ensures the `code-analyze-mcp` server is not available
+file. The empty config for native conditions ensures the `aptu-coder` server is not available
 even if the user's global Claude Code config has it enabled.
 
 **Structured output:** Each run uses `--json-schema` to enforce the output shape. The runner extracts

--- a/docs/benchmarks/v14/mcp-aptu-coder-only.json
+++ b/docs/benchmarks/v14/mcp-aptu-coder-only.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "code-analyze": {
+    "aptu-coder": {
       "type": "stdio",
-      "command": "code-analyze-mcp",
+      "command": "aptu-coder",
       "args": []
     }
   }

--- a/docs/benchmarks/v14/methodology.md
+++ b/docs/benchmarks/v14/methodology.md
@@ -92,7 +92,7 @@ Environment variables:
 - `ANTHROPIC_DEFAULT_SONNET_MODEL` -- model ID for conditions A/B (default: claude-sonnet-4-6)
 - `ANTHROPIC_DEFAULT_HAIKU_MODEL` -- model ID for conditions C/D (default: claude-haiku-4-5)
 
-Tool isolation: MCP conditions (A, C) use --strict-mcp-config with mcp-code-analyze-only.json.
+Tool isolation: MCP conditions (A, C) use --strict-mcp-config with mcp-aptu-coder-only.json.
 Native conditions (B, D) use empty MCP config. Tool isolation is validated by parsing session JSONL.
 
 ## Conditions
@@ -177,6 +177,6 @@ See run-order.txt. Pilots execute in order (A, B, C, D). Scored runs execute in 
 - docs/benchmarks/v14/prompts/condition-d-native-haiku.md
 - docs/benchmarks/v14/run-order.txt
 - docs/benchmarks/v14/scores-template.json
-- docs/benchmarks/v14/mcp-code-analyze-only.json
+- docs/benchmarks/v14/mcp-aptu-coder-only.json
 - docs/benchmarks/v14/results/runs/.gitkeep
 - scripts/bench-v14-run.sh

--- a/scripts/bench-v12-run.sh
+++ b/scripts/bench-v12-run.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUNS_DIR="$REPO_ROOT/docs/benchmarks/v12/results/runs"
 PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/v12/prompts"
-MCP_CODE_ANALYZE_ONLY="$REPO_ROOT/docs/benchmarks/v12/mcp-code-analyze-only.json"
+MCP_APTU_CODER_CONFIG="$REPO_ROOT/docs/benchmarks/v12/mcp-aptu-coder-only.json"
 
 mkdir -p "$RUNS_DIR"
 
@@ -72,7 +72,7 @@ LOG_FILE="$RUNS_DIR/${RUN_ID}.log"
 # Tool isolation flags
 if [[ "$TOOL_SET" == "mcp" ]]; then
   ALLOWED_TOOLS="mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module"
-  MCP_FLAGS="--mcp-config $MCP_CODE_ANALYZE_ONLY --strict-mcp-config"
+  MCP_FLAGS="--mcp-config $MCP_APTU_CODER_CONFIG --strict-mcp-config"
   trap 'rm -f "$JSONL_FILE"' EXIT
 else
   ALLOWED_TOOLS="Bash,Glob,Grep,Read,Write,ToolSearch"

--- a/scripts/bench-v13-run.sh
+++ b/scripts/bench-v13-run.sh
@@ -36,7 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUNS_DIR="$REPO_ROOT/docs/benchmarks/v13/results/runs"
 PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/v13/prompts"
-MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v13/mcp-code-analyze-only.json"
+MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v13/mcp-aptu-coder-only.json"
 
 mkdir -p "$RUNS_DIR"
 

--- a/scripts/bench-v14-run.sh
+++ b/scripts/bench-v14-run.sh
@@ -36,7 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUNS_DIR="$REPO_ROOT/docs/benchmarks/v14/results/runs"
 PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/v14/prompts"
-MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v14/mcp-code-analyze-only.json"
+MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v14/mcp-aptu-coder-only.json"
 
 mkdir -p "$RUNS_DIR"
 

--- a/scripts/cross-client-compat.py
+++ b/scripts/cross-client-compat.py
@@ -269,7 +269,7 @@ class TestMcpInspector(unittest.TestCase):
         )
         config = {
             "mcpServers": {
-                "code-analyze": {
+                "aptu-coder": {
                     "command": str(self.server_binary),
                     "args": [],
                 }
@@ -303,7 +303,7 @@ class TestMcpInspector(unittest.TestCase):
                 "--config",
                 self.config_file.name,
                 "--server",
-                "code-analyze",
+                "aptu-coder",
                 "--method",
                 "tools/list",
             ]
@@ -324,7 +324,7 @@ class TestMcpInspector(unittest.TestCase):
                 "--config",
                 self.config_file.name,
                 "--server",
-                "code-analyze",
+                "aptu-coder",
                 "--method",
                 "tools/call",
                 "--tool-name",


### PR DESCRIPTION
## Summary

Completes the project rename from `code-analyze-mcp` to `aptu-coder` by cleaning up the last remaining references across source code, benchmark tooling, and documentation. Two environment variable names in the source code carried the old `CODE_ANALYZE_*` prefix; benchmark MCP config files still named the binary `code-analyze-mcp`; and the cross-client compatibility test used `code-analyze` as the MCP server key. Adds unit tests covering the renamed env vars, and sorts the README environment variables table alphabetically.

## Changes

- `crates/aptu-coder-core/src/cache.rs` -- `CODE_ANALYZE_DIR_CACHE_CAPACITY` renamed to `APTU_CODER_DIR_CACHE_CAPACITY` (doc comment + `env::var` read); added `#[doc(hidden)] pub fn file_capacity()` getter; added `test_dir_cache_capacity_default` and `test_dir_cache_capacity_from_env` unit tests
- `crates/aptu-coder/src/lib.rs` -- `CODE_ANALYZE_FILE_CACHE_CAPACITY` renamed to `APTU_CODER_FILE_CACHE_CAPACITY`; added `test_file_cache_capacity_default` and `test_file_cache_capacity_from_env` unit tests
- `README.md` -- env vars table updated to new names and sorted alphabetically
- `docs/benchmarks/v12/mcp-code-analyze-only.json` -- renamed to `mcp-aptu-coder-only.json` via `git mv`; server key and command updated
- `docs/benchmarks/v13/mcp-code-analyze-only.json` -- same
- `docs/benchmarks/v14/mcp-code-analyze-only.json` -- same
- `scripts/bench-v12-run.sh` -- variable name and path updated to reference new config filename
- `scripts/bench-v13-run.sh` -- path updated
- `scripts/bench-v14-run.sh` -- path updated
- `scripts/cross-client-compat.py` -- `mcpServers` key and `--server` args changed from `code-analyze` to `aptu-coder`
- `docs/benchmarks/v13/methodology.md` -- section heading, `allowedTools` string, and prose updated
- `docs/benchmarks/v14/methodology.md` -- config file name references updated

Not changed: `metrics.rs` (intentional migration code that reads the old `~/.local/share/code-analyze-mcp` path), `rename-finalize.sh`, and frozen benchmark records v3--v11.

## Test plan

- [ ] Tests pass (`cargo test` -- 500+ tests, all pass)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] 4 new unit tests cover default and env-override behavior for both renamed vars
- [ ] No old-name references remaining in source, scripts, or active benchmark configs
- [ ] Protected files (`metrics.rs`, `rename-finalize.sh`) unchanged
- [ ] JSON file renames tracked as renames by git (not delete + add)

Closes #825
