### PR TITLE
fix(release): make create-release step idempotent against concurrent creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Idempotent: skip creation if release already exists; if creation fails with 422
+          # (concurrent race), the final view confirms existence and exits 0.
           gh release view "v${VERSION}" &>/dev/null \
             || gh release create "v${VERSION}" \
               --title "v${VERSION}" \
-              --generate-notes
+              --generate-notes \
+            || gh release view "v${VERSION}" &>/dev/null
 
       - name: Dry run - skip release creation
         if: ${{ env.DRY_RUN == 'true' }}


### PR DESCRIPTION
## Summary

Makes the `create-release` step resilient to concurrent release creation. If `gh release create` races with a release created manually or by another process (HTTP 422 `Release.tag_name already exists`, exit 1), a trailing `gh release view` confirms the release exists and exits 0, unblocking all downstream jobs.

## Root Cause

Run [#25796750641](https://github.com/clouatre-labs/aptu-coder/actions/runs/25796750641) failed because a release was created manually while `create-release` was already in flight. The original two-leg guard has a TOCTOU window: `view` saw no release, then `create` raced and got HTTP 422, failing the step and causing all downstream jobs (build-and-attest, crates.io, Homebrew, MCPB, MCP Registry) to be skipped.

## Change

```diff
-          gh release view "v${VERSION}" &>/dev/null \
-            || gh release create "v${VERSION}" \
-              --title "v${VERSION}" \
-              --generate-notes
+          gh release view "v${VERSION}" &>/dev/null \
+            || gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+            || gh release view "v${VERSION}" &>/dev/null
```

Logic:

- `view` exits 0 (release already exists) -- short-circuits, `create` never runs, step exits 0
- `view` exits non-0, `create` exits 0 (normal creation) -- step exits 0
- `view` exits non-0, `create` exits 1 (race, already exists) -- trailing `view` exits 0, step exits 0
- `view` exits non-0, `create` exits 1 (any other API error) -- trailing `view` exits non-0, step fails correctly

## Verification

Verified locally that `gh release create` on an existing tag exits 1 with `HTTP 422: Release.tag_name already exists` -- the exact error from run #25796750641.

## Test plan
- [ ] Dry-run workflow dispatch passes
- [ ] Next tag push triggers full pipeline
