### PR TITLE
ci(release): use ubuntu-24.04-arm runners consistently

### DIFF
--- a/.github/workflows/release-repair.yml
+++ b/.github/workflows/release-repair.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   validate-release:
     name: Validate Release Exists
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
     steps:
@@ -99,7 +99,7 @@ jobs:
     name: Update Homebrew Formula
     needs: [build-aarch64-apple-darwin, build-aarch64-unknown-linux-musl, build-x86_64-unknown-linux-musl]
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout homebrew-tap repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -215,7 +215,7 @@ jobs:
     name: Generate MCPB Bundles
     needs: [build-aarch64-apple-darwin, build-aarch64-unknown-linux-musl, build-x86_64-unknown-linux-musl]
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:
@@ -278,7 +278,7 @@ jobs:
     name: Update server.json
     needs: [generate-mcpb]
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   verify-tag-signature:
     name: Verify Tag Signature
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
     name: Create Release
     needs: [verify-tag-signature]
     if: always() && (needs.verify-tag-signature.result == 'success' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     outputs:
@@ -154,7 +154,7 @@ jobs:
     name: Update Homebrew Formula
     needs: [create-release, build-and-attest]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout homebrew-tap repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -262,7 +262,7 @@ jobs:
     name: Generate MCPB Bundles
     needs: [create-release, build-and-attest]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:
@@ -325,7 +325,7 @@ jobs:
     name: Publish to MCP Registry
     needs: [create-release, generate-mcpb]
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write
@@ -422,7 +422,7 @@ jobs:
     name: Publish to crates.io
     needs: create-release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

All CI jobs use `ubuntu-24.04-arm` per AGENTS.md. The release and release-repair workflows were using `ubuntu-24.04` (x86) for every non-build job (verify-tag-signature, create-release, update-homebrew, generate-mcpb, publish-registry, publish, validate-release, update-server-json). This aligns them with the documented convention.

## Changes

- `.github/workflows/release.yml`: 6 occurrences of `ubuntu-24.04` replaced with `ubuntu-24.04-arm`
- `.github/workflows/release-repair.yml`: 4 occurrences of `ubuntu-24.04` replaced with `ubuntu-24.04-arm`

Matrix jobs in `build-and-attest.yml` take `os` as a caller input and are unchanged -- those correctly specify `ubuntu-24.04` or `macos-15` per build target.

## Test plan

- [ ] CI passes
