### PR TITLE
feat(transport): add APTU_CODER_PORT env var for HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,18 +89,53 @@ The binary is at `target/release/aptu-coder`.
 
 ### Configure MCP Client
 
-Two transports are available:
+Two transports are available. **Streamable HTTP is recommended** when using orchestrators that spawn delegates (e.g. goose coder): a single server process is shared across the orchestrator and all agents, eliminating extension-drift that occurs when each stdio subprocess gets its own isolated instance.
 
-**stdio (local, default):** Register with the Claude Code CLI:
+**Streamable HTTP (recommended for multi-agent setups)**
+
+With Homebrew, one command starts the server on login and keeps it running:
+
+```bash
+brew services start aptu-coder
+```
+
+The Homebrew formula starts the server on port `49200` by default. Then add the extension once to `~/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  aptu-coder:
+    type: streamable_http
+    uri: http://127.0.0.1:49200/mcp
+    name: aptu-coder
+    timeout: 300
+```
+
+Or for Claude Code:
+
+```bash
+claude mcp add --transport http aptu-coder http://127.0.0.1:49200/mcp
+```
+
+To use a different port, set `APTU_CODER_PORT` before restarting:
+
+```bash
+APTU_CODER_PORT=4000 brew services restart aptu-coder
+```
+
+To start directly without brew services:
+
+```bash
+aptu-coder --port 49200
+# or equivalently
+APTU_CODER_PORT=49200 aptu-coder
+```
+
+**stdio (single-client use)**
+
+Suitable when only one process needs the server. The client owns the process lifecycle and spawns it automatically:
 
 ```bash
 claude mcp add --transport stdio aptu-coder -- aptu-coder
-```
-
-If you built from source, use the binary path directly:
-
-```bash
-claude mcp add --transport stdio aptu-coder -- /path/to/repo/target/release/aptu-coder
 ```
 
 Or add manually to `.mcp.json` at your project root (shared with your team via version control):
@@ -114,20 +149,6 @@ Or add manually to `.mcp.json` at your project root (shared with your team via v
     }
   }
 }
-```
-
-**Streamable HTTP (`--port N`):** Binds to `127.0.0.1:N` and serves all tools over the MCP streamable HTTP transport (localhost only; no TLS or auth required). Useful for MCP clients that prefer HTTP over stdio.
-
-```bash
-aptu-coder --port 3042
-```
-
-goose configuration:
-
-```yaml
-- type: streamable_http
-  name: aptu-coder
-  uri: http://127.0.0.1:3042/mcp
 ```
 
 ## Tools
@@ -185,6 +206,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | Variable | Default | Description |
 |---|---|---|
 | `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | LRU cache size for directory-analysis results. |
+| `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
 | `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | LRU cache size for `exec_command` results. |
 | `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result cache. |
 | `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -64,6 +64,17 @@ async fn run_http(analyzer: CodeAnalyzer, port: u16) -> Result<(), Box<dyn std::
     Ok(())
 }
 
+/// Parse a port string into a non-zero u16.  Returns `Err` with a human-readable message on
+/// failure so callers share identical validation logic regardless of whether the value came
+/// from a CLI flag or an environment variable.
+fn parse_port(s: &str) -> Result<u16, String> {
+    match s.parse::<u16>() {
+        Ok(0) => Err("must be a non-zero u16 value".to_string()),
+        Ok(p) => Ok(p),
+        Err(_) => Err(format!("{s:?} is not a valid u16 value")),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     aws_lc_rs::default_provider()
@@ -79,10 +90,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Ok(());
             }
             "--port" => match args.next() {
-                Some(port_str) => match port_str.parse::<u16>() {
+                Some(val) => match parse_port(&val) {
                     Ok(p) => port = Some(p),
-                    Err(_) => {
-                        eprintln!("error: --port requires a valid u16 value");
+                    Err(msg) => {
+                        eprintln!("error: --port {msg}");
                         std::process::exit(1);
                     }
                 },
@@ -92,6 +103,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             },
             _ => {}
+        }
+    }
+
+    // Fall back to APTU_CODER_PORT env var when --port was not passed.
+    if port.is_none()
+        && let Ok(val) = std::env::var("APTU_CODER_PORT")
+    {
+        match parse_port(&val) {
+            Ok(p) => port = Some(p),
+            Err(msg) => {
+                eprintln!("error: APTU_CODER_PORT {msg}");
+                std::process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

When `--port` is not passed, the server now checks `APTU_CODER_PORT` before falling back to stdio mode. This enables `brew services start aptu-coder` as a single-step setup for multi-agent environments where the orchestrator and all delegates must share one server process (HTTP is multi-tenant; stdio is not).

## Changes

- `crates/aptu-coder/src/main.rs`: added `parse_port()` helper used by both CLI flag and env var, eliminating duplicated validation logic; added `APTU_CODER_PORT` env var resolution between CLI parsing and stdio fallback
- `README.md`: reordered Quick Start to lead with streamable HTTP + `brew services`; documented `APTU_CODER_PORT` in the env var table; updated default port from `3042` (IANA-registered) to `49200` (IANA dynamic/private range, RFC 6335 §6, explicitly unassigned)

## Port selection rationale

`3042` was an arbitrary example from the original `--port` PR commit message. It is registered by IANA to "journee" (assigned 2003, service defunct). `49200` is in the 49152--65535 dynamic/private range, which RFC 6335 §6 reserves for exactly this use case: unregistered ephemeral and private ports.

## Security

The server binds exclusively to `127.0.0.1`. The MCP security guidance and Backslash Security's 2025 CVE analysis of HTTP-transport servers both carve out loopback as safe. The 2025 CVE wave (CVE-2025-49596 et al.) targeted servers binding to `0.0.0.0`.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` passes
- [x] `APTU_CODER_PORT=49200 aptu-coder` starts HTTP mode
- [x] `aptu-coder --port 49200` still works; `--port` takes precedence over env var
- [x] Invalid values (`APTU_CODER_PORT=0`, `APTU_CODER_PORT=notanumber`) exit 1 with actionable error messages

Closes #887
