### PR TITLE
test(cache): serialize test_file_cache_capacity_default to fix env var race

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -4928,6 +4928,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_file_cache_capacity_default() {
         // Arrange: ensure the env var is not set
         unsafe { std::env::remove_var("APTU_CODER_FILE_CACHE_CAPACITY") };


### PR DESCRIPTION
## Summary

`test_file_cache_capacity_default` mutated the `APTU_CODER_FILE_CACHE_CAPACITY` env var without isolation. Its sibling `test_file_cache_capacity_from_env` already had `#[serial_test::serial]`; the default test did not. Under parallel test execution the two tests raced on the env var, causing intermittent failures.

Added `#[serial_test::serial]` to `test_file_cache_capacity_default` to serialize the pair. `serial_test` is already a dev-dependency at `=3.4.0`; no new dependencies added.

## Changes

- `crates/aptu-coder/src/lib.rs` -- add `#[serial_test::serial]` to `test_file_cache_capacity_default` (+1 line)

## Test plan

- [ ] Both `test_file_cache_capacity_default` and `test_file_cache_capacity_from_env` pass
- [ ] Linter clean
