### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "blake3",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.11", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.12", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 aptu-coder-remote = { path = "../aptu-coder-remote" }
 rmcp = { workspace = true }
 rustls = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the workspace version to 0.12.0. This release adds the `aptu-coder-remote` crate with two new MCP tools (`remote_tree`, `remote_file`), extends the observability stack with new telemetry fields and corrected metrics, introduces a persistent L2 disk cache for all `analyze_*` tools, and ships several performance improvements and bug fixes.

## Changes

- `Cargo.toml`: workspace version `0.11.0` -> `0.12.0`
- `crates/aptu-coder/Cargo.toml`: `aptu-coder-core` version constraint `0.11` -> `0.12`
- `Cargo.lock`: updated workspace crate versions

## Test plan

- [ ] Build passes (`cargo build`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
