### PR TITLE
fix(remote): install rustls CryptoProvider at server startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rmcp",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ opentelemetry-appender-tracing = { version = "0.31", features = ["log"] }
 tracing-opentelemetry = "0.32"
 gitlab = "0.1811.0"
 octocrab = "0.50.0"
+rustls = "0.23"
 url = "2"
 
 [profile.release]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 aptu-coder-core = { path = "../aptu-coder-core", version = "0.11", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 aptu-coder-remote = { path = "../aptu-coder-remote" }
 rmcp = { workspace = true }
+rustls = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { workspace = true }

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -7,6 +7,7 @@ use aptu_coder::{
 };
 use rmcp::serve_server;
 use rmcp::transport::stdio;
+use rustls::crypto::aws_lc_rs;
 use std::sync::{Arc, Mutex};
 use tokio::sync::Mutex as TokioMutex;
 use tracing_subscriber::filter::LevelFilter;
@@ -17,6 +18,10 @@ mod otel;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     if std::env::args().any(|a| a == "--version") {
         println!("{}", env!("CARGO_PKG_VERSION"));
         return Ok(());


### PR DESCRIPTION
## Summary

`remote_tree` and `remote_file` crash the MCP server with `Abort trap: 6` on the first TLS connection. The root cause is that both `aws-lc-rs` and `ring` rustls crypto backends are compiled in (via `octocrab` and `gitlab` transitive dependencies) and rustls 0.23.x panics when it cannot determine an unambiguous default provider.

This fix calls `rustls::crypto::aws_lc_rs::default_provider().install_default()` at the top of `fn main()`, before any async code, version checks, or OpenTelemetry initialization. This installs `aws-lc-rs` as the process-level default provider and prevents the panic on the first TLS handshake.

## Changes

- `crates/aptu-coder/src/main.rs`: add `install_default()` call as the first statement in `fn main()`
- `Cargo.toml`: add `rustls` to workspace dependencies (required to reference `rustls::crypto::aws_lc_rs` from `main.rs`; transitive dependencies are not directly accessible in Rust code)
- `crates/aptu-coder/Cargo.toml`: add `rustls` as a direct crate dependency via workspace reference
- `Cargo.lock`: updated

## Test plan

- [x] Tests pass (510 passed, 0 failed -- `cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Security scan clean (`cargo deny check advisories licenses`)
- [x] No `unsafe` code introduced

Fixes #852
