### PR TITLE
feat(telemetry): mcp.session.id, client.name, cache_hits_total counter, exec_command JSONL fields

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -84,6 +84,13 @@ pub fn summary_cursor_conflict(summary: Option<bool>, cursor: Option<&str>) -> b
     summary == Some(true) && cursor.is_some()
 }
 
+/// Session and client metadata recorded as span attributes on every tool call.
+pub struct ClientMetadata {
+    pub session_id: Option<String>,
+    pub client_name: Option<String>,
+    pub client_version: Option<String>,
+}
+
 /// Extract W3C Trace Context from MCP request _meta field and set as parent span context.
 ///
 /// Attempts to extract traceparent and tracestate from the request's _meta field.
@@ -91,8 +98,29 @@ pub fn summary_cursor_conflict(summary: Option<bool>, cursor: Option<&str>) -> b
 /// re-parents it to the caller's trace. This must be called after the `#[instrument]`
 /// span has been entered (i.e., inside the function body) for `set_parent` to take effect.
 /// If extraction fails or _meta is absent, silently proceeds with root context (no panic).
-pub fn extract_and_set_trace_context(meta: Option<&rmcp::model::Meta>) {
+pub fn extract_and_set_trace_context(
+    meta: Option<&rmcp::model::Meta>,
+    client_meta: ClientMetadata,
+) {
     use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let span = tracing::Span::current();
+
+    // Record session and client attributes
+    if let Some(sid) = client_meta.session_id {
+        span.record("mcp.session.id", &sid);
+    }
+    if let Some(cn) = client_meta.client_name {
+        span.record("client.name", &cn);
+    }
+    if let Some(cv) = client_meta.client_version {
+        span.record("client.version", &cv);
+    }
+
+    // Extract agent-session-id from _meta if present (opportunistic; silent no-op if absent)
+    if let Some(asi_str) = meta.and_then(|m| m.0.get("agent-session-id").and_then(|v| v.as_str())) {
+        span.record("mcp.client.session.id", asi_str);
+    }
 
     let Some(meta) = meta else { return };
 
@@ -124,7 +152,7 @@ pub fn extract_and_set_trace_context(meta: Option<&rmcp::model::Meta>) {
 
     // Re-parent the current tracing span (already entered via #[instrument]) to the
     // extracted OTel context. set_parent is a no-op if the OTel layer is not installed.
-    let _ = tracing::Span::current().set_parent(parent_cx);
+    let _ = span.set_parent(parent_cx);
 }
 
 /// Helper struct for W3C Trace Context extraction from HashMap
@@ -486,6 +514,8 @@ pub struct CodeAnalyzer {
     session_id: Arc<TokioMutex<Option<String>>>,
     // Store profile metadata from initialize request for use in on_initialized
     profile_meta: Arc<TokioMutex<Option<serde_json::Map<String, serde_json::Value>>>>,
+    client_name: Arc<TokioMutex<Option<String>>>,
+    client_version: Arc<TokioMutex<Option<String>>>,
 }
 
 #[tool_router]
@@ -528,6 +558,8 @@ impl CodeAnalyzer {
             session_call_seq: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             session_id: Arc::new(TokioMutex::new(None)),
             profile_meta: Arc::new(TokioMutex::new(None)),
+            client_name: Arc::new(TokioMutex::new(None)),
+            client_version: Arc::new(TokioMutex::new(None)),
         }
     }
 
@@ -1123,7 +1155,7 @@ impl CodeAnalyzer {
         Ok(output)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "analyze_directory",
         title = "Analyze Directory",
@@ -1144,7 +1176,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1303,11 +1345,13 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: Some(dir_cache_hit),
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "analyze_file",
         title = "Analyze File",
@@ -1328,7 +1372,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1544,11 +1598,13 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: Some(file_cache_hit),
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, symbol = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, symbol = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "analyze_symbol",
         title = "Analyze Symbol",
@@ -1569,7 +1625,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -1733,7 +1799,9 @@ impl CodeAnalyzer {
                 error_type: None,
                 session_id: sid,
                 seq: Some(seq),
-                cache_hit: Some(false),
+                cache_hit: None,
+                exit_code: None,
+                timed_out: false,
             });
             return Ok(result);
         }
@@ -1964,12 +2032,14 @@ impl CodeAnalyzer {
             error_type: None,
             session_id: sid,
             seq: Some(seq),
-            cache_hit: Some(false),
+            cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "analyze_module",
         title = "Analyze Module",
@@ -1990,7 +2060,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2031,6 +2111,8 @@ impl CodeAnalyzer {
                 session_id: sid.clone(),
                 seq: Some(seq),
                 cache_hit: None,
+                exit_code: None,
+                timed_out: false,
             });
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2217,11 +2299,13 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: Some(module_cache_hit),
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "edit_overwrite",
         title = "Edit Overwrite",
