### PR TITLE
chore: bump version to 0.13.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bumps workspace version from `0.13.4` to `0.13.5` ahead of the patch release.

## Summary

Patch release fixing `exec_command` PATH resolution in HTTP transport mode. When running as a launchd service (`brew services start aptu-coder`), the process received a bare system PATH from launchd and could not find user-installed tools (`gpg`, `brew`, `rg`, etc.). This was a regression introduced in v0.13.4 when HTTP mode was added.

## What's Changed

### Bug Fixes

- **exec_command PATH injection**: At server startup, aptu-coder now snapshots the user's full login PATH by invoking `$SHELL -l -c 'echo $PATH'` once. The result is stored as `Arc<Option<String>>` on `CodeAnalyzer` and injected via `cmd.env("PATH", ...)` into every child process spawned by `exec_command`. Falls back to the current process PATH (inherited in stdio mode) if the login shell snapshot fails. Zero per-command overhead. (#917, closes #916)

## Breaking Changes

None - this release is fully backward compatible with v0.13.4.

**Full Changelog:** https://github.com/clouatre-labs/aptu-coder/compare/v0.13.4...v0.13.5
