### PR TITLE
chore: release 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.10.5"
+version = "0.11.0"
 dependencies = [
  "base64",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.5"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.10", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.11", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["io-util"] }


### PR DESCRIPTION
## Summary

Bump version to 0.11.0 for release. All changes were merged to main in PRs #819--#829; this commit advances the workspace version from 0.10.5 to 0.11.0 and updates the `aptu-coder-core` version constraint in `crates/aptu-coder/Cargo.toml`.

## Changes

- `Cargo.toml`: version 0.10.5 -> 0.11.0
- `crates/aptu-coder/Cargo.toml`: `aptu-coder-core` constraint 0.10 -> 0.11
- `Cargo.lock`: regenerated

## Test plan

- [x] `cargo build` clean
- [x] `cargo test`: 499 tests pass
- [x] No source changes beyond version fields
