### PR TITLE
docs: sync ARCHITECTURE and ROADMAP with observability-v1, rename, and Fortran handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,8 @@ All languages are enabled by default. Disable individual languages at compile ti
 | Kotlin | `.kt`, `.kts` | `lang-kotlin` |
 | Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | `lang-fortran` |
 | JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
-| C | `.c` | `lang-cpp` |
-| C++ | `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` | `lang-cpp` |
+| C/C++ | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` | `lang-cpp` |
 | C# | `.cs` | `lang-csharp` |
-
-To build with a subset of languages, disable default features and opt in:
-
-```toml
-[dependencies]
-aptu-coder-core = { version = "*", default-features = false, features = ["lang-rust", "lang-python"] }
-```
-
-The current version is published on [crates.io](https://crates.io/crates/aptu-coder-core). Replace `"*"` with the latest version string if you prefer a pinned dependency.
 
 ## Installation
 
@@ -138,8 +128,6 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `force` | boolean | false | Bypass output size warning |
 | `verbose` | boolean | false | Full output with section headers and imports |
 
-`summary=true` and `cursor` are mutually exclusive. Passing both returns an error.
-
 | Tool | Purpose | Languages |
 |------|---------|-----------|
 | `analyze_directory` | Directory tree with LOC, function, and class counts; respects `.gitignore` | all |
@@ -168,18 +156,6 @@ NEXT_CURSOR: eyJvZmZzZXQiOjUwfQ==
 analyze_symbol path: /my/project symbol: my_function cursor: eyJvZmZzZXQiOjUwfQ==
 ```
 
-**Summary Mode**
-
-When output exceeds 50K chars, the server auto-compacts results using aggregate statistics. Override with `summary: true` (force compact) or `summary: false` (disable).
-
-```bash
-# Force summary for large project
-analyze_directory path: /huge/codebase summary: true
-
-# Disable summary (get full details, may be large)
-analyze_directory path: /project summary: false
-```
-
 ## Non-Interactive Pipelines
 
 In single-pass subagent sessions, prompt caches are written but never reused. Benchmarks showed MCP responses writing ~2x more to cache than native-only workflows, adding cost with no quality gain. Set `DISABLE_PROMPT_CACHING=1` (or `DISABLE_PROMPT_CACHING_HAIKU=1` for Haiku-specific pipelines) to avoid this overhead.
@@ -188,20 +164,27 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 
 ## Environment Variables
 
+### Cache and runtime
+
 | Variable | Default | Description |
 |---|---|---|
-| `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | Maximum number of directory-analysis results held in the in-process LRU cache. |
-| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | Maximum number of cached `exec_command` results held in memory. |
-| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result caching. Increase for stable, slow commands. |
-| `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | Maximum number of file-analysis results held in the in-process LRU cache. Increase for large repos where many files are queried repeatedly. |
-| `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export written on server shutdown. Relative paths are ignored. |
-| `APTU_CODER_PROFILE` | unset | Tool subset profile. `edit` enables only edit tools and `exec_command`; `analyze` enables only analyze tools and `exec_command`; unknown values leave all tools enabled. Can also be set per-session via `io.clouatre-labs/profile` in the MCP `_meta` field. |
-| `APTU_SHELL` | unset | Shell used by `exec_command`. Defaults to `bash` (PATH search) then `/bin/sh`. Override to use a different shell. |
+| `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | LRU cache size for directory-analysis results. |
+| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | LRU cache size for `exec_command` results. |
+| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result cache. |
+| `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |
+| `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export on shutdown. |
+| `APTU_CODER_PROFILE` | unset | Tool subset: `edit` (edit tools + `exec_command` only), `analyze` (analyze tools + `exec_command` only). Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
+| `APTU_SHELL` | unset | Shell for `exec_command`. Defaults to `bash` then `/bin/sh`. |
+
+### Telemetry
+
+| Variable | Default | Description |
+|---|---|---|
 | `DISABLE_PROMPT_CACHING` | unset | Set to `1` to disable prompt caching (recommended for single-pass subagent sessions). |
 | `DISABLE_PROMPT_CACHING_HAIKU` | unset | Set to `1` to disable prompt caching for Haiku-specific pipelines only. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OpenTelemetry OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables export of traces, logs, and metrics via OTLP/HTTP. When unset, noop providers are used with zero overhead. |
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset | Reserved per OpenTelemetry GenAI semantic conventions for opt-in capture of full tool arguments and results as blobs. aptu-coder does not implement this: raw file content, command output, and stdin are never recorded. Individual bounded parameters (path, symbol, depth) are recorded as span attributes instead. |
-| `XDG_DATA_HOME` | `~/.local/share` | Base directory for daily-rotated JSONL metrics files. The server writes to `$XDG_DATA_HOME/aptu-coder/metrics/` and retains files for 30 days. Defaults to `~/.local/share` if unset. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | OTLP HTTP endpoint URL (e.g., `http://localhost:4318`). When set, enables trace, log, and metric export via OTLP/HTTP; noop providers when unset. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | unset | Reserved per OTel GenAI conventions; aptu-coder does not implement this -- bounded parameters are recorded as span attributes instead. |
+| `XDG_DATA_HOME` | `~/.local/share` | Base directory for daily-rotated JSONL metrics files (`$XDG_DATA_HOME/aptu-coder/metrics/`, 30-day retention). |
 
 ## Observability
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,53 +4,38 @@ This document captures planned work and its rationale. Issues are the authoritat
 
 ## Active milestones
 
