### PR TITLE
fix(telemetry): mcp.server.operation.duration unit ms->s, bucket boundaries, MCP labels

### DIFF
--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -793,7 +793,7 @@ fn record_otel_metrics(event: &MetricEvent) {
         KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
         KeyValue::new("error.type", error_type.to_string()),
         KeyValue::new("mcp.method.name", "tools/call"),
-        KeyValue::new("mcp.protocol.version", "2024-11-05"),
+        KeyValue::new("mcp.protocol.version", "2025-11-25"),
         KeyValue::new("network.transport", "pipe"),
     ];
 

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -775,7 +775,10 @@ fn record_otel_metrics(event: &MetricEvent) {
     let histogram = DURATION_HISTOGRAM.get_or_init(|| {
         global::meter("aptu-coder")
             .f64_histogram("mcp.server.operation.duration")
-            .with_unit("ms")
+            .with_unit("s")
+            .with_boundaries(vec![
+                0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+            ])
             .build()
     });
 
@@ -789,8 +792,11 @@ fn record_otel_metrics(event: &MetricEvent) {
     let attributes = [
         KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
         KeyValue::new("error.type", error_type.to_string()),
+        KeyValue::new("mcp.method.name", "tools/call"),
+        KeyValue::new("mcp.protocol.version", "2024-11-05"),
+        KeyValue::new("network.transport", "pipe"),
     ];
 
-    histogram.record(event.duration_ms as f64, &attributes);
+    histogram.record(event.duration_ms as f64 / 1000.0, &attributes);
     counter.add(1, &attributes);
 }


### PR DESCRIPTION
## Summary

Fixes #831. The `mcp.server.operation.duration` histogram was recording values in milliseconds with no explicit bucket boundaries and missing required/recommended MCP semantic convention labels. This PR corrects all three issues to align with the [MCP OpenTelemetry semconv specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md).

## Changes

- `crates/aptu-coder/src/metrics.rs` -- `record_otel_metrics`: 8 lines changed

Specific changes:
- Histogram unit changed from `"ms"` to `"s"`
- Duration value converted from `duration_ms as f64` to `duration_ms as f64 / 1000.0` at the `record()` call site
- Explicit bucket boundaries added to the OnceLock histogram builder: `[0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0]`
- Required label `mcp.method.name = "tools/call"` added to every `record()` call
- Recommended labels `mcp.protocol.version = "2024-11-05"` and `network.transport = "pipe"` added to every `record()` call

## Test plan

- [ ] Tests pass: 42 passed (1 pre-existing unrelated failure in `test_file_cache_capacity_default`)
- [ ] Linter clean: `cargo clippy -- -D warnings` passes
- [ ] Security scan clean
- [ ] Only `crates/aptu-coder/src/metrics.rs` modified
