### PR TITLE
chore(mcp): remove aptu MCP server, use CLI instead

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -15,18 +15,14 @@
     "brave_search": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@brave/brave-search-mcp-server", "--transport", "stdio"],
+      "args": [
+        "-y",
+        "@brave/brave-search-mcp-server",
+        "--transport",
+        "stdio"
+      ],
       "env": {
         "BRAVE_API_KEY": "${BRAVE_API_KEY}"
-      }
-    },
-    "aptu": {
-      "type": "stdio",
-      "command": "aptu-mcp",
-      "args": ["--read-only"],
-      "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
-        "GROQ_API_KEY": "${GROQ_API_KEY}"
       }
     }
   }


### PR DESCRIPTION
## Summary

Remove the `aptu` MCP server entry from `.mcp.json`. We now use the `aptu` CLI directly rather than through MCP.

## Changes

- `.mcp.json`: deleted `aptu` key from `mcpServers`

## Test plan

- [ ] No functional code changed; MCP config only
