### PR TITLE
fix(release): inline expressions in extract step instead of env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || steps.extract_version.outputs.version }}
+      version: ${{ steps.extract_version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Passing `inputs.version` via a step-level `env:` block and reading it as `$INPUT_VERSION` in the shell is unreliable on the ARM runner: the value is visible in the job log but evaluates to empty in the shell, causing `needs.create-release.outputs.version` to propagate as an empty string and silently skip all downstream jobs.

Inlining `${{ inputs.version }}` and `${{ github.event_name }}` directly in the `run:` script bakes the values in before shell execution, removing the env var indirection entirely.

## Changes

- `.github/workflows/release.yml`: remove `env:` block from `Extract version from tag or input` step; inline `${{ github.event_name }}` and `${{ inputs.version }}` expressions directly in the shell script

## Test plan

- [ ] CI passes
- [ ] `workflow_dispatch` with `dry_run=false version=0.13.0` runs all jobs (not just `Create Release`)
