### PR TITLE
chore(release): bump version to 0.13.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "aptu-coder-core",
  "aptu-coder-remote",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "base64",
  "blake3",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-remote"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "base64",
  "gitlab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bumps the workspace version from `0.13.5` to `0.13.6` in preparation for the patch release.

## Changes

- `Cargo.toml` -- version `0.13.5` -> `0.13.6`
- `Cargo.lock` -- regenerated to reflect the new version

## Test plan

- [ ] CI passes
- [ ] Tag `v0.13.6` to be pushed after merge to trigger the release workflow
