### PR TITLE
chore(ci): upgrade aptu action to v0.7.0, add pr-review instructions

### DIFF
--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -1,0 +1,32 @@
+# PR Review Instructions
+
+## Scope
+
+Review only what the PR changes. Do not flag issues in files the PR does not touch.
+
+## Workflow files
+
+When reviewing `.github/workflows/` changes:
+
+- Evaluate the full job context, not individual steps in isolation. A step that installs a binary
+  and a step that executes it are part of the same job; verify both exist before flagging a
+  missing publish or execution command.
+- Flag `${{ expression }}` interpolation directly inside `run:` scripts as an injection risk;
+  inputs should be passed via `env:` blocks.
+- Verify action pins use commit SHAs, not mutable tags.
+- Check that `permissions:` blocks are present and minimal.
+
+## Rust crates
+
+- Do not suggest adding dependencies without a clear justification.
+- Do not flag missing `unwrap()` suppression in test code; `.unwrap()` is acceptable in tests.
+- Verify that new tool handlers in `crates/aptu-coder/src/lib.rs` follow the patterns documented
+  in `AGENTS.md` (rmcp footguns section) before flagging style issues.
+
+## General
+
+- One comment per distinct issue; do not duplicate findings across multiple inline comments.
+- Prefer suggesting a fix (suggestion block) over describing the problem when the fix is
+  unambiguous.
+- Do not comment on code style that `cargo fmt` or `cargo clippy` would catch automatically;
+  those are enforced by CI.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@9cdcf9ac5f62b88345a20f1f6748e622df7a9798 # v0.5.1
+        uses: clouatre-labs/aptu@cb08760ef7f38176359a4b1713297cced31b76f5 # v0.7.0
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrades the `aptu` PR review action from v0.5.1 to v0.7.0 and adds `.github/instructions/pr-review.md`
with repo-specific review guidance.

## Changes

- `.github/workflows/pr-review.yml`: bump `clouatre-labs/aptu` pin from `9cdcf9ac` (v0.5.1) to `cb08760e` (v0.7.0)
- `.github/instructions/pr-review.md`: new file; injects review constraints into the AI reviewer's system prompt

## Motivation

PR #905 received a false-positive inline comment (ID 3243563061) asserting the workflow had no publish step,
when `mcp-publisher publish` exists in a separate `run:` block four steps later. Two v0.7.0 fixes address this:

- **#1233** (v0.6.0, carried into v0.7.0): paginate PR files and detect patch truncation -- a truncated patch
  is the most likely reason the reviewer only saw part of the install step.
- **#1235** (v0.7.0): inject `AGENTS.md` and `.github/instructions/pr-review.md` into review context.

The new `pr-review.md` explicitly instructs the reviewer to evaluate full job context rather than individual
steps in isolation before flagging a missing execution command.

## Test plan

- [ ] CI passes (zizmor, lint, coverage)
- [ ] `aptu` action runs on next PR open/sync and produces a review without the step-isolation false positive
