### PR TITLE
fix(profiles): restore 9-tool default, add compact profile for remote-* opt-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 - `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution; must be within the server CWD.
-- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* and remote_* tools (3 tools); `analyze` disables edit_* and remote_* tools (5 tools); `remote` enables all 9 tools; absent/unknown disables remote_* tools (7 tools). By default, `remote_tree` and `remote_file` are disabled unless profile is explicitly set to `remote`.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* and remote_* tools (3 tools); `analyze` disables edit_* and remote_* tools (5 tools); `compact` disables remote_* tools (7 tools); `remote` enables all 9 tools; absent/unknown enables all 9 tools. By default, all 9 tools are available including `remote_tree` and `remote_file`.
 
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3972,7 +3972,7 @@ impl ServerHandler for CodeAnalyzer {
         // feature. The spec-compliant way to restrict tools is for the orchestrator to pass
         // a filtered `tools` array in the API call, or for clients to use tool annotations
         // (readOnlyHint/destructiveHint) to apply their own policy.
-        // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
+        // Profiles: "edit" (3 tools), "analyze" (5 tools), "compact" (7 tools), "remote" (9 tools), absent/unknown (9 tools).
         // _meta key "io.clouatre-labs/profile" takes precedence over APTU_CODER_PROFILE env var.
         let meta_lock = self.profile_meta.lock().await;
         let meta_profile = meta_lock
@@ -3988,9 +3988,12 @@ impl ServerHandler for CodeAnalyzer {
         {
             let mut router = self.tool_router.write().await;
 
-            // Default: remote tools off unless profile explicitly enables them.
-            // Profiles: "edit" (3 tools), "analyze" (5 tools), "remote" (all 9 tools), absent/unknown (7 tools, no remote_*).
-            let enable_remote = active_profile.as_deref() == Some("remote");
+            // Default: all 9 tools enabled unless profile explicitly disables them.
+            // Profiles: "edit" (3 tools), "analyze" (5 tools), "compact" (7 tools), "remote" (9 tools), absent/unknown (9 tools).
+            let enable_remote = !matches!(
+                active_profile.as_deref(),
+                Some("compact") | Some("edit") | Some("analyze")
+            );
             // Add new remote_* tool names here when introduced.
             if !enable_remote {
                 disable_routes(&mut router, &["remote_tree", "remote_file"]);
@@ -4016,11 +4019,15 @@ impl ServerHandler for CodeAnalyzer {
                         disable_routes(&mut router, &["edit_replace", "edit_overwrite"]);
                         // remote_tree and remote_file already disabled above
                     }
+                    "compact" => {
+                        // Enable 7 tools: all except remote_tree and remote_file
+                        // remote_tree and remote_file already disabled above
+                    }
                     "remote" => {
                         // All 9 tools enabled; remote tools re-enabled by enable_remote=true above
                     }
                     _ => {
-                        // Unknown profile: leave non-remote tools as default (lenient fallback)
+                        // Unknown profile: all 9 tools enabled (lenient fallback)
                     }
                 }
             }

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -325,6 +325,40 @@ async fn test_remote_profile_tool_count() {
 }
 
 #[tokio::test]
+async fn test_compact_profile_tool_count() {
+    let _guard = env_var_lock();
+    // Arrange: initialize with compact profile
+    let resp = call_tools_list_with_profile(Some("compact")).await;
+
+    // Act: extract tool count from response
+    let tools = &resp["result"]["tools"];
+    let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
+    let tool_names: Vec<String> = tools
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    // Assert: compact profile should have exactly 7 tools (remote_tree and remote_file disabled)
+    assert_eq!(
+        tool_count, 7,
+        "compact profile should enable exactly 7 tools, got: {:?}",
+        tool_names
+    );
+
+    // Verify remote tools are NOT present
+    assert!(
+        !tool_names.contains(&"remote_tree".to_string()),
+        "compact profile should NOT include remote_tree"
+    );
+    assert!(
+        !tool_names.contains(&"remote_file".to_string()),
+        "compact profile should NOT include remote_file"
+    );
+}
+
+#[tokio::test]
 async fn test_no_profile_tool_count() {
     let _guard = env_var_lock();
     // Arrange: initialize with no profile metadata; env var must be absent.
@@ -337,10 +371,10 @@ async fn test_no_profile_tool_count() {
     let tools = &resp["result"]["tools"];
     let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
 
-    // Assert: no profile should enable 7 tools (remote_tree and remote_file disabled by default)
+    // Assert: no profile should enable all 9 tools (default behavior)
     assert_eq!(
-        tool_count, 7,
-        "no profile should enable 7 tools (remote_tree and remote_file disabled), got: {}",
+        tool_count, 9,
+        "no profile should enable all 9 tools (default behavior), got: {}",
         tool_count
     );
 }
@@ -358,10 +392,10 @@ async fn test_unknown_profile_tool_count() {
     let tools = &resp["result"]["tools"];
     let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
 
-    // Assert: unknown profile should enable 7 tools (remote_tree and remote_file disabled by default)
+    // Assert: unknown profile should enable all 9 tools (lenient fallback)
     assert_eq!(
-        tool_count, 7,
-        "unknown profile should enable 7 tools (remote_tree and remote_file disabled), got: {}",
+        tool_count, 9,
+        "unknown profile should enable all 9 tools (lenient fallback), got: {}",
         tool_count
     );
 }


### PR DESCRIPTION
## Summary

Restores the 9-tool default broken by #872. Clients connecting without `APTU_CODER_PROFILE` or `io.clouatre-labs/profile` now receive all 9 tools including `remote_tree` and `remote_file`. A new `compact` profile is introduced for clients that want to suppress remote tools to save schema bytes.

Profiles after this change:

| Profile | Tools | Notes |
|---------|-------|-------|
| absent/unknown | 9 | restored default |
| `remote` | 9 | retained as explicit alias |
| `compact` | 7 | new opt-in, disables remote_* |
| `analyze` | 5 | unchanged |
| `edit` | 3 | unchanged |

## Changes

- `crates/aptu-coder/src/lib.rs`: flip `enable_remote` to default true (disabled only for `compact`/`edit`/`analyze`); add `compact` match arm; update profile comment block
- `crates/aptu-coder/tests/profiles.rs`: update `test_no_profile_tool_count` and `test_unknown_profile_tool_count` assertions 7 -> 9; add `test_compact_profile_tool_count` asserting 7 tools with remote_tree/remote_file absent
- `AGENTS.md`: update profile table to document `compact` and corrected defaults

## Test plan

- [x] Tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [x] Security scan clean (no secrets, no unsafe, no new dependencies)

Closes #909
