### PR TITLE
ci(pr-review): wire instructions file and add anthropic key

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,6 +27,7 @@ jobs:
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
@@ -34,4 +35,5 @@ jobs:
           skip-labeled: 'false'
           fallback-provider: 'openrouter'
           fallback-model: 'inception/mercury-2'
+          instructions-file: .github/instructions/pr-review.md
           repo-path: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

Wires the existing `.github/instructions/pr-review.md` into the PR review workflow via `instructions-file`. Also passes `ANTHROPIC_API_KEY` so the Anthropic provider is available as a fallback.

## Changes

- `.github/workflows/pr-review.yml`: add `anthropic-api-key`, add `instructions-file`
