### PR TITLE
fix(ci): use ubuntu-24.04-arm runner in pr-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   label:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Summary

Aligns the `pr-review` workflow runner with every other CI job in the repo. The `label` job was using `ubuntu-24.04` (x86_64); all other jobs use `ubuntu-24.04-arm`.

## Changes

- `.github/workflows/pr-review.yml` -- `runs-on: ubuntu-24.04` -> `runs-on: ubuntu-24.04-arm`

## Test plan

- [ ] CI passes on ARM runner
