### PR TITLE
docs: add JSONL metrics analysis section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ By default, the server operates with noop telemetry providers (zero overhead). T
 
 - `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` -- Reserved per OpenTelemetry GenAI semantic conventions for opt-in capture of tool arguments and results. aptu-coder does not implement this: individual bounded parameters (path, symbol, depth) are recorded as span attributes instead of serializing the full tool call arguments or results, ensuring credentials and file content are never emitted.
 
-- `XDG_DATA_HOME` -- Base directory for the always-on JSONL metrics channel. The server writes daily-rotated metrics to `$XDG_DATA_HOME/aptu-coder/metrics/` and retains them for 30 days. Defaults to `~/.local/share` if unset.
+- `XDG_DATA_HOME` -- Base directory for the always-on JSONL metrics channel. The server writes daily-rotated metrics to `$XDG_DATA_HOME/aptu-coder/` and retains them for 30 days. Defaults to `~/.local/share` if unset.
 
 **Instrumentation:** Each tool invocation is wrapped in a span carrying OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`). W3C Trace Context is extracted from the MCP `_meta` field, allowing MCP clients to propagate their trace context so tool spans become children in a distributed trace.
 
@@ -44,6 +44,20 @@ By default, the server operates with noop telemetry providers (zero overhead). T
 - OpenTelemetry: optional, parallel to JSONL. Configured at server init; no runtime reconfiguration.
 
 For span attribute policy and the never-record list, see [OBSERVABILITY.md](OBSERVABILITY.md) at the repository root.
+
+### JSONL Metrics Analysis
+
+Daily-rotated JSONL files live at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (default: `~/.local/share/aptu-coder/`). See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full field reference.
+
+Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool).
+
+Five validated jq one-liners:
+
+1. Tool call volume: `jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
+2. Avg duration by tool: `jq -r '[.tool, .duration_ms] | @tsv' metrics-*.jsonl | awk -F'\t' '{c[$1]++;s[$1]+=$2} END{for(t in c) printf "%s\t%dms avg\n",t,s[t]/c[t]}' | sort -t$'\t' -k2 -rn`
+3. Error rate by tool: `jq -r 'select(.result=="error") | .tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
+4. Cache hit rate by day: `for f in metrics-*.jsonl; do d=${f#metrics-}; d=${d%.jsonl}; total=$(jq 'select(.cache_hit!=null)' $f | wc -l); hits=$(jq 'select(.cache_hit==true)' $f | wc -l); echo "$d: $hits/$total"; done`
+5. Slowest 10 calls: `jq -r '[.tool, (.duration_ms|tostring), (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn | head -10`
 
 ## API verification (critical)
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -37,6 +37,10 @@ Each line in the JSONL file is one JSON object:
 | `cache_hit` | `bool \| null` | `true` if the result was served from cache (L1 or L2); `false` if computed; `null` if caching is not applicable for this tool |
 | `session_id` | `string \| null` | Session identifier in format `MILLIS-N` (13-digit Unix milliseconds + AtomicU64 counter); generated on server initialization |
 | `seq` | `u32 \| null` | 0-indexed call sequence within session; incremented atomically when emitting each `MetricEvent` at handler return |
+| `cache_tier` | `string \| null` | Disk cache tier hit: `l1_memory` or `l2_disk`; `null` if not applicable |
+| `cache_write_failure` | `bool \| null` | `true` if cache write failed (dir, tempfile, write, or rename); `null` if not applicable |
+| `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable |
+| `timed_out` | `bool` | `true` if the call timed out; `false` otherwise |
 
 ### Example record
 


### PR DESCRIPTION
## Summary

Adds a `### JSONL Metrics Analysis` subsection to AGENTS.md under the existing Observability section. The section gives maintainers a quick reference for querying aptu-coder's own telemetry without having to remember jq syntax or look up schema field names.

Also fixes a factual path error in AGENTS.md and fills a gap in `docs/OBSERVABILITY.md` where four fields present in `MetricEvent` were missing from the schema table.

## Changes

- `AGENTS.md` -- fix `$XDG_DATA_HOME/aptu-coder/metrics/` path (the `/metrics/` subdirectory does not exist; files land directly in `$XDG_DATA_HOME/aptu-coder/`)
- `AGENTS.md` -- new `### JSONL Metrics Analysis` subsection: file location, key schema fields with nullable annotations, and five validated jq one-liners (tool volume, avg duration by tool, error rate by tool, cache hit rate by day, slowest 10 calls)
- `docs/OBSERVABILITY.md` -- add four previously undocumented schema fields to the table: `cache_tier`, `cache_write_failure`, `exit_code`, `timed_out`

All jq field names were verified against the `MetricEvent` struct in `crates/aptu-coder/src/metrics.rs` and tested against real metrics files before commit.

## Test plan

- [ ] `cargo fmt --check` passes (no source changes)
- [ ] `AGENTS.md` grep: `### JSONL Metrics Analysis` present between Observability and API verification sections
- [ ] `AGENTS.md` grep: `aptu-coder/metrics/` no longer present (path fix confirmed)
- [ ] `docs/OBSERVABILITY.md`: schema table contains `cache_tier`, `cache_write_failure`, `exit_code`, `timed_out`
- [ ] All links are absolute (`https://github.com/clouatre-labs/aptu-coder/blob/main/...`)
- [ ] Security scan: no findings (docs-only change)
