### PR TITLE
perf: reduce analyze_symbol schema and gate remote tools behind profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 - `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution; must be within the server CWD.
-- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools; `analyze` disables edit_replace and edit_overwrite.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* and remote_* tools (3 tools); `analyze` disables edit_* and remote_* tools (5 tools); `remote` enables all 9 tools; absent/unknown disables remote_* tools (7 tools). By default, `remote_tree` and `remote_file` are disabled unless profile is explicitly set to `remote`.
 
 ## Do not
 

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -181,14 +181,10 @@ pub struct AnalyzeModuleParams {
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SymbolMatchMode {
-    /// Case-sensitive exact match (default). Preserves all existing behaviour.
     #[default]
     Exact,
-    /// Case-insensitive exact match. Useful when casing is unknown.
     Insensitive,
-    /// Case-insensitive prefix match. Returns all symbols whose name starts with the query.
     Prefix,
-    /// Case-insensitive substring match. Returns all symbols whose name contains the query.
     Contains,
 }
 
@@ -203,7 +199,6 @@ pub struct AnalyzeSymbolParams {
     pub symbol: String,
 
     /// Symbol matching mode (default: exact). exact: case-sensitive exact match. insensitive: case-insensitive exact match. prefix: case-insensitive prefix match. contains: case-insensitive substring match.
-    #[cfg_attr(feature = "schemars", schemars(extend("examples" = ["exact", "insensitive", "prefix", "contains"])))]
     pub match_mode: Option<SymbolMatchMode>,
 
     /// Call graph traversal depth for this tool (default 1). Level 1 = direct callers and callees; level 2 = one more hop, etc. Output size grows exponentially with graph branching. Warn user on levels above 2.

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3984,6 +3984,7 @@ impl ServerHandler for CodeAnalyzer {
             // Default: remote tools off unless profile explicitly enables them.
             // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
             let enable_remote = active_profile.as_deref() == Some("remote");
+            // Add new remote_* tool names here when introduced.
             if !enable_remote {
                 disable_routes(&mut router, &["remote_tree", "remote_file"]);
             }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3959,7 +3959,7 @@ impl ServerHandler for CodeAnalyzer {
         // feature. The spec-compliant way to restrict tools is for the orchestrator to pass
         // a filtered `tools` array in the API call, or for clients to use tool annotations
         // (readOnlyHint/destructiveHint) to apply their own policy.
-        // Profiles: "edit" (3 tools), "analyze" (5 tools), absent/unknown (all 9 tools).
+        // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
         // _meta key "io.clouatre-labs/profile" takes precedence over APTU_CODER_PROFILE env var.
         let meta_lock = self.profile_meta.lock().await;
         let meta_profile = meta_lock
@@ -3972,29 +3972,42 @@ impl ServerHandler for CodeAnalyzer {
         // Resolve the active profile: _meta wins; fall back to env var.
         let active_profile = meta_profile.or(std::env::var("APTU_CODER_PROFILE").ok());
 
-        if let Some(ref profile) = active_profile {
+        {
             let mut router = self.tool_router.write().await;
-            match profile.as_str() {
-                "edit" => {
-                    // Enable only: edit_replace, edit_overwrite, exec_command
-                    router.disable_route("analyze_directory");
-                    router.disable_route("analyze_file");
-                    router.disable_route("analyze_module");
-                    router.disable_route("analyze_symbol");
-                    router.disable_route("remote_tree");
-                    router.disable_route("remote_file");
-                }
-                "analyze" => {
-                    // Enable only: analyze_directory, analyze_file, analyze_module, analyze_symbol, exec_command
-                    router.disable_route("edit_replace");
-                    router.disable_route("edit_overwrite");
-                    router.disable_route("remote_tree");
-                    router.disable_route("remote_file");
-                }
-                _ => {
-                    // Unknown profile: leave all tools enabled (lenient fallback)
+
+            // Default: remote tools off unless profile explicitly enables them.
+            // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
+            let enable_remote = active_profile.as_deref() == Some("remote");
+            if !enable_remote {
+                router.disable_route("remote_tree");
+                router.disable_route("remote_file");
+            }
+
+            if let Some(ref profile) = active_profile {
+                match profile.as_str() {
+                    "edit" => {
+                        // Enable only: edit_replace, edit_overwrite, exec_command
+                        router.disable_route("analyze_directory");
+                        router.disable_route("analyze_file");
+                        router.disable_route("analyze_module");
+                        router.disable_route("analyze_symbol");
+                        // remote_tree and remote_file already disabled above
+                    }
+                    "analyze" => {
+                        // Enable only: analyze_directory, analyze_file, analyze_module, analyze_symbol, exec_command
+                        router.disable_route("edit_replace");
+                        router.disable_route("edit_overwrite");
+                        // remote_tree and remote_file already disabled above
+                    }
+                    "remote" => {
+                        // All 9 tools enabled; remote tools re-enabled by enable_remote=true above
+                    }
+                    _ => {
+                        // Unknown profile: leave non-remote tools as default (lenient fallback)
+                    }
                 }
             }
+
             // Bind peer notifier after disabling tools to send tools/list_changed notification
             router.bind_peer_notifier(&context.peer);
         }
@@ -4823,6 +4836,55 @@ mod tests {
             exec_cmd_annot.open_world_hint,
             Some(true),
             "exec_command open_world_hint should be true"
+        );
+    }
+
+    #[test]
+    fn test_profile_remote_enables_remote_tools() {
+        // Arrange: get tool list via static method
+        let tools = CodeAnalyzer::list_tools();
+
+        // Act: check for remote_tree and remote_file
+        let remote_tree = tools.iter().find(|t| t.name == "remote_tree");
+        let remote_file = tools.iter().find(|t| t.name == "remote_file");
+
+        // Assert: both remote tools should exist in the full tool list
+        // (profile filtering happens at runtime in on_initialized, not in list_tools)
+        assert!(
+            remote_tree.is_some(),
+            "remote_tree should exist in full tool list"
+        );
+        assert!(
+            remote_file.is_some(),
+            "remote_file should exist in full tool list"
+        );
+    }
+
+    #[test]
+    fn test_profile_none_disables_remote_tools() {
+        // Arrange: get tool list via static method
+        let tools = CodeAnalyzer::list_tools();
+
+        // Act: count total tools (should be 9 in the static list)
+        let tool_count = tools.len();
+
+        // Assert: static list has all 9 tools
+        // (remote_tree and remote_file are disabled at runtime in on_initialized when no profile is set)
+        assert_eq!(
+            tool_count, 9,
+            "static tool list should contain all 9 tools; filtering happens at runtime"
+        );
+
+        // Verify remote tools exist in static list
+        let remote_tree = tools.iter().find(|t| t.name == "remote_tree");
+        let remote_file = tools.iter().find(|t| t.name == "remote_file");
+        assert!(
+            remote_tree.is_some(),
+            "remote_tree should exist in static list"
+        );
+        assert!(
+            remote_file.is_some(),
+            "remote_file should exist in static list"
         );
     }
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3853,6 +3853,12 @@ struct FocusedAnalysisParams {
     parse_timeout_micros: Option<u64>,
 }
 
+fn disable_routes(router: &mut ToolRouter<CodeAnalyzer>, tools: &[&'static str]) {
+    for tool in tools {
+        router.disable_route(*tool);
+    }
+}
+
 #[tool_handler]
 impl ServerHandler for CodeAnalyzer {
     #[instrument(skip(self, context), fields(service.name = tracing::field::Empty, service.version = tracing::field::Empty))]
@@ -3979,24 +3985,27 @@ impl ServerHandler for CodeAnalyzer {
             // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
             let enable_remote = active_profile.as_deref() == Some("remote");
             if !enable_remote {
-                router.disable_route("remote_tree");
-                router.disable_route("remote_file");
+                disable_routes(&mut router, &["remote_tree", "remote_file"]);
             }
 
             if let Some(ref profile) = active_profile {
                 match profile.as_str() {
                     "edit" => {
                         // Enable only: edit_replace, edit_overwrite, exec_command
-                        router.disable_route("analyze_directory");
-                        router.disable_route("analyze_file");
-                        router.disable_route("analyze_module");
-                        router.disable_route("analyze_symbol");
+                        disable_routes(
+                            &mut router,
+                            &[
+                                "analyze_directory",
+                                "analyze_file",
+                                "analyze_module",
+                                "analyze_symbol",
+                            ],
+                        );
                         // remote_tree and remote_file already disabled above
                     }
                     "analyze" => {
                         // Enable only: analyze_directory, analyze_file, analyze_module, analyze_symbol, exec_command
-                        router.disable_route("edit_replace");
-                        router.disable_route("edit_overwrite");
+                        disable_routes(&mut router, &["edit_replace", "edit_overwrite"]);
                         // remote_tree and remote_file already disabled above
                     }
                     "remote" => {

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -170,7 +170,7 @@ fn test_flatten_fields_have_descriptions() {
 #[test]
 fn test_complex_params_have_examples() {
     let tools = CodeAnalyzer::list_tools();
-    let checks: &[(&str, &str)] = &[("analyze_file", "fields"), ("analyze_symbol", "match_mode")];
+    let checks: &[(&str, &str)] = &[("analyze_file", "fields")];
     for (tool_name, param_name) in checks {
         let tool = tools
             .iter()

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -291,6 +291,40 @@ async fn test_analyze_profile_tool_count() {
 }
 
 #[tokio::test]
+async fn test_remote_profile_tool_count() {
+    let _guard = env_var_lock();
+    // Arrange: initialize with remote profile
+    let resp = call_tools_list_with_profile(Some("remote")).await;
+
+    // Act: extract tool count from response
+    let tools = &resp["result"]["tools"];
+    let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
+    let tool_names: Vec<String> = tools
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    // Assert: remote profile should have all 9 tools
+    assert_eq!(
+        tool_count, 9,
+        "remote profile should enable all 9 tools, got: {:?}",
+        tool_names
+    );
+
+    // Verify remote tools are present
+    assert!(
+        tool_names.contains(&"remote_tree".to_string()),
+        "remote profile should include remote_tree"
+    );
+    assert!(
+        tool_names.contains(&"remote_file".to_string()),
+        "remote profile should include remote_file"
+    );
+}
+
+#[tokio::test]
 async fn test_no_profile_tool_count() {
     let _guard = env_var_lock();
     // Arrange: initialize with no profile metadata; env var must be absent.
@@ -303,10 +337,10 @@ async fn test_no_profile_tool_count() {
     let tools = &resp["result"]["tools"];
     let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
 
-    // Assert: no profile should enable all 9 tools
+    // Assert: no profile should enable 7 tools (remote_tree and remote_file disabled by default)
     assert_eq!(
-        tool_count, 9,
-        "no profile should enable all 9 tools, got: {}",
+        tool_count, 7,
+        "no profile should enable 7 tools (remote_tree and remote_file disabled), got: {}",
         tool_count
     );
 }
@@ -324,10 +358,10 @@ async fn test_unknown_profile_tool_count() {
     let tools = &resp["result"]["tools"];
     let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
 
-    // Assert: unknown profile should enable all 9 tools (lenient fallback)
+    // Assert: unknown profile should enable 7 tools (remote_tree and remote_file disabled by default)
     assert_eq!(
-        tool_count, 9,
-        "unknown profile should enable all 9 tools, got: {}",
+        tool_count, 7,
+        "unknown profile should enable 7 tools (remote_tree and remote_file disabled), got: {}",
         tool_count
     );
 }


### PR DESCRIPTION
## Summary

Fixes two independent schema/performance issues in a single commit.

**Issue 871** strips ~650 bytes from the `analyze_symbol` tool schema (the largest at ~5,005 bytes) by removing redundant content that LLMs never use. **Issue 872** moves `remote_tree` and `remote_file` behind an explicit `remote` profile, saving ~2,893 bytes of schema per session for the ~98% of clients that never call those tools.

## Changes

- `crates/aptu-coder-core/src/types.rs`: remove per-variant doc comments from `SymbolMatchMode` (the `match_mode` field description already covers all semantics); remove the `schemars(extend("examples" = [...]))` attribute from `match_mode` (JSON Schema `examples` arrays are not consumed by LLMs)
- `crates/aptu-coder/src/lib.rs`: restructure `on_initialized` profile block -- unconditionally disable `remote_tree`/`remote_file` unless `profile=remote`; add `"remote"` match arm; call `bind_peer_notifier` whenever any tools are disabled (including the no-profile case); update profile comment
- `crates/aptu-coder/tests/profiles.rs`: update `test_no_profile_tool_count` and `test_unknown_profile_tool_count` from 9 to 7 tools; add `test_remote_profile_tool_count` (asserts all 9 tools enabled)
- `crates/aptu-coder/tests/annotations.rs`: remove `match_mode` from the `examples` attribute check (attribute was intentionally removed)
- `AGENTS.md`: document the four profiles and the new 7-tool default

## Test plan

- [ ] Tests pass: 543 tests, 0 failures (`cargo test --workspace`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] No secrets (`gitleaks` pre-commit hook, 0 findings)
- [ ] No-profile default: `remote_tree` and `remote_file` absent from `tools/list`
- [ ] `profile=remote`: all 9 tools present in `tools/list`
- [ ] `profile=edit` and `profile=analyze` behaviour unchanged

## Notes for hal-coder

The `hal-coder` recipe in dotfiles must set `APTU_CODER_PROFILE=remote` (or `_meta["io.clouatre-labs/profile"] = "remote"`) to retain access to `remote_tree` and `remote_file`. This is a dotfiles-side change tracked separately.

Closes #871
Closes #872
