### PR TITLE
fix(deps): add missing version to aptu-coder-remote dependency

### DIFF
--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 aptu-coder-core = { path = "../aptu-coder-core", version = "0.12", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
-aptu-coder-remote = { path = "../aptu-coder-remote" }
+aptu-coder-remote = { path = "../aptu-coder-remote", version = "0.12" }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

The 0.12.0 release failed to publish `aptu-coder` to crates.io because `aptu-coder-remote` was declared as a path-only dependency with no `version` field. Cargo requires a `version` when publishing so it can reference the crate on crates.io after stripping the `path` specifier.

## Changes

- `crates/aptu-coder/Cargo.toml`: added `version = "0.12"` to the `aptu-coder-remote` dependency entry

## Test plan

- [ ] `cargo publish --dry-run -p aptu-coder` passes (verified locally -- "aborting upload due to dry run")
- [ ] `cargo check -p aptu-coder` clean
