### PR TITLE
chore: bump version to 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Version bump to 0.13.2. No code changes.

0.13.0 partially failed (aptu-coder crate never published to crates.io) and 0.13.1 failed due to release workflow bugs now fixed in main. This release carries the workflow fixes and publishes all three crates cleanly.

## Changes

- `Cargo.toml`: workspace version `0.13.1` -> `0.13.2`
- `Cargo.lock`: updated checksums

## Test plan

- [ ] CI passes
- [ ] All three crates publish to crates.io at 0.13.2 after tag push
