### PR TITLE
fix(kotlin): correct DEFUSE_QUERY to use identifier via variable_declaration

### DIFF
--- a/crates/aptu-coder-core/src/languages/kotlin.rs
+++ b/crates/aptu-coder-core/src/languages/kotlin.rs
@@ -28,14 +28,20 @@ pub const IMPORT_QUERY: &str = r"
 ";
 
 /// Tree-sitter query for extracting definition and use sites.
+/// Write-site patterns capture the identifier node within property declarations:
+/// - (single): captures `val x = ...` or `var x = ...` via variable_declaration
+/// - (multi): captures `val (a, b) = ...` via multi_variable_declaration
 pub const DEFUSE_QUERY: &str = r"
+; write site: val/var x = ... (single variable declaration)
 (property_declaration
   (variable_declaration
     (identifier) @write.property))
+; write site: val (a, b) = ... (destructuring declaration)
 (property_declaration
   (multi_variable_declaration
     (variable_declaration
       (identifier) @write.property)))
+; read site: any identifier reference -- intentionally broad, consistent with Python/Go/Rust patterns
 (identifier) @read.usage
 ";
 

--- a/crates/aptu-coder-core/src/languages/kotlin.rs
+++ b/crates/aptu-coder-core/src/languages/kotlin.rs
@@ -30,8 +30,13 @@ pub const IMPORT_QUERY: &str = r"
 /// Tree-sitter query for extracting definition and use sites.
 pub const DEFUSE_QUERY: &str = r"
 (property_declaration
-  name: (simple_identifier) @write.property)
-(simple_identifier) @read.usage
+  (variable_declaration
+    (identifier) @write.property))
+(property_declaration
+  (multi_variable_declaration
+    (variable_declaration
+      (identifier) @write.property)))
+(identifier) @read.usage
 ";
 
 use tree_sitter::Node;
@@ -540,5 +545,66 @@ mod tests {
             find_node(class_node, "function_declaration").expect("function_declaration not found");
         let result = find_method_for_receiver(&node, src, None);
         assert_eq!(result, Some("bar".to_string()));
+    }
+
+    #[test]
+    fn test_defuse_kotlin_val_declaration() {
+        // Arrange: val declaration with write and read
+        let source = r#"
+fun main() {
+    val x = 42
+    val y = x + 1
+}
+"#;
+        // Act
+        let sites = crate::parser::SemanticExtractor::extract_def_use_for_file(
+            source,
+            "kotlin",
+            "x",
+            "src/main.kt",
+            None,
+        );
+
+        // Assert
+        assert!(
+            !sites.is_empty(),
+            "expected at least one def-use site for 'x'"
+        );
+        let has_write = sites
+            .iter()
+            .any(|s| s.kind == crate::types::DefUseKind::Write);
+        let has_read = sites
+            .iter()
+            .any(|s| s.kind == crate::types::DefUseKind::Read);
+        assert!(has_write, "expected a write site for 'x'");
+        assert!(has_read, "expected a read site for 'x'");
+    }
+
+    #[test]
+    fn test_defuse_kotlin_multi_variable_declaration() {
+        // Arrange: destructuring assignment with multiple write sites
+        let source = r#"
+fun main() {
+    val (a, b) = Pair(1, 2)
+}
+"#;
+        // Act
+        let sites_a = crate::parser::SemanticExtractor::extract_def_use_for_file(
+            source,
+            "kotlin",
+            "a",
+            "src/main.kt",
+            None,
+        );
+
+        // Assert
+        assert!(
+            !sites_a.is_empty(),
+            "expected at least one def-use site for 'a'"
+        );
+        let has_write_a = sites_a
+            .iter()
+            .any(|s| s.kind == crate::types::DefUseKind::Write);
+        assert!(has_write_a, "expected a write site for 'a'");
     }
 }


### PR DESCRIPTION
## Summary

Fixes a startup-time query compilation failure for the Kotlin language support. The `DEFUSE_QUERY` constant in `kotlin.rs` referenced `simple_identifier`, a node type that does not exist in `tree-sitter-kotlin-ng` v1.1.0, and used a `name:` field on `property_declaration` that does not exist in the grammar. This caused the error logged at every server start:

```
ERROR aptu_coder_core::parser: Failed to compile queries for language kotlin: Query error: Failed to compile defuse query for kotlin: Query error at 3:10. Invalid node type "simple_identifier"
```

## Changes

- `crates/aptu-coder-core/src/languages/kotlin.rs`: Replace the broken `DEFUSE_QUERY` with patterns that follow the actual grammar path (`property_declaration` > `variable_declaration` > `identifier` and `property_declaration` > `multi_variable_declaration` > `variable_declaration` > `identifier`). Add semicolon-style inline comments inside the query string and `///` doc comments on the const explaining each capture's intent. Add two tests: `test_defuse_kotlin_val_declaration` (write + read sites for a simple `val`) and `test_defuse_kotlin_multi_variable_declaration` (write sites for a destructuring declaration), one per structurally distinct query path.

## Test plan

- [ ] Tests pass: 17/17 kotlin (`cargo test -p aptu-coder-core -- languages::kotlin`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] No `simple_identifier` references remain in `kotlin.rs`
- [ ] Security scan clean (0 findings)

Closes #920
