### PR TITLE
docs: add install command and MCP protocol version to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Rust workspace with two crates:
 - `crates/aptu-coder` -- MCP server, tool handlers, logging, metrics
 
 Seven MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family).
-Rust edition 2024, async with tokio, MCP protocol via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
+Rust edition 2024, async with tokio, MCP protocol 2025-11-25 via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
 
 ## CI runners
 
@@ -23,6 +23,7 @@ cargo clippy -- -D warnings
 cargo fmt --check
 cargo deny check advisories licenses
 cargo bench
+cargo install --path crates/aptu-coder --profile release   # local install; binary lands in ~/.cargo/bin/
 ```
 
 ## Observability


### PR DESCRIPTION
## Summary

Documents two pieces of information contributors need when working locally: where the binary lands after `cargo install` and which MCP protocol version the server targets.

## Changes

- `AGENTS.md`: add `cargo install --path crates/aptu-coder --profile release` to the Commands section, with a comment noting it installs to `~/.cargo/bin/aptu-coder`
- `AGENTS.md`: pin the MCP protocol version to `2025-11-25` in the project structure description

## Test plan

- [ ] Documentation-only change; no code or tests affected
