### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,8 +22,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.12", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
-aptu-coder-remote = { path = "../aptu-coder-remote", version = "0.12" }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.13", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-remote = { path = "../aptu-coder-remote", version = "0.13" }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Bump workspace version to 0.13.0 for the minor release including streamable HTTP transport (`--port` flag, `APTU_CODER_PORT` env var).

## Changes

- `Cargo.toml`: workspace version `0.12.1` -> `0.13.0`
- `crates/aptu-coder/Cargo.toml`: internal path dep version constraints `0.12` -> `0.13`
- `Cargo.lock`: updated checksums
