### PR TITLE
ci: pass --locked to all cargo commands to honour Cargo.lock

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ inputs.dry_run }}
         env:
           TARGET: ${{ inputs.target }}
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --locked --release --target "${TARGET}"
 
       - name: Sign tarball with cosign
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Run Clippy lints
-        run: cargo clippy --profile ci -- -D warnings -W clippy::cognitive_complexity
+        run: cargo clippy --locked --profile ci -- -D warnings -W clippy::cognitive_complexity
       - name: Check SPDX headers
         run: |
           rg --files crates/ | rg '\.rs$' | while read -r f; do
@@ -173,22 +173,22 @@ jobs:
           tool: cargo-nextest
       - name: Coverage
         run: |
-          cargo llvm-cov nextest --no-report --all-features \
+          cargo llvm-cov nextest --locked --no-report --all-features \
             --workspace \
             -E 'not binary(mcp_smoke)'
-          cargo llvm-cov report -p aptu-coder-core \
+          cargo llvm-cov report --locked -p aptu-coder-core \
             --fail-under-lines 90 \
             --fail-under-regions 80 \
             --lcov --output-path lcov-core.info
           # aptu-coder coverage tracked but not gated (transport/logging/metrics layer)
-          cargo llvm-cov report -p aptu-coder \
+          cargo llvm-cov report --locked -p aptu-coder \
             --lcov --output-path lcov-mcp.info || true
           # aptu-coder-remote coverage with thresholds enforced.
           # The gitlab crate does not support HTTP base URL injection so
           # gitlab_fetch_tree / gitlab_fetch_file internals cannot be reached
           # via wiremock. Thresholds reflect coverage achievable without
           # refactoring the GitLab client.
-          cargo llvm-cov report -p aptu-coder-remote \
+          cargo llvm-cov report --locked -p aptu-coder-remote \
             --lcov --output-path lcov-remote.info \
             --fail-under-lines 60 --fail-under-regions 50
 
@@ -227,7 +227,7 @@ jobs:
           cache-targets: false
           save-if: true
       - name: Check MSRV
-        run: cargo check
+        run: cargo check --locked
 
   zizmor:
     name: zizmor


### PR DESCRIPTION
## Summary

CI currently ignores the committed `Cargo.lock` because no cargo command passes `--locked`. Any new crates.io publish can break every open PR simultaneously, even when those PRs have no dependency changes.

On 2026-05-18, `tracing-opentelemetry 0.32.1` published and triggered exactly this: all open PRs failed MSRV, Lint, and Coverage jobs due to a transitive `opentelemetry 0.32` vs `0.31` conflict.

## Changes

Adds `--locked` to 8 cargo commands across 2 workflow files:

- `.github/workflows/ci.yml` -- clippy, llvm-cov nextest, llvm-cov report (x3), check
- `.github/workflows/build-and-attest.yml` -- cargo build --release

Exempt by design (unchanged):

- `cargo fmt --check` -- source-only formatter, no dependency resolution
- `cargo deny check advisories licenses` -- audits the lockfile directly; `--locked` is not a supported flag
- `cargo release publish` -- publishing tool manages its own resolution

## Test plan

- [ ] CI passes on this branch with no Cargo.lock changes
- [ ] Lint clean
- [ ] Once merged, PR #926 CI should go green

Closes #927
