### PR TITLE
fix(release): remove redundant if on matrix reusable workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,6 @@ jobs:
   build-and-attest:
     name: Build ${{ matrix.target }}
     needs: create-release
-    if: ${{ needs.create-release.result == 'success' }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

The `build-and-attest` matrix job uses a reusable workflow (`uses:`) with an `if: ${{ needs.create-release.result == 'success' }}` condition. GitHub Actions does not correctly evaluate `needs` context in `if` conditions on matrix+reusable-workflow jobs triggered via `workflow_dispatch` -- the matrix collapses to a single skipped entry, which cascades to skip `generate-mcpb` and `publish-registry`.

The `if` condition is also redundant: `needs: create-release` already enforces the dependency and prevents the job from running if `create-release` fails.

Fix: remove the `if`. The `needs:` declaration is sufficient.

## Changes

- `.github/workflows/release.yml`: remove `if: ${{ needs.create-release.result == 'success' }}` from `build-and-attest`

## Context

Discovered while attempting `workflow_dispatch` to re-run the `publish-registry` job after it failed with `Exec format error` (ARM64 vs amd64 mcp-publisher binary, fixed in #903).
