### PR TITLE
ci(supply-chain): add package-age check and scorecard SARIF upload

### DIFF
--- a/.github/scripts/check-package-age.sh
+++ b/.github/scripts/check-package-age.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-package-age.sh: Validate that new dependencies introduced in a PR
+# were published at least 7 days ago on crates.io.
+#
+# This script:
+# 1. Diffs Cargo.lock against origin/main to find new [[package]] entries
+# 2. Extracts crate name and version pairs
+# 3. Queries the crates.io API for each new crate
+# 4. Compares the published date to today minus 7 days
+# 5. Fails if any crate is too new (unless SKIP_PACKAGE_AGE_CHECK=true)
+
+SKIP_PACKAGE_AGE_CHECK="${SKIP_PACKAGE_AGE_CHECK:-false}"
+
+if [ "$SKIP_PACKAGE_AGE_CHECK" = "true" ]; then
+  echo "Package age check skipped (SKIP_PACKAGE_AGE_CHECK=true)"
+  exit 0
+fi
+
+# Ensure we have Cargo.lock and origin/main is available
+if [ ! -f "Cargo.lock" ]; then
+  echo "Error: Cargo.lock not found"
+  exit 1
+fi
+
+# Fetch origin/main to ensure we have the latest base branch
+git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
+
+# Get the diff of Cargo.lock against origin/main
+# We look for lines that start with '+[[package]]' to find new package entries
+DIFF_OUTPUT=$(git diff origin/main -- Cargo.lock || echo "")
+
+if [ -z "$DIFF_OUTPUT" ]; then
+  echo "No changes to Cargo.lock detected"
+  exit 0
+fi
+
+# Extract new package entries: look for added lines with [[package]]
+# Then extract the name and version from the following lines
+NEW_PACKAGES=$(echo "$DIFF_OUTPUT" | awk '
+  /^\+\[\[package\]\]/ {
+    in_new_package = 1
+  }
+  in_new_package && /^\+name = / {
+    gsub(/^\+name = "/, "")
+    gsub(/"$/, "")
+    name = $0
+  }
+  in_new_package && /^\+version = / {
+    gsub(/^\+version = "/, "")
+    gsub(/"$/, "")
+    version = $0
+    print name ":" version
+    in_new_package = 0
+  }
+')
+
+if [ -z "$NEW_PACKAGES" ]; then
+  echo "No new packages detected in Cargo.lock"
+  exit 0
+fi
+
+echo "Checking age of new packages..."
+
+# Use gdate if available (GNU date), otherwise use date
+DATE_CMD="date"
+if command -v gdate &> /dev/null; then
+  DATE_CMD="gdate"
+fi
+
+# Calculate the threshold date (7 days ago)
+THRESHOLD_SECONDS=$((7 * 24 * 60 * 60))
+CURRENT_TIMESTAMP=$($DATE_CMD +%s)
+THRESHOLD_TIMESTAMP=$((CURRENT_TIMESTAMP - THRESHOLD_SECONDS))
+
+FAILED=0
+
+while IFS=':' read -r NAME VERSION; do
+  if [ -z "$NAME" ] || [ -z "$VERSION" ]; then
+    continue
+  fi
+
+  echo -n "Checking $NAME@$VERSION... "
+
+  # Query crates.io API for this specific version
+  RESPONSE=$(curl -s "https://crates.io/api/v1/crates/$NAME/$VERSION" 2>/dev/null || echo "{}")
+
+  # Extract the created_at timestamp
+  CREATED_AT=$(echo "$RESPONSE" | jq -r '.version.created_at // empty' 2>/dev/null || echo "")
+
+  if [ -z "$CREATED_AT" ]; then
+    echo "WARNING: Could not fetch metadata from crates.io"
+    continue
+  fi
+
+  # Convert ISO 8601 timestamp to Unix timestamp
+  CREATED_TIMESTAMP=$($DATE_CMD -d "$CREATED_AT" +%s 2>/dev/null || echo "0")
+
+  if [ "$CREATED_TIMESTAMP" -eq 0 ]; then
+    echo "WARNING: Could not parse created_at timestamp"
+    continue
+  fi
+
+  # Check if the package is too new
+  if [ "$CREATED_TIMESTAMP" -gt "$THRESHOLD_TIMESTAMP" ]; then
+    DAYS_OLD=$(( (CURRENT_TIMESTAMP - CREATED_TIMESTAMP) / (24 * 60 * 60) ))
+    echo "FAIL (published $DAYS_OLD days ago, threshold is 7 days)"
+    FAILED=1
+  else
+    DAYS_OLD=$(( (CURRENT_TIMESTAMP - CREATED_TIMESTAMP) / (24 * 60 * 60) ))
+    echo "OK (published $DAYS_OLD days ago)"
+  fi
+done <<< "$NEW_PACKAGES"
+
+if [ "$FAILED" -eq 1 ]; then
+  echo ""
+  echo "Error: One or more new dependencies are too recent."
+  echo "To override this check for urgent security patches, set SKIP_PACKAGE_AGE_CHECK=true"
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/check-package-age.sh
+++ b/.github/scripts/check-package-age.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 aptu-coder contributors
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 # check-package-age.sh: Validate that new dependencies introduced in a PR
@@ -24,14 +26,16 @@ if [ ! -f "Cargo.lock" ]; then
   exit 1
 fi
 
-# Fetch origin/main to ensure we have the latest base branch
-git fetch origin main:refs/remotes/origin/main 2>/dev/null || true
+# Fetch origin/main with minimal depth to ensure the ref is available even in
+# shallow clones (GitHub Actions default fetch-depth: 1 only fetches HEAD).
+git fetch --depth=1 origin main:refs/remotes/origin/main 2>/dev/null || true
 
-# Get the diff of Cargo.lock against origin/main
-# We look for lines that start with '+[[package]]' to find new package entries
-DIFF_OUTPUT=$(git diff origin/main -- Cargo.lock || echo "")
-
-if [ -z "$DIFF_OUTPUT" ]; then
+# Get the diff of Cargo.lock against origin/main.
+# Use --exit-code to distinguish "no diff" (exit 0) from errors; capture output
+# separately so set -e does not abort on a clean diff.
+if ! git diff --exit-code --quiet origin/main -- Cargo.lock 2>/dev/null; then
+  DIFF_OUTPUT=$(git diff origin/main -- Cargo.lock)
+else
   echo "No changes to Cargo.lock detected"
   exit 0
 fi
@@ -83,8 +87,10 @@ while IFS=':' read -r NAME VERSION; do
 
   echo -n "Checking $NAME@$VERSION... "
 
-  # Query crates.io API for this specific version (10s timeout to avoid hanging the job)
-  RESPONSE=$(curl -s --max-time 10 "https://crates.io/api/v1/crates/$NAME/$VERSION" 2>/dev/null || echo "{}")
+  # Query crates.io API for this specific version.
+  # --connect-timeout 5: fail fast if crates.io is unreachable.
+  # --max-time 10: cap total transfer time so the job cannot hang indefinitely.
+  RESPONSE=$(curl -s --connect-timeout 5 --max-time 10 "https://crates.io/api/v1/crates/$NAME/$VERSION" 2>/dev/null || echo "{}")
 
   # Extract the created_at timestamp
   CREATED_AT=$(echo "$RESPONSE" | jq -r '.version.created_at // empty' 2>/dev/null || echo "")

--- a/.github/scripts/check-package-age.sh
+++ b/.github/scripts/check-package-age.sh
@@ -83,8 +83,8 @@ while IFS=':' read -r NAME VERSION; do
 
   echo -n "Checking $NAME@$VERSION... "
 
-  # Query crates.io API for this specific version
-  RESPONSE=$(curl -s "https://crates.io/api/v1/crates/$NAME/$VERSION" 2>/dev/null || echo "{}")
+  # Query crates.io API for this specific version (10s timeout to avoid hanging the job)
+  RESPONSE=$(curl -s --max-time 10 "https://crates.io/api/v1/crates/$NAME/$VERSION" 2>/dev/null || echo "{}")
 
   # Extract the created_at timestamp
   CREATED_AT=$(echo "$RESPONSE" | jq -r '.version.created_at // empty' 2>/dev/null || echo "")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,6 @@ jobs:
           tool: cargo-deny
       - name: Check advisories and licenses
         run: cargo deny check advisories licenses
-      - name: Install jq
-        # jq is pre-installed on ubuntu-24.04-arm but the explicit install step
-        # makes the dependency visible and survives runner image updates.
-        run: sudo apt-get install -y jq
       - name: Check package age
         run: bash .github/scripts/check-package-age.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,8 @@ jobs:
       - name: Check advisories and licenses
         run: cargo deny check advisories licenses
       - name: Install jq
+        # jq is pre-installed on ubuntu-24.04-arm but the explicit install step
+        # makes the dependency visible and survives runner image updates.
         run: sudo apt-get install -y jq
       - name: Check package age
         run: bash .github/scripts/check-package-age.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,8 @@ jobs:
           tool: cargo-deny
       - name: Check advisories and licenses
         run: cargo deny check advisories licenses
+      - name: Check package age
+        run: bash .github/scripts/check-package-age.sh
 
   msrv:
     name: MSRV Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,8 @@ jobs:
           tool: cargo-deny
       - name: Check advisories and licenses
         run: cargo deny check advisories licenses
+      - name: Install jq
+        run: sudo apt-get install -y jq
       - name: Check package age
         run: bash .github/scripts/check-package-age.sh
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -26,3 +27,4 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          publish_results: true


### PR DESCRIPTION
## Summary

Adds two supply-chain validation improvements to CI: SARIF upload for OpenSSF Scorecard results and a package-age check that blocks dependencies published less than 7 days ago.

The Scorecard job already ran weekly but results were not visible in the GitHub Security tab because `publish_results` and the required `id-token: write` permission were missing. This PR fixes that with a two-line change to `scorecard.yml`.

The package-age check guards against day-zero slopsquatting by diffing `Cargo.lock` against `origin/main` on every PR, querying the crates.io API for each newly introduced crate, and failing the `deny` job if any crate was published within the past 7 days. An escape hatch is available via `SKIP_PACKAGE_AGE_CHECK=true` for urgent security patches that require a very recent crate. This implements the CI defense recommended in [AI Supply Chain Attacks: New Vectors in Dependencies](https://clouatre.ca/posts/ai-supply-chain-attack-vectors/) (Code Snippet 1: "verify that packages existed before the commit date").

## Why a bash script and not cargo-cooldown

`cargo-cooldown` (v0.3.1) was evaluated and rejected for this use case. Its own README states: "CI pipelines and release automation should usually use plain Cargo against committed `Cargo.lock` files." The tool is designed for local `cargo update` workflows, where it downgrades freshly resolved versions before they are written to `Cargo.lock`. In CI with a committed lock file there is nothing to downgrade -- it is a no-op. Running it in `ignore + deny` mode against the committed lock file would refuse to build any dependency newer than the threshold, including crates merged months ago that have not been updated, breaking the build incorrectly.

The PR-gate problem is different: given a Cargo.lock diff on a pull request, verify that net-new crates were not published in the last 7 days. A targeted bash script diffing against `origin/main` and querying the crates.io version endpoint is the correct tool for that specific check.

## Changes

- `.github/workflows/scorecard.yml` -- add `publish_results: true` and `id-token: write` (ossf/scorecard-action v2.4.3 requires both for Security tab visibility)
- `.github/scripts/check-package-age.sh` -- new bash script: git-diff Cargo.lock, query `https://crates.io/api/v1/crates/{name}/{version}`, fail if `created_at` is less than 7 days ago; supports `SKIP_PACKAGE_AGE_CHECK=true` override
- `.github/workflows/ci.yml` -- add package-age check step inside the `deny` job, after `cargo deny check`

## Test plan

- [ ] `shellcheck .github/scripts/check-package-age.sh` passes (verified locally)
- [ ] YAML syntax valid for both workflow files (verified locally)
- [ ] Smoke test: no new deps in Cargo.lock exits 0
- [ ] Smoke test: `SKIP_PACKAGE_AGE_CHECK=true` exits 0 with skip message
- [ ] Manual: merge this PR and confirm Scorecard results appear in the Security tab on next weekly run

Closes #930
