### PR TITLE
feat(release): add standalone publish-registry workflow for manual dispatch

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -1,0 +1,111 @@
+# Standalone workflow to publish a release to the MCP Registry.
+# Triggered manually when the publish-registry job in release.yml fails
+# (e.g. due to the matrix+reusable-workflow skip on workflow_dispatch).
+# Prerequisites: GitHub release must already exist with .mcpb assets uploaded.
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (e.g. 0.13.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download MCPB files and compute SHA256
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          RELEASE_TAG="v${VERSION}"
+
+          declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
+          declare -A shas
+
+          for target in "${targets[@]}"; do
+            MCPB_NAME="aptu-coder-${VERSION}-${target}.mcpb"
+            gh release download "${RELEASE_TAG}" \
+              --repo clouatre-labs/aptu-coder \
+              --pattern "${MCPB_NAME}" \
+              --dir /tmp
+            sha=$(sha256sum "/tmp/${MCPB_NAME}" | cut -d' ' -f1)
+            shas["${target}"]="$sha"
+          done
+
+          echo "SHA_AARCH64_APPLE_DARWIN=${shas[aarch64-apple-darwin]}" >> "$GITHUB_ENV"
+          echo "SHA_AARCH64_LINUX_MUSL=${shas[aarch64-unknown-linux-musl]}" >> "$GITHUB_ENV"
+          echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
+
+      - name: Build server.json from template
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+
+          jq \
+            --arg version "$VERSION" \
+            --arg sha_darwin "$SHA_AARCH64_APPLE_DARWIN" \
+            --arg sha_linux_arm "$SHA_AARCH64_LINUX_MUSL" \
+            --arg sha_linux_x86 "$SHA_X86_64_LINUX_MUSL" \
+            '.version = $version |
+             .packages = [
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/aptu-coder/releases/download/v\($version)/aptu-coder-\($version)-aarch64-apple-darwin.mcpb",
+                 "fileSha256": $sha_darwin,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/aptu-coder/releases/download/v\($version)/aptu-coder-\($version)-aarch64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_arm,
+                 "transport": {"type": "stdio"}
+               },
+               {
+                 "registryType": "mcpb",
+                 "identifier": "https://github.com/clouatre-labs/aptu-coder/releases/download/v\($version)/aptu-coder-\($version)-x86_64-unknown-linux-musl.mcpb",
+                 "fileSha256": $sha_linux_x86,
+                 "transport": {"type": "stdio"}
+               }
+             ]' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download v1.7.8 \
+            --repo modelcontextprotocol/registry \
+            --pattern "mcp-publisher_linux_arm64.tar.gz" \
+            --output /tmp/mcp-publisher.tar.gz
+          echo "3eaa88ea0590433b538d3971a6ca0863d0345d3ff5937b0d1874b7a8de71a591  /tmp/mcp-publisher.tar.gz" | sha256sum --check
+          tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
+          test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }
+          sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher
+          rm -f /tmp/mcp-publisher.tar.gz
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Login via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: mcp-publisher publish

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -29,10 +29,9 @@ jobs:
       - name: Download MCPB files and compute SHA256
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-
-          VERSION="${{ inputs.version }}"
           RELEASE_TAG="v${VERSION}"
 
           declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
@@ -53,10 +52,10 @@ jobs:
           echo "SHA_X86_64_LINUX_MUSL=${shas[x86_64-unknown-linux-musl]}" >> "$GITHUB_ENV"
 
       - name: Build server.json from template
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-
-          VERSION="${{ inputs.version }}"
 
           jq \
             --arg version "$VERSION" \

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -22,6 +22,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      MCP_PUBLISHER_VERSION: '1.7.8'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -33,6 +35,8 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_TAG="v${VERSION}"
+          TMPDIR="$(mktemp -d)"
+          echo "MCPB_TMPDIR=${TMPDIR}" >> "$GITHUB_ENV"
 
           declare -a targets=("aarch64-apple-darwin" "aarch64-unknown-linux-musl" "x86_64-unknown-linux-musl")
           declare -A shas
@@ -42,8 +46,8 @@ jobs:
             gh release download "${RELEASE_TAG}" \
               --repo clouatre-labs/aptu-coder \
               --pattern "${MCPB_NAME}" \
-              --dir /tmp
-            sha=$(sha256sum "/tmp/${MCPB_NAME}" | cut -d' ' -f1)
+              --dir "${TMPDIR}"
+            sha=$(sha256sum "${TMPDIR}/${MCPB_NAME}" | cut -d' ' -f1)
             shas["${target}"]="$sha"
           done
 
@@ -90,7 +94,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release download v1.7.8 \
+          gh release download "v${MCP_PUBLISHER_VERSION}" \
             --repo modelcontextprotocol/registry \
             --pattern "mcp-publisher_linux_arm64.tar.gz" \
             --output /tmp/mcp-publisher.tar.gz
@@ -108,3 +112,7 @@ jobs:
 
       - name: Publish to MCP Registry
         run: mcp-publisher publish
+
+      - name: Cleanup temporary files
+        if: always()
+        run: rm -rf "${MCPB_TMPDIR:-}"

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -90,8 +90,6 @@ jobs:
             server.json > server.json.tmp && mv server.json.tmp server.json
 
       - name: Install mcp-publisher
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           gh release download "v${MCP_PUBLISHER_VERSION}" \


### PR DESCRIPTION
## Summary

The `publish-registry` job in `release.yml` cannot be re-triggered via `workflow_dispatch` because it depends on `generate-mcpb` which depends on `build-and-attest` -- a matrix job using a reusable workflow (`uses:`). GitHub Actions does not expand matrix+reusable-workflow jobs when triggered via `workflow_dispatch`, causing the entire dependency chain to be skipped.

This PR adds a standalone `publish-registry.yml` workflow with a single `workflow_dispatch` trigger that accepts a `version` input and runs only the MCP Registry publish steps. It uses `gh release download` for the `.mcpb` assets (already uploaded) and the correct `mcp-publisher_linux_arm64.tar.gz` binary for the ARM64 runner.

## Changes

- `.github/workflows/publish-registry.yml`: new standalone workflow for manual MCP Registry publish

## Context

Discovered while attempting to re-publish 0.13.2 to the MCP Registry after the initial publish-registry job failed with `Exec format error` (ARM64 vs amd64 binary, fixed in #903). Multiple `workflow_dispatch` attempts on `release.yml` confirmed the matrix skip is a GitHub Actions platform limitation.
