### PR TITLE
chore: bump version to 0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump version to 0.13.4 to cut a release that ships the Homebrew `service do` block added in clouatre-labs/homebrew-tap#102.

## Changes

- `Cargo.toml`: `0.13.3` -> `0.13.4`
- `Cargo.lock`: updated workspace member versions

## Test plan

- [ ] Tests pass
- [ ] Linter clean
- [ ] Release workflow builds and publishes binaries for all three targets
- [ ] homebrew-tap formula is updated to 0.13.4 by the post-release automation

Closes #912
