### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump workspace version to 0.13.1. This is a patch release to complete the partial 0.13.0 publish:
`aptu-coder` 0.13.0 was never published to crates.io (only `aptu-coder-core` and `aptu-coder-remote` were). 0.13.1 publishes all three crates cleanly.

## Changes

- `Cargo.toml`: workspace version `0.13.0` -> `0.13.1`
- `Cargo.lock`: updated to reflect new version

## Test plan

- [ ] `cargo check --workspace` passes (verified locally)
- [ ] Release workflow publishes all three crates: `aptu-coder-core`, `aptu-coder-remote`, `aptu-coder`

Closes N/A - patch release, no issue.
