### PR TITLE
fix(release): remove invalid --unpublished flag and fix $target interpolation

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -75,7 +75,7 @@ jobs:
           target: ${{ inputs.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256
-          archive: aptu-coder-${{ inputs.version }}-$target
+          archive: aptu-coder-${{ inputs.version }}-${{ inputs.target }}
           ref: refs/tags/v${{ inputs.version }}
 
       - name: Build binary (dry-run)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,4 +456,4 @@ jobs:
           # Replaces hand-rolled curl-poll loops. 30s is conservative; crates.io typically
           # propagates within 10-15s but spikes under load.
           PUBLISH_GRACE_SLEEP: 30
-        run: cargo release publish --execute --no-confirm --unpublished
+        run: cargo release publish --execute --no-confirm


### PR DESCRIPTION
## Summary

Two workflow bugs caused the v0.13.1 release to fail.

## Changes

**`release.yml`** - Remove `--unpublished` from `cargo release publish`. The flag does not exist in cargo-release v1.1.2; the `publish` subcommand skips already-published versions by default.

**`build-and-attest.yml`** - Replace bare shell variable `$target` with `${{ inputs.target }}` in the `archive:` input of `taiki-e/upload-rust-binary-action`. In a `with:` block, only GitHub expression syntax is evaluated; the bare variable was passed literally, producing an archive name of `aptu-coder-<version>-$target` instead of the actual target triple. This caused `INPUT_ASSET` to be empty and the upload step to fail with exit code 1.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, re-tag v0.13.1 to trigger the release workflow and verify both jobs succeed
