### PR TITLE
fix(release): read inputs.version directly in job output for dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Validate dispatch inputs
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -z "$INPUT_VERSION" ]; then
+            echo "ERROR: version input is required for workflow_dispatch"
+            exit 1
+          fi
+
       - name: Extract version from tag or input
         id: extract_version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,16 +81,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Validate dispatch inputs
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -z "$INPUT_VERSION" ]; then
-            echo "ERROR: version input is required for workflow_dispatch"
-            exit 1
-          fi
-
       - name: Extract version from tag or input
         id: extract_version
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         default: true
       version:
         description: 'Version to simulate (e.g., 0.1.1)'
-        required: false
+        required: true
         type: string
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.extract_version.outputs.version }}
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || steps.extract_version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Step outputs set via `$GITHUB_OUTPUT` inside a `run:` block are not reliably propagated to the `outputs:` map at the job level in all runner configurations. The `version` job output was resolving to empty string for `workflow_dispatch` runs, causing all downstream jobs (build, publish, homebrew, mcpb, registry) to be skipped silently.

## Changes

- `.github/workflows/release.yml`: resolve version directly from `inputs.version` in the `outputs:` expression for `workflow_dispatch`, falling through to `steps.extract_version.outputs.version` for tag push events

## Root cause

The `outputs:` map uses expression context evaluated at job completion. For `workflow_dispatch`, `inputs.version` is available in the expression context at this point, making the step intermediary unnecessary and avoiding the propagation gap entirely.

Closes #896
