### PR TITLE
fix(remote): join all segments for GitLab nested namespace URLs

### DIFF
--- a/crates/aptu-coder-remote/src/lib.rs
+++ b/crates/aptu-coder-remote/src/lib.rs
@@ -88,17 +88,35 @@ pub fn detect_platform(url: &str) -> Result<(Platform, String, String), RemoteEr
         ));
     }
 
-    let owner = segments[0].to_string();
-    // Strip .git suffix from repo name
-    let repo = segments[1].trim_end_matches(".git").to_string();
-
     let platform = match host.as_str() {
-        "gitlab.com" => Platform::GitLab {
-            host: "gitlab.com".to_string(),
-        },
-        "github.com" => Platform::GitHub,
+        "gitlab.com" => Platform::GitLab { host: host.clone() },
+        "github.com" => {
+            // GitHub does not support nested namespaces; reject URLs with more than 2 segments
+            if segments.len() > 2 {
+                return Err(RemoteError::InvalidUrl(
+                    "GitHub URLs must contain exactly owner/repo path (no extra segments)"
+                        .to_string(),
+                ));
+            }
+            Platform::GitHub
+        }
         other => return Err(RemoteError::UnsupportedHost(other.to_string())),
     };
+
+    // Extract owner and repo based on platform
+    let owner = segments[0].to_string();
+    let repo = match platform {
+        Platform::GitLab { .. } => {
+            // For GitLab, join all segments after the first (owner) to support nested namespaces
+            segments[1..].join("/")
+        }
+        Platform::GitHub => {
+            // For GitHub, use only the second segment (no nested namespaces)
+            segments[1].to_string()
+        }
+    }
+    .trim_end_matches(".git")
+    .to_string();
 
     Ok((platform, owner, repo))
 }

--- a/crates/aptu-coder-remote/src/tests.rs
+++ b/crates/aptu-coder-remote/src/tests.rs
@@ -87,6 +87,63 @@ fn test_detect_platform_rejects_non_https() {
     );
 }
 
+#[test]
+fn test_detect_platform_gitlab_3segment() {
+    let (platform, owner, repo) =
+        detect_platform("https://gitlab.com/group/subgroup/project").expect("should parse");
+    assert!(
+        matches!(platform, Platform::GitLab { host } if host == "gitlab.com"),
+        "expected GitLab platform"
+    );
+    assert_eq!(owner, "group");
+    assert_eq!(repo, "subgroup/project");
+}
+
+#[test]
+fn test_detect_platform_gitlab_4segment() {
+    let (platform, owner, repo) =
+        detect_platform("https://gitlab.com/a/b/c/d").expect("should parse");
+    assert!(
+        matches!(platform, Platform::GitLab { host } if host == "gitlab.com"),
+        "expected GitLab platform"
+    );
+    assert_eq!(owner, "a");
+    assert_eq!(repo, "b/c/d");
+}
+
+#[test]
+fn test_detect_platform_gitlab_3segment_git_suffix() {
+    let (platform, owner, repo) =
+        detect_platform("https://gitlab.com/group/subgroup/project.git").expect("should parse");
+    assert!(
+        matches!(platform, Platform::GitLab { host } if host == "gitlab.com"),
+        "expected GitLab platform"
+    );
+    assert_eq!(owner, "group");
+    assert_eq!(repo, "subgroup/project");
+}
+
+#[test]
+fn test_detect_platform_gitlab_trailing_slash() {
+    let (platform, owner, repo) =
+        detect_platform("https://gitlab.com/group/subgroup/project/").expect("should parse");
+    assert!(
+        matches!(platform, Platform::GitLab { host } if host == "gitlab.com"),
+        "expected GitLab platform"
+    );
+    assert_eq!(owner, "group");
+    assert_eq!(repo, "subgroup/project");
+}
+
+#[test]
+fn test_detect_platform_github_extra_segment_rejected() {
+    let err = detect_platform("https://github.com/org/repo/extra").expect_err("should fail");
+    assert!(
+        matches!(err, RemoteError::InvalidUrl(_)),
+        "expected InvalidUrl for extra segment, got: {err}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Line range slicing tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `remote_tree` and `remote_file` silently dropping subgroup path segments for GitLab URLs with nested namespaces (e.g. `https://gitlab.com/group/subgroup/project`).

Previously `detect_platform` extracted only `segments[0]` and `segments[1]`, producing `project = "group/subgroup"` and a 404 from the GitLab API. For GitHub, only two segments are valid; extra segments now return `InvalidUrl`.

## Changes

- `crates/aptu-coder-remote/src/lib.rs`: branch `detect_platform` on host before segment extraction. GitLab joins `segments[1..]` into `repo` (stripping `.git`); GitHub enforces the 2-segment constraint and returns `InvalidUrl` for extra segments. Empty segments (trailing slash) are filtered before extraction.
- `crates/aptu-coder-remote/src/tests.rs`: five new tests -- `gitlab_3segment`, `gitlab_4segment`, `gitlab_3segment_git_suffix`, `gitlab_trailing_slash`, `github_extra_segment_rejected`.

## Test plan

- [x] 19 tests pass (`cargo test -p aptu-coder-remote`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)
- [x] Security scan clean

Closes #850.