@@ -2242,7 +2326,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2294,6 +2388,8 @@ impl CodeAnalyzer {
                 session_id: sid.clone(),
                 seq: Some(seq),
                 cache_hit: None,
+                exit_code: None,
+                timed_out: false,
             });
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2330,6 +2426,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2357,6 +2455,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
@@ -2384,6 +2484,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
@@ -2426,11 +2528,13 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
 
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
@@ -2451,7 +2555,17 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2503,6 +2617,8 @@ impl CodeAnalyzer {
                 session_id: sid.clone(),
                 seq: Some(seq),
                 cache_hit: None,
+                exit_code: None,
+                timed_out: false,
             });
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2540,6 +2656,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2567,6 +2685,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2596,6 +2716,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -2623,6 +2745,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
@@ -2650,6 +2774,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: None,
+                    exit_code: None,
+                    timed_out: false,
                 });
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
@@ -2695,6 +2821,8 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         });
         Ok(result)
     }
@@ -2712,7 +2840,7 @@ impl CodeAnalyzer {
             open_world_hint = true
         )
     )]
-    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, command = tracing::field::Empty, exit_code = tracing::field::Empty, timed_out = tracing::field::Empty, output_truncated = tracing::field::Empty))]
+    #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, command = tracing::field::Empty, exit_code = tracing::field::Empty, timed_out = tracing::field::Empty, output_truncated = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     pub async fn exec_command(
         &self,
         params: Parameters<types::ExecCommandParams>,
@@ -2721,7 +2849,17 @@ impl CodeAnalyzer {
         let t_start = std::time::Instant::now();
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
-        extract_and_set_trace_context(Some(&context.meta));
+        let session_id = self.session_id.lock().await.clone();
+        let client_name = self.client_name.lock().await.clone();
+        let client_version = self.client_version.lock().await.clone();
+        extract_and_set_trace_context(
+            Some(&context.meta),
+            ClientMetadata {
+                session_id,
+                client_name,
+                client_version,
+            },
+        );
         let span = tracing::Span::current();
         span.record("gen_ai.system", "mcp");
         span.record("gen_ai.operation.name", "execute_tool");
@@ -2906,6 +3044,8 @@ impl CodeAnalyzer {
                     session_id: sid.clone(),
                     seq: Some(seq),
                     cache_hit: Some(was_cached),
+                    exit_code,
+                    timed_out,
                 });
                 return Ok(err_to_tool_result(e));
             }
@@ -2927,6 +3067,8 @@ impl CodeAnalyzer {
             session_id: sid,
             seq: Some(seq),
             cache_hit: Some(was_cached),
+            exit_code,
+            timed_out,
         });
         Ok(result)
     }
