### PR TITLE
docs(contributing): add Code Quality Rules and enforce undocumented_unsafe_blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,19 @@ All changes go through a pull request; no direct pushes to main are permitted.
 - No unresolved review comments
 - Reviewer approves or all raised issues are addressed
 
+## Code Quality Rules
+
+This project follows a Rust adaptation of the [NASA/JPL Power of 10](https://en.wikipedia.org/wiki/The_Power_of_10:_Rules_for_Developing_Safety-Critical_Code) to ensure code reliability and maintainability. The following rules are mechanically enforced via CI:
+
+- **Zero warnings:** `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test`, and `cargo deny check` must all pass
+- **Every unsafe block requires a SAFETY comment:** Enforced by `clippy::undocumented_unsafe_blocks = deny` in workspace lints
+- **No .unwrap() or .expect() in library or server code:** Restricted to tests, examples, and startup paths (future mechanical enforcement via `clippy::unwrap_used`)
+- **No unchecked indexing on untrusted data:** Use `.get()` with explicit error propagation instead of `[]`
+- **Loops over untrusted or externally-driven data must have an explicit bound or checked max-iteration guard**
+- **Minimize #[cfg] feature combinations:** Each supported combination must be covered by CI
+
+Note: Mechanical enforcement of `unwrap_used` is deferred to a follow-on issue.
+
 ## Automated Review Tooling
 
 This repository uses [aptu](https://github.com/clouatre-labs/aptu) for automated issue triage and pull request review via GitHub Actions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ rustls = "0.23"
 url = "2"
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false }
 
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3642,6 +3642,9 @@ fn build_exec_command(
             warn!("memory_limit_mb is not enforced on this platform (Linux only)");
         }
         if memory_limit_mb.is_some() || cpu_limit_secs.is_some() {
+            // SAFETY: This closure runs in the child process after fork() and before exec(),
+            // making it safe to call setrlimit (a signal-safe syscall). No Rust objects are
+            // accessed or mutated, and the closure does not unwind.
             unsafe {
                 cmd.pre_exec(move || {
                     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Adds a Code Quality Rules section to `CONTRIBUTING.md` documenting a Rust adaptation of the NASA/JPL Power of 10 principles, calibrated for developer experience. Enables `clippy::undocumented_unsafe_blocks = "deny"` as the first mechanical enforcement step, and fixes the single non-test unsafe block in the codebase that was missing a `SAFETY` comment.

## Changes

- **CONTRIBUTING.md**: new `## Code Quality Rules` section inserted after the Code review section, listing six rules (zero warnings, `SAFETY` comments on unsafe, no `.unwrap()`/`.expect()` in production paths, no unchecked indexing on untrusted data, explicit loop bounds on untrusted input, minimal `#[cfg]` combinations). Notes that `clippy::unwrap_used` mechanical enforcement is deferred to a follow-on issue.
- **Cargo.toml**: new `[workspace.lints.clippy]` section with `undocumented_unsafe_blocks = "deny"`.
- **crates/aptu-coder/src/lib.rs**: `// SAFETY:` comment added to the `pre_exec` setrlimit closure -- the single non-test unsafe block that lacked one.

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes once the pre-existing otel compilation error on `main` is resolved (tracked separately; unrelated to this PR)
- [ ] `cargo test` passes
- [ ] 19 lines added total; no new dependencies

Closes #925
