### PR TITLE
fix(release): source inputs.version via top-level env not step env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+  DISPATCH_VERSION: ${{ inputs.version }}
 
 jobs:
   verify-tag-signature:
@@ -83,12 +84,9 @@ jobs:
 
       - name: Extract version from tag or input
         id: extract_version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION="$INPUT_VERSION"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi


### PR DESCRIPTION
## Summary

Step-level `env:` vars populated from `inputs.*` expressions are visible in the runner log on `ubuntu-24.04-arm` but not injected into the shell at execution time. The top-level `env:` context works correctly (`DRY_RUN` already proves this path). Move `inputs.version` into a top-level `DISPATCH_VERSION` env var so the extract step reads it from the global env.

## Changes

- `.github/workflows/release.yml`: add `DISPATCH_VERSION: ${{ inputs.version }}` to top-level `env:`; remove step-level `env:` block from `Extract version` step; read `$DISPATCH_VERSION` instead of `$INPUT_VERSION`

## Test plan

- [ ] CI passes
- [ ] `workflow_dispatch` with `version=0.13.0` produces non-empty `needs.create-release.outputs.version`

Closes #898