@@ -3219,12 +3361,22 @@ impl ServerHandler for CodeAnalyzer {
     #[instrument(skip(self, context), fields(service.name = tracing::field::Empty, service.version = tracing::field::Empty))]
     async fn initialize(
         &self,
-        _request: InitializeRequestParams,
+        request: InitializeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, ErrorData> {
         let span = tracing::Span::current();
         span.record("service.name", "aptu-coder");
         span.record("service.version", env!("CARGO_PKG_VERSION"));
+
+        // Store client_info from the initialize request
+        {
+            let mut client_name_lock = self.client_name.lock().await;
+            *client_name_lock = Some(request.client_info.name.clone());
+        }
+        {
+            let mut client_version_lock = self.client_version.lock().await;
+            *client_version_lock = Some(request.client_info.version.clone());
+        }
 
         // The _meta field is extracted from params and stored in request extensions.
         // Extract it and store for use in on_initialized.

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -31,6 +31,10 @@ pub struct MetricEvent {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_hit: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub timed_out: bool,
 }
 
 /// Sender half of the metrics channel; cloned and passed to tools for event emission.
@@ -462,6 +466,8 @@ mod tests {
             session_id: None,
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         };
         tx.send(make_event()).unwrap();
         tx.send(make_event()).unwrap();
@@ -512,6 +518,8 @@ mod tests {
             session_id: None,
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("analyze_directory"));
@@ -533,6 +541,8 @@ mod tests {
             session_id: None,
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""result":"error""#));
@@ -555,6 +565,8 @@ mod tests {
             session_id: Some("1742468880123-42".to_string()),
             seq: Some(5),
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         };
         let serialized = serde_json::to_string(&event).unwrap();
         let json_str = r#"{"ts":1700000000000,"tool":"analyze_file","duration_ms":100,"output_chars":500,"param_path_depth":2,"max_depth":3,"result":"ok","error_type":null,"session_id":"1742468880123-42","seq":5}"#;
@@ -590,6 +602,8 @@ mod tests {
             session_id: Some("test-session-123".to_string()),
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         })
         .unwrap();
         tx.send(MetricEvent {
@@ -604,6 +618,8 @@ mod tests {
             session_id: Some("test-session-123".to_string()),
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         })
         .unwrap();
         drop(tx);
@@ -671,6 +687,8 @@ mod tests {
             session_id: Some("test-session-456".to_string()),
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         })
         .unwrap();
         drop(tx);
@@ -725,6 +743,8 @@ mod tests {
             session_id: Some(marker.to_string()),
             seq: None,
             cache_hit: None,
+            exit_code: None,
+            timed_out: false,
         })
         .unwrap();
         drop(tx);
@@ -771,6 +791,7 @@ fn record_otel_metrics(event: &MetricEvent) {
 
     static DURATION_HISTOGRAM: OnceLock<Histogram<f64>> = OnceLock::new();
     static CALL_COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
+    static CACHE_HITS_COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
 
     let histogram = DURATION_HISTOGRAM.get_or_init(|| {
         global::meter("aptu-coder")
@@ -788,6 +809,13 @@ fn record_otel_metrics(event: &MetricEvent) {
             .build()
     });
 
+    let cache_hits_counter = CACHE_HITS_COUNTER.get_or_init(|| {
+        global::meter("aptu-coder")
+            .u64_counter("mcp.server.tool.cache_hits_total")
+            .with_description("Number of tool responses served from cache")
+            .build()
+    });
+
     let error_type = event.error_type.as_deref().unwrap_or("success");
     let attributes = [
         KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
@@ -799,4 +827,11 @@ fn record_otel_metrics(event: &MetricEvent) {
 
     histogram.record(event.duration_ms as f64 / 1000.0, &attributes);
     counter.add(1, &attributes);
+
+    if event.cache_hit == Some(true) {
+        cache_hits_counter.add(
+            1,
+            &[KeyValue::new("gen_ai.tool.name", event.tool.to_string())],
+        );
+    }
 }

--- a/crates/aptu-coder/tests/otel_tests.rs
+++ b/crates/aptu-coder/tests/otel_tests.rs
@@ -104,14 +104,28 @@ fn test_traceparent_malformed_no_panic() {
     let meta = rmcp::model::Meta(meta_map);
 
     // Act: call the real extraction function -- must not panic regardless of input
-    aptu_coder::extract_and_set_trace_context(Some(&meta));
+    aptu_coder::extract_and_set_trace_context(
+        Some(&meta),
+        aptu_coder::ClientMetadata {
+            session_id: None,
+            client_name: None,
+            client_version: None,
+        },
+    );
 }
 
 #[test]
 #[serial]
 fn test_traceparent_missing_meta_no_panic() {
     // Act: None meta must be handled silently
-    aptu_coder::extract_and_set_trace_context(None);
+    aptu_coder::extract_and_set_trace_context(
+        None,
+        aptu_coder::ClientMetadata {
+            session_id: None,
+            client_name: None,
+            client_version: None,
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two related telemetry enrichment features landing together. Both issues touch `record_otel_metrics` in `metrics.rs`, so combining them avoids a sequential merge conflict.

**Issue #833** adds `exit_code` and `timed_out` to the `exec_command` JSONL output (they were already on the span but missing from JSONL), introduces a new `mcp.server.tool.cache_hits_total` OTel counter incremented only on a confirmed cache hit, and fixes a hardcoded `cache_hit: Some(false)` in the `analyze_symbol` handler that incorrectly reported every call as a cache miss.

**Issue #832** stores `clientInfo.name` and `clientInfo.version` from the MCP `initialize` request in `CodeAnalyzer`, then surfaces four new span attributes on every tool call via the shared `extract_and_set_trace_context` helper: `mcp.session.id` (server-generated UUID), `client.name`, `client.version`, and `mcp.client.session.id` (opportunistic read of `agent-session-id` from `_meta`; silent no-op when absent, as only goose sends it).

## Changes

- `crates/aptu-coder/src/metrics.rs` -- `MetricEvent`: new `exit_code: Option<i32>` and `timed_out: bool` fields with serde defaults for backward-compatible JSONL deserialization; new `mcp.server.tool.cache_hits_total` `Counter<u64>` OnceLock; conditional increment in `record_otel_metrics` guarded by `cache_hit == Some(true)`
- `crates/aptu-coder/src/lib.rs` -- `CodeAnalyzer`: new `client_name` / `client_version` `Arc<Mutex<Option<String>>>` fields, populated in the `initialize` handler; `extract_and_set_trace_context`: three new parameters + four `span.record()` calls; all seven tool handlers updated with new `#[instrument(fields(...))]` entries and updated call-sites; `exec_command`: `exit_code` and `timed_out` populated in `MetricEvent` at success and error sites; `analyze_symbol`: `cache_hit: Some(false)` corrected to `None`
- `crates/aptu-coder/tests/otel_tests.rs` -- updated call-sites for the changed `extract_and_set_trace_context` signature

## Test plan

- [x] Tests pass: 138 passed, 0 failed (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] Security scan clean
- [x] `MetricEvent` backward-compat: JSON without `exit_code`/`timed_out` deserializes with defaults (`None` / `false`)
- [x] Cache counter guard: increments only on `cache_hit == Some(true)`, not on `None` or `Some(false)`
- [x] `agent-session-id` absent from `_meta`: silent no-op, no panic
