### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "blake3",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bumps workspace version from 0.12.0 to 0.12.1 and updates Cargo.lock accordingly.

This is the version bump commit for the 0.12.1 patch release.