-### observability-v1
-
-**Goal:** Replace benchmark waves as the primary tool for runtime performance investigation. Give contributors and users the ability to answer "what happened and why" without grepping session logs.
-
-**Background:** aptu-coder uses the `tracing` crate throughout, but spans carry zero semantic attributes and are never exported. The custom JSONL metrics system records `duration_ms` and `error_type` per tool call but these are file-local, not correlated with spans or logs, and not queryable across sessions. When a tool call fails or performs unexpectedly in production, the only recourse is to dig through goose or Claude session logs -- a slow, manual process.
-
-**What changes:**
-
-- All 7 tool handlers gain GenAI semantic convention attributes (`gen_ai.operation.name`, `gen_ai.tool.name`, `gen_ai.system`) and key parameters as span fields, so any span is fully self-describing.
-- Behavioral decisions (`auto_summary`, `cache_hit`, `truncated`) become span events, making them queryable without touching log files.
-- Error recording lands on spans: error type, status, and exception events at every error return path.
-- A `tracing-opentelemetry` bridge wires the existing `#[instrument]` spans to OTLP export, gated on `OTEL_EXPORTER_OTLP_ENDPOINT`. When the variable is unset (the default), overhead is zero: spans are created but never exported. When set, a `BatchSpanProcessor` handles export asynchronously with no hot-path latency.
-- `opentelemetry-appender-tracing` forwards log events as OTel `LogRecord`s, injecting `trace_id` and `span_id` automatically. Every `info!` and `error!` callsite gains trace correlation without code changes.
-- W3C Trace Context is extracted from MCP `params._meta` (`traceparent`, `tracestate`) and used as the parent span context, connecting tool spans to the calling agent's trace (goose session, Claude turn).
-- Child spans for sub-operations inside `analyze_symbol` and `analyze_directory` (parse, AST query, call graph traversal, pagination, formatting) expose P95 breakdowns by sub-operation from real traffic.
-- JSONL metrics migrate to the OTel Metrics SDK, emitting `mcp.server.operation.duration` (the standard MCP histogram) and per-tool counters. The JSONL writer is retained as a local-dev fallback.
-
-**Performance commitment:** zero overhead when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset. Span creation with a noop provider costs ~6.6 µs; for a tool call taking tens of milliseconds this is irrelevant. All export is asynchronous (BatchSpanProcessor, background thread). Benchmarks must not regress.
-
-**Issues (in dependency order):**
-
-Span attribute policy: [OBSERVABILITY.md](OBSERVABILITY.md). Every PR adding span attributes must comply with the never-record list defined there. The policy issue (#820) is a prerequisite for all attribute enrichment work.
-
-| Issue | Title | Tier | Depends on |
-|---|---|---|---|
-| #820 | define span attribute policy and never-record list | 0 (prerequisite) | - |
-| #812 | enrich tool spans with GenAI semantic attributes and error recording | 1 | #820 |
-| #813 | emit behavioral decisions as span events | 1 | #820 |
-| #814 | add tracing-opentelemetry bridge with conditional OTLP export | 2 (keystone) | - |
-| #815 | add log-trace correlation via opentelemetry-appender-tracing | 2 | #814, #820 |
-| #816 | extract W3C Trace Context from MCP params._meta | 2 | #814, #820 |
-| #817 | add child spans for sub-operations in analyze_symbol and analyze_directory | 3 | #814, #820 |
-| #818 | migrate JSONL metrics to OTel Metrics SDK | 3 | #814 |
-
-**Spec reference:** [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status, May 2026), [MCP-specific OTel conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/).
-
----
-
 ### openssf-gold
 
 Track criteria needed to achieve the OpenSSF Best Practices Gold badge (project 12275). See milestone for individual issues.
 
-### wave-9
+---
 
-Editing tools: five MCP tools (`read_file`, `write_file`, `edit_file`, `rename_symbol`, `insert_at_symbol`) completing the read-analyze-write loop. Phase 1 (mechanical, no AST) then Phase 2 (AST-backed). Closes with a benchmark.
+## Completed milestones
+
+### [Complete] observability-v1
+
+All issues (#820, #821, #822, #823, #824) merged. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full wave history entry.
+
+Key deliverables shipped:
+- GenAI semantic convention attributes on all 7 tool handlers (#821)
+- `tracing-opentelemetry` bridge with conditional OTLP export (#822)
+- Log-trace correlation, W3C Trace Context extraction, child spans for sub-operations (#823)
+- JSONL metrics retain daily-rotating local trail; OTel Metrics SDK initialized in parallel when endpoint is set (#823)
+- Span attribute policy and never-record list documented in [OBSERVABILITY.md](OBSERVABILITY.md) (#820)
+- Observability documentation updated in [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) (#824)
+
+**Spec reference:** [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status, May 2026), [MCP-specific OTel conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/).
+
+### [Complete] wave-9
+
+Editing tools completing the read-analyze-write loop. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full wave history entry. `edit_rename` and `edit_insert` were subsequently removed (#779); `edit_overwrite` and `edit_replace` remain.
 
 ---
+
+## Recent completions
+
+- **Project rename** (#826): `code-analyze-mcp` renamed to `aptu-coder` across all source, docs, and benchmark tooling. Env vars `CODE_ANALYZE_DIR_CACHE_CAPACITY` and `CODE_ANALYZE_FILE_CACHE_CAPACITY` renamed to `APTU_CODER_DIR_CACHE_CAPACITY` and `APTU_CODER_FILE_CACHE_CAPACITY`. `migrate_legacy_metrics_dir()` handles XDG path migration at runtime for existing users.
+- **Fortran handler** (#828): Complete handler with module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`), and call graph traversal. Registers `extract_function_name`, `find_receiver_type`, `find_method_for_receiver` in LanguageInfo. Validated against OpenFAST source tree (v13 benchmark).
 
 ## Backlog
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,11 +20,12 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 
 | Module | File | Responsibility |
 |--------|------|-----------------|
-| `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing and stdio transport |
+| `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing, OTel providers, metrics channel, and stdio transport |
 | `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command` |
-| `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients |
+| `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients via `notifications/message` |
+| `otel` | `crates/aptu-coder/src/otel.rs` | OpenTelemetry provider initialization; `init_otel` (traces), `init_log_appender` (logs), `init_meter` (metrics); all gated on `OTEL_EXPORTER_OTLP_ENDPOINT`; noop when unset |
 | `schema_helpers` | `crates/aptu-coder-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
-| `metrics` | `crates/aptu-coder/src/metrics.rs` | Metrics collection and daily-rotating JSONL emission; `MetricEvent`, `MetricsSender`, `MetricsWriter` |
+| `metrics` | `crates/aptu-coder/src/metrics.rs` | Always-on JSONL metrics: daily-rotating files, `MetricEvent`, `MetricsSender`, `MetricsWriter`; includes `migrate_legacy_metrics_dir` for the `code-analyze-mcp` → `aptu-coder` XDG path migration |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
@@ -35,6 +36,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `languages/mod` | `crates/aptu-coder-core/src/languages/mod.rs` | LanguageInfo registry and handler function types |
 | `languages/rust` | `crates/aptu-coder-core/src/languages/rust.rs` | Rust-specific queries and semantic handlers |
 | `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
+| `languages/fortran` | `crates/aptu-coder-core/src/languages/fortran.rs` | Fortran-specific queries and semantic handlers; supports module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`); registers `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` |
 | `cache` | `crates/aptu-coder-core/src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
 | `test_detection` | `crates/aptu-coder-core/src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |
@@ -75,6 +77,10 @@ graph TD
     F2 --> Q
     F3 --> Q
     F6 --> Q
+    Q --> Z1["MetricEvent channel"]
+    Z1 --> Z2["MetricsWriter JSONL"]
+    Q --> Z3["OTel span end"]
+    Z3 --> Z4["BatchSpanProcessor OTLP"]
 ```
 
 ## Analysis Modes
@@ -130,6 +136,34 @@ Exported from `aptu_coder_core` as a public API for library consumers that hold 
 **Git ref filtering:** When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the set of changed files, and `filter_entries_by_git_ref()` restricts the analysis to those files before the graph is built.
 
 **Def-use mode:** When `def_use=true`, the tool computes definition and use sites alongside the call graph. However, `def_use_sites` is cleared (`Vec::new()`) in `structuredContent` on the initial response. Once the callers and callees pages are exhausted, the handler automatically emits a `{mode: defuse, offset: 0}` cursor. Following that cursor enters `PaginationMode::DefUse`, where `def_use_sites` is populated as `Vec<DefUseSite>` and sliced per page. Each `DefUseSite` has: `kind` (write/read/write_read), `symbol`, `file`, `line`, `column`, `snippet`, `enclosing_scope`.
+
+## Observability Architecture
+
+### Dual-stream model
+
+Two independent telemetry channels run in parallel; neither blocks tool execution.
+
+**JSONL metrics (always-on):** Every tool handler fires a `MetricEvent` into an unbounded Tokio channel at return. `MetricsWriter` drains the channel in a background task and appends to a daily-rotated JSONL file at `$XDG_DATA_HOME/aptu-coder/metrics/`. File retention is 30 days. `migrate_legacy_metrics_dir()` runs on startup to rename the old `code-analyze-mcp` directory to `aptu-coder` if the new path does not yet exist.
+
+**OpenTelemetry (opt-in):** When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, `otel.rs` initializes three providers (trace, log, meter) via OTLP/HTTP with `BatchSpanProcessor` / `PeriodicReader` export. The `tracing-opentelemetry` bridge wires `#[instrument]` spans into the OTel trace provider. `opentelemetry-appender-tracing` forwards log events as OTel `LogRecord`s, injecting `trace_id` and `span_id`. When the env var is unset, noop providers are used with zero runtime overhead; noop span creation costs ~6.6 µs.
+
+### W3C Trace Context propagation
+
+The server extracts `traceparent` and `tracestate` from `MCP params._meta` on every tool call and sets them as the span parent context. Tool spans appear as children of the calling agent's distributed trace (goose session, Claude turn). This requires no changes to tool handlers -- context extraction is done at the handler dispatch layer in `lib.rs`.
+
+### Child spans for sub-operations
+
+Key sub-operations are wrapped in named child spans so P95 breakdowns are visible per-operation from real traffic:
+
+| Span name | Location | Sub-operation |
+|---|---|---|
+| `ast.parse_batch` | `analyze.rs` | Rayon parallel parse batch for `analyze_directory` |
+| `graph.traverse` | `graph.rs` | BFS traversal per depth level in `analyze_symbol` |
+| `walk_directory` | `traversal.rs` | .gitignore-aware directory walk |
+
+### Span attribute policy
+
+All tool handlers record bounded, safe-to-emit span attributes (tool name, path, symbol, result status, error category). Secrets, file content, command output, and stdin are in the never-record list. See [OBSERVABILITY.md](../OBSERVABILITY.md) at the repository root for the full policy and PR review checklist.
 
 ## Language Handler System
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@ Key changes:
 
 Full observability stack shipped across #820–#824:
 
-- **#820**: Span attribute policy and never-record list defined; see [OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/OBSERVABILITY.md).
+- **#820**: Span attribute policy and never-record list defined; see [OBSERVABILITY.md](../OBSERVABILITY.md).
 - **#821**: All 7 tool handlers enriched with OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`) and key parameters as span fields. Behavioral decisions (`auto_summary`, `cache_hit`, `truncated`) emitted as span events.
 - **#822**: `tracing-opentelemetry` bridge added. Conditional OTLP export via `BatchSpanProcessor` gated on `OTEL_EXPORTER_OTLP_ENDPOINT`. Noop providers when unset; zero overhead. OTel Metrics SDK initialized in parallel (JSONL channel retained as always-on local trail).
 - **#823**: Log-trace correlation via `opentelemetry-appender-tracing`; every `info!`/`error!` callsite gains `trace_id` and `span_id` automatically. W3C Trace Context (`traceparent`, `tracestate`) extracted from MCP `params._meta` and propagated as span parent -- tool spans become children in the calling agent's distributed trace. Child spans added for key sub-operations: `ast.parse_batch` (directory parse batch), `graph.traverse` (BFS per depth), `walk_directory` (traversal). Graceful shutdown flushes all three OTel providers.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,13 +41,42 @@ Key changes:
 - #624: `CallChainEntry { symbol, file, line }` public type; `callers`, `test_callers`, `callees` fields on `FocusedAnalysisOutput`; MCP clients can now consume caller/callee relationships from `structuredContent` without text parsing
 - #625: `analyze_symbol` tool description updated to accurately reflect `FocusedAnalysisOutput` schema
 
-### [Benchmarking] Wave 7: OpenFAST Fortran Analysis (v13)
+### [Complete] Wave 7: OpenFAST Fortran Analysis (v13)
 
-2x2 factorial design (model x tool_set) on Fortran scientific HPC code (OpenFAST). See [v13 methodology](docs/benchmarks/v13/methodology.md).
+2x2 factorial design (model x tool_set) on Fortran scientific HPC code (OpenFAST). See [v13 methodology](benchmarks/v13/methodology.md). Haiku savings: 68% fewer tokens, 68% cheaper. Sonnet savings: 46% fewer tokens, 42% cheaper. Validated Fortran language support for scientific HPC repositories.
 
-### [Benchmarking] Wave 8: Rust Trait Dispatch Analysis (v14)
+### [Complete] Wave 8: Rust Trait Dispatch Analysis (v14)
 
-2x2 factorial design (model x tool_set) on Rust trait implementations (ripgrep). See [v14 methodology](docs/benchmarks/v14/methodology.md).
+2x2 factorial design (model x tool_set) on Rust trait implementations (ripgrep). See [v14 methodology](benchmarks/v14/methodology.md).
+
+### [Complete] observability-v1
+
+Full observability stack shipped across #820–#824:
+
+- **#820**: Span attribute policy and never-record list defined; see [OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/OBSERVABILITY.md).
+- **#821**: All 7 tool handlers enriched with OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`) and key parameters as span fields. Behavioral decisions (`auto_summary`, `cache_hit`, `truncated`) emitted as span events.
+- **#822**: `tracing-opentelemetry` bridge added. Conditional OTLP export via `BatchSpanProcessor` gated on `OTEL_EXPORTER_OTLP_ENDPOINT`. Noop providers when unset; zero overhead. OTel Metrics SDK initialized in parallel (JSONL channel retained as always-on local trail).
+- **#823**: Log-trace correlation via `opentelemetry-appender-tracing`; every `info!`/`error!` callsite gains `trace_id` and `span_id` automatically. W3C Trace Context (`traceparent`, `tracestate`) extracted from MCP `params._meta` and propagated as span parent -- tool spans become children in the calling agent's distributed trace. Child spans added for key sub-operations: `ast.parse_batch` (directory parse batch), `graph.traverse` (BFS per depth), `walk_directory` (traversal). Graceful shutdown flushes all three OTel providers.
+- **#824**: Observability documentation updated in [docs/OBSERVABILITY.md](OBSERVABILITY.md).
+
+### [Complete] Project rename: code-analyze-mcp to aptu-coder (#826)
+
+All source, docs, benchmark tooling, env vars, and binary references updated. Env vars renamed (breaking for users who had these set):
+
+- `CODE_ANALYZE_DIR_CACHE_CAPACITY` → `APTU_CODER_DIR_CACHE_CAPACITY`
+- `CODE_ANALYZE_FILE_CACHE_CAPACITY` → `APTU_CODER_FILE_CACHE_CAPACITY`
+
+`migrate_legacy_metrics_dir()` handles XDG data path migration at runtime for existing users with metrics data in the old directory.
+
+### [Complete] Fortran handler: module extraction and call graph (#828)
+
+Completes the Fortran language handler that was partially implemented:
+
+- Fixed `ELEMENT_QUERY` to capture module constructs via `internal_procedures` for `CONTAINS` sections; corrected stale comment about `module_statement` (name child is required in tree-sitter-fortran 0.6.0).
+- Added `derived_type_member_expression` pattern to `CALL_QUERY` for Fortran 2003+ `obj%method()` bound procedure calls.
+- Implemented `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` handlers to unblock call graph traversal and module-scoped procedure tracking.
+- Added `extract_module_name` private helper for the two-level child walk on `module_statement`.
+- 16 AAA-pattern tests: module extraction, subroutine/function name extraction, USE import detection, direct CALL and OOP member call patterns, module-scoped vs top-level procedure distinction, CONTAINS sections, empty modules.
 
 ---
 


### PR DESCRIPTION
## Summary

Sync documentation to reflect all work merged since the last docs pass (commits `2829f94` through `7fa8c12`): observability-v1 milestone, project rename, Fortran handler completion, and README table conciseness pass.

## Changes

### `docs/ARCHITECTURE.md`

- Add `otel` module row (init_otel, init_log_appender, init_meter; gated on `OTEL_EXPORTER_OTLP_ENDPOINT`)
- Update `main`, `logging`, `metrics` module rows to reflect current responsibilities
- Add `languages/fortran` module row (module extraction, OOP bound procedure calls, handler functions)
- Extend Data Flow diagram with MetricEvent channel and OTel span/export nodes
- Add Observability Architecture section: dual-stream model, W3C Trace Context propagation, child span table (`ast.parse_batch`, `graph.traverse`, `walk_directory`), span attribute policy cross-reference

### `ROADMAP.md`

- Move `observability-v1` and `wave-9` from Active to Completed
- `openssf-gold` is now the sole active milestone
- Add Recent completions: rename (#826) and Fortran handler (#828)

### `docs/ROADMAP.md`

- Mark Wave 7 (OpenFAST/Fortran) and Wave 8 (ripgrep/Rust) as `[Complete]`; add v13 benchmark numbers to Wave 7; fix broken relative links
- Add `[Complete] observability-v1` entry with per-issue breakdown (#820-#824)
- Add `[Complete] Project rename` entry (#826) with env var migration detail
- Add `[Complete] Fortran handler` entry (#828) with implementation and test coverage summary

### `README.md`

- Merge C and C++ language rows into one (shared `lang-cpp` flag)
- Split 14-row environment variables table into **Cache and runtime** (7 vars) and **Telemetry** (5 vars) subsections with one-sentence descriptions
- Remove redundant `aptu-coder-core` Cargo.toml library snippet (covered in Design Guide)
- Remove trailing mutual-exclusion note after shared params table (already in the table Description column)
- Remove Summary Mode bash examples from Output Management (duplicated the table above); retain NEXT_CURSOR pagination example

## Test plan

- [ ] No source changes; no tests required
- [ ] All links absolute per AGENTS.md requirement
- [ ] DISABLE_PROMPT_CACHING, OTEL_*, XDG_DATA_HOME, APTU_CODER_PROFILE all present in README env vars table
- [ ] Linter and formatter not applicable (docs only)
- [ ] Security scan: no findings
