### PR TITLE
refactor(types): add ModuleInfo::new() constructor and fix extract_module_info docs

### DIFF
--- a/crates/aptu-coder-core/src/formatter.rs
+++ b/crates/aptu-coder-core/src/formatter.rs
@@ -1902,11 +1902,11 @@ mod tests {
     #[test]
     fn test_format_module_info_happy_path() {
         use crate::types::{ModuleFunctionInfo, ModuleImportInfo, ModuleInfo};
-        let info = ModuleInfo {
-            name: "parser.rs".to_string(),
-            line_count: 312,
-            language: "rust".to_string(),
-            functions: vec![
+        let info = ModuleInfo::new(
+            "parser.rs".to_string(),
+            312,
+            "rust".to_string(),
+            vec![
                 ModuleFunctionInfo {
                     name: "parse_file".to_string(),
                     line: 24,
@@ -1916,7 +1916,7 @@ mod tests {
                     line: 58,
                 },
             ],
-            imports: vec![
+            vec![
                 ModuleImportInfo {
                     module: "crate::types".to_string(),
                     items: vec!["Token".to_string(), "Expr".to_string()],
@@ -1926,7 +1926,7 @@ mod tests {
                     items: vec!["BufReader".to_string()],
                 },
             ],
-        };
+        );
         let result = format_module_info(&info);
         assert!(result.starts_with("FILE: parser.rs (312L, 2F, 2I)"));
         assert!(result.contains("F:"));
@@ -1942,13 +1942,13 @@ mod tests {
     #[test]
     fn test_format_module_info_empty() {
         use crate::types::ModuleInfo;
-        let info = ModuleInfo {
-            name: "empty.rs".to_string(),
-            line_count: 0,
-            language: "rust".to_string(),
-            functions: vec![],
-            imports: vec![],
-        };
+        let info = ModuleInfo::new(
+            "empty.rs".to_string(),
+            0,
+            "rust".to_string(),
+            vec![],
+            vec![],
+        );
         let result = format_module_info(&info);
         assert!(result.starts_with("FILE: empty.rs (0L, 0F, 0I)"));
         assert!(!result.contains("F:"));

--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -618,6 +618,13 @@ impl SemanticExtractor {
     /// # Returns
     ///
     /// A `ModuleInfo` containing the file name, line count, language, functions, and imports.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `ParserError` if:
+    /// * `ParserError::Timeout` - The operation exceeds the specified timeout
+    /// * `ParserError::UnsupportedLanguage` - The language is not supported
+    /// * `ParserError::ParseError` - Tree-sitter parsing fails
     #[instrument(skip_all, fields(language))]
     pub fn extract_module_info(
         source: &str,
@@ -700,13 +707,13 @@ impl SemanticExtractor {
 
         let line_count = source.lines().count();
 
-        Ok(crate::types::ModuleInfo {
-            name: String::new(), // Will be set by caller
+        Ok(crate::types::ModuleInfo::new(
+            String::new(), // Will be set by caller
             line_count,
-            language: language.to_string(),
-            functions: module_functions,
-            imports: module_imports,
-        })
+            language.to_string(),
+            module_functions,
+            module_imports,
+        ))
     }
 
     // Extracts function and class definitions from a pre-parsed syntax tree.

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -591,6 +591,26 @@ pub struct ModuleInfo {
     pub imports: Vec<ModuleImportInfo>,
 }
 
+impl ModuleInfo {
+    /// Create a new `ModuleInfo` with all fields specified.
+    #[must_use]
+    pub fn new(
+        name: String,
+        line_count: usize,
+        language: String,
+        functions: Vec<ModuleFunctionInfo>,
+        imports: Vec<ModuleImportInfo>,
+    ) -> Self {
+        Self {
+            name,
+            line_count,
+            language,
+            functions,
+            imports,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2356,11 +2356,7 @@ impl CodeAnalyzer {
             .and_then(aptu_coder_core::lang::language_for_extension)
             .unwrap_or("unknown")
             .to_string();
-        let mut module_info = types::ModuleInfo::default();
-        module_info.name = name;
-        module_info.line_count = arc_output.line_count;
-        module_info.language = language;
-        module_info.functions = arc_output
+        let functions = arc_output
             .semantic
             .functions
             .iter()
@@ -2371,7 +2367,7 @@ impl CodeAnalyzer {
                 mfi
             })
             .collect();
-        module_info.imports = arc_output
+        let imports = arc_output
             .semantic
             .imports
             .iter()
@@ -2382,6 +2378,8 @@ impl CodeAnalyzer {
                 mii
             })
             .collect();
+        let module_info =
+            types::ModuleInfo::new(name, arc_output.line_count, language, functions, imports);
 
         let text = format_module_info(&module_info);
 


### PR DESCRIPTION
## Summary

Follow-up to #865. Addresses two inline review comments that were not resolved before merge.

## Changes

**`crates/aptu-coder-core/src/types.rs`** -- Add `ModuleInfo::new()` constructor following the `SemanticAnalysis::new()` pattern. Takes all five fields as parameters; exhaustive construction is now compiler-enforced. `#[derive(Default)]` is retained for tests that need partial values.

**`crates/aptu-coder-core/src/parser.rs`** -- Expand `extract_module_info` doc comment with a complete `# Errors` section documenting `ParserError::Timeout`, `ParserError::UnsupportedLanguage`, and `ParserError::ParseError`.

**`crates/aptu-coder-core/src/formatter.rs`** -- Update two test fixture call sites to use `ModuleInfo::new()`.

**`crates/aptu-coder/src/lib.rs`** -- Update the `analyze_module` handler call site to use `ModuleInfo::new()` (was `ModuleInfo::default()` + five individual field mutations).

## Test plan

- [ ] All tests pass (551 total, no new failures)
- [ ] Linter clean
- [ ] Formatter clean
