### PR TITLE
fix(release): coerce dry_run input to boolean in workflow conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
 
 jobs:
   verify-tag-signature:
@@ -153,7 +153,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew Formula
     needs: [create-release, build-and-attest]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout homebrew-tap repository
@@ -261,7 +261,7 @@ jobs:
   generate-mcpb:
     name: Generate MCPB Bundles
     needs: [create-release, build-and-attest]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -324,7 +324,7 @@ jobs:
   publish-registry:
     name: Publish to MCP Registry
     needs: [create-release, generate-mcpb]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -421,7 +421,7 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: create-release
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == true) }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fixes a silent bug where all workflow jobs gated on `dry_run=false` were being skipped instead of running. GitHub Actions passes `workflow_dispatch` boolean inputs as strings, so `"false"` is a non-empty string and evaluates as truthy in expression context. Every job condition using `!(workflow_dispatch && inputs.dry_run)` therefore evaluated to `false` regardless of the input value, skipping publish, build, Homebrew, MCPB, and registry jobs even on a real release dispatch.

This caused the `workflow_dispatch` run triggered to publish the missing `aptu-coder` 0.13.0 to crates.io to skip every job silently.

## Changes

- `.github/workflows/release.yml`: replace `inputs.dry_run` with `inputs.dry_run == true` in the top-level `DRY_RUN` env var and all four job-level `if:` conditions (`update-homebrew`, `generate-mcpb`, `publish-registry`, `publish`). The `build-and-attest` reusable workflow call already used the correct form.

## Test plan

- [ ] CI passes (actionlint)
- [ ] After merge, re-trigger `workflow_dispatch` with `dry_run=false, version=0.13.0` -- `publish` job must run and complete, landing `aptu-coder` 0.13.0 on crates.io

Closes #894
