### PR TITLE
docs: sync documentation with PRs 926, 935, and 936

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ cargo bench
 cargo install --path crates/aptu-coder --profile release   # local install; binary lands in ~/.cargo/bin/
 ```
 
+Workspace lints enforced in CI (deny): undocumented_unsafe_blocks, unwrap_used (test code exempted via cfg_attr).
+Dependency freshness: new Cargo.lock entries must be >=7 days old; bypass with SKIP_PACKAGE_AGE_CHECK=true.
+
 ## Observability
 
 By default, the server operates with noop telemetry providers (zero overhead). Telemetry export is opt-in via environment variables:
@@ -96,7 +99,7 @@ Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) y
 ## Do not
 
 - Add dependencies without justification in the PR description
-- Use `unsafe` code
+- Use `unsafe` code without a `// SAFETY:` comment (every unsafe block requires documentation, enforced by `clippy::undocumented_unsafe_blocks = "deny"`)
 - Implement features not specified in the assigned issue
 - Modify files outside the scope of the assigned issue
 - Assume any API exists based on training data; verify against installed crate versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The `-S` flag GPG-signs the commit (required by branch protection).
 - [ ] Tests pass (`cargo test`)
 - [ ] No clippy warnings (`cargo clippy -- -D warnings`)
 - [ ] Code formatted (`cargo fmt --check`)
-- [ ] Dependency audit clean (`cargo deny check advisories licenses`)
+- [ ] Dependency audit clean (`cargo deny check advisories licenses`); dependencies must also pass the 7-day freshness gate (run automatically in CI; bypass with `SKIP_PACKAGE_AGE_CHECK=true` if necessary)
 - [ ] Commits GPG-signed and signed off (`git commit -S --signoff`)
 - [ ] Clear PR description
 
