### PR TITLE
fix(release): add index propagation wait after aptu-coder-remote publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,6 +481,26 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+      - name: Wait for aptu-coder-remote index propagation
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          MAX_ATTEMPTS=12
+          SLEEP_INTERVAL=10
+          ATTEMPT=0
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder-remote/${VERSION}" > /dev/null; then
+              echo "aptu-coder-remote ${VERSION} found in crates.io index"
+              exit 0
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Waiting for index propagation... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+              sleep $SLEEP_INTERVAL
+            fi
+          done
+          echo "Timeout waiting for aptu-coder-remote to appear in crates.io index"
+          exit 1
+
       - name: Publish aptu-coder to crates.io
         run: |
           VERSION="${{ needs.create-release.outputs.version }}"


### PR DESCRIPTION
The `Publish to crates.io` job in the `v0.13.0` release run (#25860630751) failed because `cargo publish -p aptu-coder` ran immediately after uploading `aptu-coder-remote`, before the crates.io index had propagated the new version.

`aptu-coder-core` had a wait loop after its publish step; `aptu-coder-remote` did not. This PR adds the same propagation wait after `aptu-coder-remote` to mirror the existing pattern.

## Root Cause

`aptu-coder-remote 0.13.0` was uploaded successfully at 12:45:54Z but the `Publish aptu-coder` step started at 12:46:54Z -- before the index updated. `cargo publish -p aptu-coder` then failed with `failed to select a version for the requirement aptu-coder-remote = "^0.13"`.

## Changes

- `.github/workflows/release.yml`: added `Wait for aptu-coder-remote index propagation` step (identical logic to the existing `aptu-coder-core` wait, 12 attempts × 10s = max 2 min) between `Publish aptu-coder-remote` and `Publish aptu-coder`

Closes #890
