### PR TITLE
fix(release): replace hand-rolled publish steps with cargo-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,79 +435,21 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install cargo-release
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
+        with:
+          tool: cargo-release
+
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
-      - name: Publish aptu-coder-core to crates.io
-        run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder-core/${VERSION}" > /dev/null; then
-            echo "aptu-coder-core ${VERSION} already published to crates.io, skipping"
-          else
-            cargo publish -p aptu-coder-core
-          fi
+      - name: Publish workspace crates to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Wait for index propagation
-        run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          MAX_ATTEMPTS=12
-          SLEEP_INTERVAL=10
-          ATTEMPT=0
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder-core/${VERSION}" > /dev/null; then
-              echo "aptu-coder-core ${VERSION} found in crates.io index"
-              exit 0
-            fi
-            ATTEMPT=$((ATTEMPT + 1))
-            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
-              echo "Waiting for index propagation... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
-              sleep $SLEEP_INTERVAL
-            fi
-          done
-          echo "Timeout waiting for aptu-coder-core to appear in crates.io index"
-          exit 1
-
-      - name: Publish aptu-coder-remote to crates.io
-        run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder-remote/${VERSION}" > /dev/null; then
-            echo "aptu-coder-remote ${VERSION} already published to crates.io, skipping"
-          else
-            cargo publish -p aptu-coder-remote
-          fi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Wait for aptu-coder-remote index propagation
-        run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          MAX_ATTEMPTS=12
-          SLEEP_INTERVAL=10
-          ATTEMPT=0
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder-remote/${VERSION}" > /dev/null; then
-              echo "aptu-coder-remote ${VERSION} found in crates.io index"
-              exit 0
-            fi
-            ATTEMPT=$((ATTEMPT + 1))
-            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
-              echo "Waiting for index propagation... (attempt $ATTEMPT/$MAX_ATTEMPTS)"
-              sleep $SLEEP_INTERVAL
-            fi
-          done
-          echo "Timeout waiting for aptu-coder-remote to appear in crates.io index"
-          exit 1
-
-      - name: Publish aptu-coder to crates.io
-        run: |
-          VERSION="${{ needs.create-release.outputs.version }}"
-          if curl -sf -A "aptu-coder-release/1.0" "https://crates.io/api/v1/crates/aptu-coder/${VERSION}" > /dev/null; then
-            echo "aptu-coder ${VERSION} already published to crates.io, skipping"
-          else
-            cargo publish -p aptu-coder
-          fi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          # PUBLISH_GRACE_SLEEP: documented cargo-release mechanism for inter-crate index
+          # propagation delay (https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md).
+          # Replaces hand-rolled curl-poll loops. 30s is conservative; crates.io typically
+          # propagates within 10-15s but spikes under load.
+          PUBLISH_GRACE_SLEEP: 30
+        run: cargo release publish --execute --no-confirm --unpublished


### PR DESCRIPTION
## Summary

Replaces the hand-rolled five-step crates.io publish sequence in the release workflow with a single `cargo release publish` invocation. The manual approach was brittle -- index propagation timing is non-deterministic, and every new workspace crate requires a new publish step and a new curl-poll loop in the correct topological position. The v0.13.0 release failed because this race fired; v0.12.1 only succeeded because compilation time happened to exceed propagation latency.

## Changes

- `.github/workflows/release.yml`: removes `Publish aptu-coder-core`, `Wait for index propagation`, `Publish aptu-coder-remote`, `Wait for aptu-coder-remote index propagation`, `Publish aptu-coder` steps (93 lines); replaces with `Install cargo-release` + `Publish workspace crates to crates.io` (21 lines)

## Why cargo-release

`cargo-release` is the canonical Rust ecosystem tool for this problem. It derives publish order from the Cargo dependency graph automatically (no manual sequencing), uses `PUBLISH_GRACE_SLEEP` as the documented inter-crate propagation delay, and `--unpublished` provides native idempotency -- crates already at the current version on crates.io are skipped without curl probing. Adding a new workspace crate requires zero workflow changes.

## Test plan

- [ ] CI passes on this PR (workflow lint via actionlint)
- [ ] After merge, re-run release workflow on `v0.13.0` tag to publish the missing `aptu-coder 0.13.0` (core and remote are already on crates.io; `--unpublished` will skip them and publish only `aptu-coder`)

Closes #891