@@ -109,12 +109,10 @@ This project follows a Rust adaptation of the [NASA/JPL Power of 10](https://en.
 
 - **Zero warnings:** `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test`, and `cargo deny check` must all pass
 - **Every unsafe block requires a SAFETY comment:** Enforced by `clippy::undocumented_unsafe_blocks = deny` in workspace lints
-- **No .unwrap() or .expect() in library or server code:** Restricted to tests, examples, and startup paths (future mechanical enforcement via `clippy::unwrap_used`)
+- **No `.unwrap()` in production code:** Enforced by `clippy::unwrap_used = "deny"`. Test code is exempted via `#[cfg_attr(test, allow(clippy::unwrap_used))]` at each crate root.
 - **No unchecked indexing on untrusted data:** Use `.get()` with explicit error propagation instead of `[]`
 - **Loops over untrusted or externally-driven data must have an explicit bound or checked max-iteration guard**
 - **Minimize #[cfg] feature combinations:** Each supported combination must be covered by CI
-
-Note: Mechanical enforcement of `unwrap_used` is deferred to a follow-on issue.
 
 ## Automated Review Tooling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,8 @@ cosign verify-blob \
 ```
 
 Replace `<version>` with the release version and `<target>` with the target triple (e.g., `x86_64-unknown-linux-musl`).
+
+## Supply Chain Integrity
+
+- New Cargo.lock dependencies must be at least 7 days old at the time of addition (enforced by CI; bypass with `SKIP_PACKAGE_AGE_CHECK=true` for urgent security patches).
+- OpenSSF Scorecard runs weekly and uploads results to the GitHub Security tab as SARIF.

--- a/docs/REPO-STANDARDS.md
+++ b/docs/REPO-STANDARDS.md
@@ -14,6 +14,7 @@ This document maps every repo-level artifact to its purpose and the rationale be
 | `.github/workflows/ci.yml` | Lint, test, audit; path-filtered; aggregate `CI Result` job; pass `--profile ci` explicitly on `cargo clippy` (not `cargo test`: profile.ci inherits `panic=abort` which aborts the test harness) |
 | `.github/workflows/build-and-attest.yml` | Reusable multi-platform build with cosign signing and provenance attestation |
 | `.github/workflows/release.yml` | GPG tag verification, Homebrew + cargo-binstall + crates.io distribution |
+| `.github/scripts/check-package-age.sh` | Validates new Cargo.lock dependencies are >=7 days old; bypass with `SKIP_PACKAGE_AGE_CHECK=true` |
 | `.commitlintrc.yml` | Enforces Conventional Commits for automated changelog and searchable history |
 | `clippy.toml` | Clippy configuration; lints enforced with `-D warnings` in CI; cognitive complexity threshold set to 30 |
 | `deny.toml` | `cargo deny` configuration for advisory and license checks |
@@ -55,6 +56,8 @@ ci-result:
 **Provenance attestation.** `build-and-attest.yml` generates a signed attestation via `actions/attest-build-provenance`. Consumers can verify with `gh attestation verify` before installing. `Cargo.lock` is committed and `cargo deny` enforces license and advisory checks in CI. Build provenance is covered by cosign signing and `actions/attest-build-provenance` (SLSA Build L3).
 
 **Runner pinning to ubuntu-24.04-arm.** `ubuntu-latest` is a moving alias; GitHub advances it to the next LTS image with short notice. Pinning to a specific image (`ubuntu-24.04-arm`) makes toolchain changes explicit and reviewable rather than silent. Renovate keeps the pin current via automated PRs.
+
+**New dependency freshness gate.** The `deny` CI job runs `.github/scripts/check-package-age.sh` to verify new Cargo.lock entries were published >=7 days ago.
 
 **Cognitive complexity threshold.** `clippy::cognitive_complexity` is enforced at a threshold of 30 (set in `clippy.toml`); `-D warnings` promotes violations to hard errors in CI. When a function legitimately exceeds the threshold and splitting it would reduce clarity rather than improve it, suppress with an attribute and a mandatory `reason` field:
 


### PR DESCRIPTION
## Summary

Syncs documentation with three recently merged PRs (926, 935, 936) that introduced active clippy lint enforcement and a new supply-chain check. The main issue is CONTRIBUTING.md still described `clippy::unwrap_used` enforcement as "deferred" when it has been live since PR 936.

## Changes

- **CONTRIBUTING.md**: Remove stale "deferred" note. Update unwrap bullet to state `clippy::unwrap_used = "deny"` is active and document the `cfg_attr` test-exemption pattern. Add 7-day dependency freshness gate with `SKIP_PACKAGE_AGE_CHECK=true` escape hatch to the pre-submit checklist.
- **AGENTS.md**: Fix the "Do not: Use unsafe code" bullet -- unsafe is allowed when accompanied by a `// SAFETY:` comment (enforced by `clippy::undocumented_unsafe_blocks = "deny"`). Add a two-line workspace lint summary and the `SKIP_PACKAGE_AGE_CHECK` escape hatch after the Commands section.
- **SECURITY.md**: Add a Supply Chain Integrity section covering the 7-day Cargo.lock freshness gate and the OpenSSF Scorecard SARIF upload introduced in PR 935.
- **docs/REPO-STANDARDS.md**: Add `.github/scripts/check-package-age.sh` to the artifact map and one bullet in Non-obvious Decisions explaining the freshness gate.

## Test plan

- [x] No "future mechanical enforcement" or "deferred" language remains in CONTRIBUTING.md
- [x] `SKIP_PACKAGE_AGE_CHECK` documented in CONTRIBUTING.md and AGENTS.md
- [x] AGENTS.md unsafe bullet accurately qualified (not a blanket prohibition)
- [x] SECURITY.md Supply Chain Integrity section present with 7-day and Scorecard references
- [x] docs/REPO-STANDARDS.md artifact map updated
- [x] No Rust source files modified
- [x] Linter clean (markdown only; no cargo checks needed)
- [x] Security scan clean (gitleaks: 0 leaks found)

Closes #937
