### PR TITLE
docs(benchmarks): add v15 remote_file/remote_tree vs curl GitLab benchmark

### DIFF
--- a/docs/benchmarks/v15/mcp-remote-only.json
+++ b/docs/benchmarks/v15/mcp-remote-only.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "aptu-coder": {
+      "type": "stdio",
+      "command": "aptu-coder",
+      "args": [],
+      "env": {
+        "APTU_CODER_PROFILE": "remote"
+      }
+    }
+  }
+}

--- a/docs/benchmarks/v15/methodology.md
+++ b/docs/benchmarks/v15/methodology.md
@@ -1,0 +1,144 @@
+# v15: remote_file / remote_tree MCP Tools vs curl Benchmark
+
+## Overview
+
+This benchmark compares the performance and usability of aptu-coder's MCP remote tools (`remote_file`, `remote_tree`) against curl CLI for fetching data from GitLab without cloning.
+
+**Design:**
+- Two conditions: E (MCP remote tools), F (curl CLI control)
+- Five targets: T1 (full file), T1b (sliced file), T2 (small tree), T3 (medium tree), T4 (depth=2 stress)
+- 5 scored runs per condition per target, interleaved
+- 1 pilot run per condition per target group to validate methodology before scoring
+- Error sub-tasks (C5 rubric): missing token and 404 not found, one per condition
+
+**References:**
+- Issue #934: benchmark remote_file/remote_tree vs curl
+- Issue #856: T4 depth=2 stress test on gitlab-org/gitlab
+
+## Background
+
+The MCP protocol allows Claude and other agents to invoke tools via a standardized interface. aptu-coder exposes `remote_file` and `remote_tree` as MCP tools for fetching GitLab data without cloning. This benchmark measures whether MCP tools provide a usability or performance advantage over direct curl CLI invocations.
+
+Key asymmetry: GitLab's Files API returns a JSON envelope with base64-encoded content. The MCP tool decodes server-side before returning plain text to the agent. curl returns the JSON envelope; the agent must decode it. This is measured by rubric criterion C3 (decode_required).
+
+## Conditions
+
+| Condition | Tool | Auth | Notes |
+|-----------|------|------|-------|
+| E (MCP) | `mcp__aptu-coder__remote_file`, `mcp__aptu-coder__remote_tree` | `GITLAB_TOKEN` env var | Tools use token automatically; agent sees plain text |
+| F (curl) | `curl` CLI via Bash | `PRIVATE-TOKEN` header | Agent must construct curl commands; must base64-decode JSON envelope |
+
+Both conditions use the same GitLab Files API endpoint (`/api/v4/projects/{encoded}/repository/files/{encoded}` for files; `/api/v4/projects/{encoded}/repository/tree` for trees).
+
+## Test Targets
+
+| ID | Operation | Repo | Path | Depth | Notes |
+|----|-----------|------|------|-------|-------|
+| T1 | File fetch (full) | gnome/gtk | gtk/gtkwidget.c | N/A | ~350 KB C source; tests baseline file fetch |
+| T1b | File fetch (sliced) | gnome/gtk | gtk/gtkwidget.c (lines 1-50) | N/A | Same network cost as T1; agent sees 50 lines vs ~350 KB; tests token efficiency |
+| T2 | Tree listing (small) | gnome/gtk | / (root) | 1 | ~14 entries; tests baseline tree fetch |
+| T3 | Tree listing (medium) | gnome/gtk | gtk/ | 1 | ~101 entries; tests larger tree handling |
+| T4 | Tree listing (depth=2 stress) | gitlab-org/gitlab | / (root) | 2 | 132 root entries + 45 subdirs; reproduces #856; expected to exceed 2000ms median |
+
+## Rubric
+
+Five criteria (C1-C5) measure correctness, latency, and usability:
+
+| Criterion | Source | Field | Description | Win Condition |
+|-----------|--------|-------|-------------|---------------|
+| C1 | Agent | `content_correct` | Content begins with expected first line | >=4/5 runs true |
+| C2 | Harness | `latency_ms` | Median latency across 5 runs | <=2000 ms |
+| C3 | Agent | `decode_required` | false = no base64 decode required | >=4/5 runs false (MCP wins) |
+| C4 | Architectural note | N/A | MCP requires GITLAB_TOKEN unconditionally; not scored per-run | Informational |
+| C5 | Agent | `error_graceful` | Clear actionable error on missing token AND on 404 | >=4/5 runs true |
+
+**Scoring:** A target passes if >=4/5 criteria are met (C2 uses median; C1/C3/C5 use run counts). C4 is architectural context only.
+
+## Run Protocol
+
+### Pilot Runs
+Before scoring, run one pilot per condition per target group to validate methodology:
+1. E-T1-pilot (MCP on T1)
+2. F-T1-pilot (curl on T1)
+3. E-T1b-pilot, F-T1b-pilot
+4. E-T2-pilot, F-T2-pilot
+5. E-T3-pilot, F-T3-pilot
+6. E-T4-pilot, F-T4-pilot
+
+Review pilot outputs for correctness before proceeding to scored runs.
+
+### Scored Runs
+After pilots pass, run 5 scored runs per condition per target, interleaved (E, F, F, E, E, F, F, E, E, F) to minimize network variance correlation.
+
+Total scored runs: 5 targets × 2 conditions × 5 runs = 50 runs.
+
+### Error Sub-Tasks
+After all targets, run error sub-tasks (not counted in n=5):
+- E-error-missing-token: MCP with GITLAB_TOKEN unset
+- E-error-not-found: MCP with nonexistent path
+- F-error-missing-token: curl with GITLAB_TOKEN unset
+- F-error-not-found: curl with nonexistent path
+
+## External Timing Harness
+
+The harness measures wall-clock latency using bash `$EPOCHREALTIME` (bash 5+) or `gdate +%s%3N` (macOS with coreutils). Falls back to noting "timing unavailable" if neither is present.
+
+For condition F (curl), the harness runs a pre-timed curl call to the GitLab API before invoking the agent, recording the baseline curl latency. The agent's curl invocations occur inside the LLM call and are not separately timed.
+
+For condition E (MCP), no pre-timing is available; latency is measured as the goose wall-clock time (includes LLM overhead).
+
+## Output Schema
+
+Per-run agent output (JSON):
+
+```json
+{
+  "run_id": "string",
+  "condition": "E or F",
+  "target_id": "T1, T1b, T2, T3, T4, or error",
+  "content_correct": "boolean (C1)",
+  "decode_required": "boolean (C3)",
+  "first_line_seen": "string (truncated to 80 chars)",
+  "content_chars": "integer (character count)",
+  "entry_count": "integer (for tree targets)",
+  "first_entry_seen": "string (for tree targets)",
+  "tool_calls_total": "integer",
+  "error_graceful": "boolean (C5, error sub-tasks only)",
+  "error_message": "string (C5, error sub-tasks only, truncated to 200 chars)"
+}
+```
+
+Per-run harness output (JSON):
+
+```json
+{
+  "run_id": "string",
+  "condition": "E or F",
+  "target_id": "T1, T1b, T2, T3, T4, or error",
+  "latency_ms": "integer (wall-clock harness measurement)",
+  "raw_bytes": "integer (bytes returned by API)",
+  "content_chars": "integer (character count as seen by agent)",
+  "est_tokens": "integer (estimated as content_chars / 4)",
+  "timestamp": "ISO 8601"
+}
+```
+
+## Discard Logic
+
+Any run exceeding 30 seconds wall-clock time is discarded and must be re-run. This is expected for T4 (depth=2 stress) and should be noted in results.
+
+## Acceptance Criteria
+
+A target passes the benchmark if:
+1. C1 (content_correct): >=4/5 runs report true
+2. C2 (latency_ok): median latency across 5 runs <=2000 ms
+3. C3 (decode_not_required): >=4/5 runs report false (MCP wins; curl loses)
+4. C5 (error_graceful): >=4/5 runs report true on both missing_token and not_found
+
+**Verdict:** MCP wins if E passes >=3/4 criteria and F passes <=2/4 criteria (or vice versa for curl win).
+
+## Notes
+
+- Token estimation: `est_tokens = content_chars / 4` is an approximation; actual token count depends on tokenizer.
+- Rate limiting: GITLAB_TOKEN may hit rate limits after 10+ runs per target; monitor for 429 responses.
+- Network variance: Median aggregation across 5 runs mitigates transient network delays.

--- a/docs/benchmarks/v15/prompts/condition-e-mcp.md
+++ b/docs/benchmarks/v15/prompts/condition-e-mcp.md
@@ -1,0 +1,22 @@
+[SYSTEM PROMPT BEGIN - Condition E: MCP remote tools]
+
+You are a remote data fetching agent. Your role is to fetch files and directory listings from GitLab repositories using MCP tools.
+
+**Allowed tools:**
+- mcp__aptu-coder__remote_file
+- mcp__aptu-coder__remote_tree
+
+**Forbidden:**
+- Bash, curl, wget, or any tool not listed above
+- Any local file system access
+
+**Instructions:**
+1. Use `mcp__aptu-coder__remote_file` to fetch file content from GitLab
+2. Use `mcp__aptu-coder__remote_tree` to list directory contents
+3. The GITLAB_TOKEN environment variable is set; tools will use it automatically
+4. Respond with JSON only (no prose, no explanations)
+
+**Output format:**
+Return a JSON object with the fields specified in the task prompt. Do not include any text outside the JSON object.
+
+[SYSTEM PROMPT END - Condition E]

--- a/docs/benchmarks/v15/prompts/condition-f-curl.md
+++ b/docs/benchmarks/v15/prompts/condition-f-curl.md
@@ -1,0 +1,42 @@
+[SYSTEM PROMPT BEGIN - Condition F: curl CLI control]
+
+You are a remote data fetching agent. Your role is to fetch files and directory listings from GitLab repositories using curl.
+
+**Allowed tools:**
+- Bash (for running curl commands)
+
+**Forbidden:**
+- mcp__aptu-coder__remote_file
+- mcp__aptu-coder__remote_tree
+- Any other MCP tool
+
+**Instructions:**
+
+For file fetches, use curl with the GitLab Files API:
+```bash
+curl -s -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+  "https://gitlab.com/api/v4/projects/{encoded_path}/repository/files/{encoded_file}?ref=HEAD"
+```
+
+This returns a JSON envelope with a base64-encoded `content` field. Decode it with:
+```bash
+python3 -c "import json,base64,sys; d=json.load(sys.stdin); print(base64.b64decode(d['content']).decode('utf-8','replace'))" <<< "$RESPONSE"
+```
+
+For directory listings, use curl with the GitLab Tree API:
+```bash
+curl -s -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+  "https://gitlab.com/api/v4/projects/{encoded_path}/repository/tree?path={path}&per_page=100"
+```
+
+This returns a JSON array directly (no envelope).
+
+For line_range slicing on files, pipe the decoded content through sed:
+```bash
+sed -n '1,50p' <<< "$CONTENT"
+```
+
+**Output format:**
+Return a JSON object with the fields specified in the task prompt. Do not include any text outside the JSON object.
+
+[SYSTEM PROMPT END - Condition F]

--- a/docs/benchmarks/v15/prompts/task-T1.md
+++ b/docs/benchmarks/v15/prompts/task-T1.md
@@ -1,0 +1,27 @@
+Fetch the file gtk/gtkwidget.c from the gnome/gtk repository on GitLab (HEAD ref).
+
+TARGET_ID_PLACEHOLDER determines the fetch mode:
+- T1: fetch the full file
+- T1b: fetch lines 1-50 only (use line_range="1-50" for MCP; pipe curl output through `sed -n '1,50p'` for curl)
+
+Respond with a JSON object and nothing else:
+
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "target_id": "TARGET_ID_PLACEHOLDER",
+  "content_correct": true or false,
+  "decode_required": true or false,
+  "first_line_seen": "first non-empty line of the fetched content (truncated to 80 chars)",
+  "content_chars": integer (character count of fetched content as seen by agent),
+  "tool_calls_total": integer
+}
+```
+
+**Scoring:**
+- `content_correct`: true if the fetched content begins with (after stripping BOM/whitespace): `/* GTK - The GIMP Toolkit`
+- `decode_required`: true if you had to base64-decode or manually parse a JSON envelope to access the text content
+- `first_line_seen`: the first non-empty line you observed (truncated to 80 characters)
+- `content_chars`: the number of characters in the content as you received it (after any decoding)
+- `tool_calls_total`: the total number of tool invocations (1 for MCP remote_file; 1+ for curl + decode)

--- a/docs/benchmarks/v15/prompts/task-T2.md
+++ b/docs/benchmarks/v15/prompts/task-T2.md
@@ -1,0 +1,29 @@
+List the directory tree of a GitLab repository.
+
+TARGET_ID_PLACEHOLDER determines the target:
+- T2: repo=gnome/gtk, path=/ (root), depth=1 (expect ~14 entries)
+- T3: repo=gnome/gtk, path=gtk/, depth=1 (expect ~101 entries)
+
+Respond with a JSON object and nothing else:
+
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "target_id": "TARGET_ID_PLACEHOLDER",
+  "content_correct": true or false,
+  "decode_required": true or false,
+  "entry_count": integer (number of entries in the listing),
+  "first_entry_seen": "name of first entry in listing",
+  "tool_calls_total": integer
+}
+```
+
+**Scoring:**
+- `content_correct`: true if the listing is non-empty and contains expected entries:
+  - T2: listing contains at least one of: README.md, meson.build, gtk/, gdk/, meson.options
+  - T3: listing contains at least one of: gtkwidget.c, gtkbutton.c, gtklabel.c
+- `decode_required`: true if you had to base64-decode or parse a JSON envelope to access the listing
+- `entry_count`: the total number of entries returned
+- `first_entry_seen`: the name of the first entry in the listing
+- `tool_calls_total`: the total number of tool invocations

--- a/docs/benchmarks/v15/prompts/task-T4.md
+++ b/docs/benchmarks/v15/prompts/task-T4.md
@@ -1,0 +1,25 @@
+List the directory tree of gitlab-org/gitlab on GitLab at depth=2 from the root.
+
+Respond with a JSON object and nothing else:
+
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "target_id": "T4",
+  "content_correct": true or false,
+  "decode_required": true or false,
+  "entry_count": integer (total entries returned across all pages/levels),
+  "first_entry_seen": "name of first top-level entry",
+  "tool_calls_total": integer
+}
+```
+
+**Scoring:**
+- `content_correct`: true if the listing is non-empty and contains at least one of: app/, lib/, spec/, config/, doc/
+- `decode_required`: true if you had to base64-decode or parse a JSON envelope
+- `entry_count`: the total number of entries returned (including subdirectory entries)
+- `first_entry_seen`: the name of the first top-level entry
+- `tool_calls_total`: the total number of tool invocations (may be >1 for depth=2 pagination)
+
+**Note:** T4 may exceed 30 seconds wall-clock time; if so, the run will be discarded and must be re-run.

--- a/docs/benchmarks/v15/prompts/task-error.md
+++ b/docs/benchmarks/v15/prompts/task-error.md
@@ -1,0 +1,25 @@
+ERROR_TYPE_PLACEHOLDER determines the error to trigger:
+- missing_token: attempt to fetch gtk/gtkwidget.c from gnome/gtk with no GITLAB_TOKEN set (unset the env var before the call if possible, or pass an empty string as the token)
+- not_found: attempt to fetch a nonexistent file path (nonexistent/path/does_not_exist.xyz) from gnome/gtk
+
+Use TOOL_OR_COMMAND_PLACEHOLDER to make the fetch attempt.
+
+Respond with a JSON object and nothing else:
+
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "error_type": "ERROR_TYPE_PLACEHOLDER",
+  "error_graceful": true or false,
+  "error_message": "the error message returned (truncated to 200 chars)"
+}
+```
+
+**Scoring:**
+- `error_graceful`: true if the tool/command returned a clear, actionable error without crashing or hanging
+- `error_message`: the error message you received (truncated to 200 characters)
+
+**Expected errors:**
+- missing_token: "401 Unauthorized" or "GITLAB_TOKEN not set" or similar
+- not_found: "404 Not Found" or "file not found" or similar

--- a/docs/benchmarks/v15/run-order.txt
+++ b/docs/benchmarks/v15/run-order.txt
@@ -1,0 +1,87 @@
+# v15 Run Order
+# Pilots run first (one per condition per target group) to verify methodology.
+# Scored runs follow interleaved (5 E + 5 F per target).
+#
+# Usage: bash scripts/bench-v15-run.sh <CONDITION_ID> <TARGET_ID> <RUN_ID>
+# CONDITION_ID: E (MCP) or F (curl)
+# TARGET_ID: T1, T1b, T2, T3, T4
+# RUN_ID: e.g. E-T1-pilot, F-T1-scored-1
+
+# --- Pilot runs (one per condition, validate methodology before scored runs) ---
+# Run these first, review outputs, then proceed to scored runs
+ 1. bash scripts/bench-v15-run.sh E T1 E-T1-pilot
+ 2. bash scripts/bench-v15-run.sh F T1 F-T1-pilot
+
+# --- Scored runs: T1 (5E + 5F interleaved) ---
+ 3. bash scripts/bench-v15-run.sh E T1 E-T1-scored-1
+ 4. bash scripts/bench-v15-run.sh F T1 F-T1-scored-1
+ 5. bash scripts/bench-v15-run.sh F T1 F-T1-scored-2
+ 6. bash scripts/bench-v15-run.sh E T1 E-T1-scored-2
+ 7. bash scripts/bench-v15-run.sh E T1 E-T1-scored-3
+ 8. bash scripts/bench-v15-run.sh F T1 F-T1-scored-3
+ 9. bash scripts/bench-v15-run.sh F T1 F-T1-scored-4
+10. bash scripts/bench-v15-run.sh E T1 E-T1-scored-4
+11. bash scripts/bench-v15-run.sh E T1 E-T1-scored-5
+12. bash scripts/bench-v15-run.sh F T1 F-T1-scored-5
+
+# --- T1b (same interleave pattern) ---
+13. bash scripts/bench-v15-run.sh E T1b E-T1b-pilot
+14. bash scripts/bench-v15-run.sh F T1b F-T1b-pilot
+15. bash scripts/bench-v15-run.sh E T1b E-T1b-scored-1
+16. bash scripts/bench-v15-run.sh F T1b F-T1b-scored-1
+17. bash scripts/bench-v15-run.sh F T1b F-T1b-scored-2
+18. bash scripts/bench-v15-run.sh E T1b E-T1b-scored-2
+19. bash scripts/bench-v15-run.sh E T1b E-T1b-scored-3
+20. bash scripts/bench-v15-run.sh F T1b F-T1b-scored-3
+21. bash scripts/bench-v15-run.sh F T1b F-T1b-scored-4
+22. bash scripts/bench-v15-run.sh E T1b E-T1b-scored-4
+23. bash scripts/bench-v15-run.sh E T1b E-T1b-scored-5
+24. bash scripts/bench-v15-run.sh F T1b F-T1b-scored-5
+
+# --- T2 ---
+25. bash scripts/bench-v15-run.sh E T2 E-T2-pilot
+26. bash scripts/bench-v15-run.sh F T2 F-T2-pilot
+27. bash scripts/bench-v15-run.sh E T2 E-T2-scored-1
+28. bash scripts/bench-v15-run.sh F T2 F-T2-scored-1
+29. bash scripts/bench-v15-run.sh F T2 F-T2-scored-2
+30. bash scripts/bench-v15-run.sh E T2 E-T2-scored-2
+31. bash scripts/bench-v15-run.sh E T2 E-T2-scored-3
+32. bash scripts/bench-v15-run.sh F T2 F-T2-scored-3
+33. bash scripts/bench-v15-run.sh F T2 F-T2-scored-4
+34. bash scripts/bench-v15-run.sh E T2 E-T2-scored-4
+35. bash scripts/bench-v15-run.sh E T2 E-T2-scored-5
+36. bash scripts/bench-v15-run.sh F T2 F-T2-scored-5
+
+# --- T3 ---
+37. bash scripts/bench-v15-run.sh E T3 E-T3-pilot
+38. bash scripts/bench-v15-run.sh F T3 F-T3-pilot
+39. bash scripts/bench-v15-run.sh E T3 E-T3-scored-1
+40. bash scripts/bench-v15-run.sh F T3 F-T3-scored-1
+41. bash scripts/bench-v15-run.sh F T3 F-T3-scored-2
+42. bash scripts/bench-v15-run.sh E T3 E-T3-scored-2
+43. bash scripts/bench-v15-run.sh E T3 E-T3-scored-3
+44. bash scripts/bench-v15-run.sh F T3 F-T3-scored-3
+45. bash scripts/bench-v15-run.sh F T3 F-T3-scored-4
+46. bash scripts/bench-v15-run.sh E T3 E-T3-scored-4
+47. bash scripts/bench-v15-run.sh E T3 E-T3-scored-5
+48. bash scripts/bench-v15-run.sh F T3 F-T3-scored-5
+
+# --- T4 (depth=2 stress; may trigger discard-and-rerun for >30s) ---
+49. bash scripts/bench-v15-run.sh E T4 E-T4-pilot
+50. bash scripts/bench-v15-run.sh F T4 F-T4-pilot
+51. bash scripts/bench-v15-run.sh E T4 E-T4-scored-1
+52. bash scripts/bench-v15-run.sh F T4 F-T4-scored-1
+53. bash scripts/bench-v15-run.sh F T4 F-T4-scored-2
+54. bash scripts/bench-v15-run.sh E T4 E-T4-scored-2
+55. bash scripts/bench-v15-run.sh E T4 E-T4-scored-3
+56. bash scripts/bench-v15-run.sh F T4 F-T4-scored-3
+57. bash scripts/bench-v15-run.sh F T4 F-T4-scored-4
+58. bash scripts/bench-v15-run.sh E T4 E-T4-scored-4
+59. bash scripts/bench-v15-run.sh E T4 E-T4-scored-5
+60. bash scripts/bench-v15-run.sh F T4 F-T4-scored-5
+
+# --- Error sub-tasks (one per condition; not counted in n=5) ---
+61. bash scripts/bench-v15-run.sh E error E-error-missing-token --error-type missing_token
+62. bash scripts/bench-v15-run.sh E error E-error-not-found --error-type not_found
+63. bash scripts/bench-v15-run.sh F error F-error-missing-token --error-type missing_token
+64. bash scripts/bench-v15-run.sh F error F-error-not-found --error-type not_found

--- a/docs/benchmarks/v15/scores-template.json
+++ b/docs/benchmarks/v15/scores-template.json
@@ -1,0 +1,38 @@
+{
+  "version": "v15",
+  "rubric": {
+    "dimensions": ["content_correct", "latency_ok", "decode_not_required", "error_graceful"],
+    "criteria": {
+      "C1": {
+        "source": "agent",
+        "field": "content_correct",
+        "description": "content begins with expected first line"
+      },
+      "C2": {
+        "source": "harness",
+        "field": "latency_ms",
+        "description": "median across 5 runs <= 2000ms"
+      },
+      "C3": {
+        "source": "agent",
+        "field": "decode_required",
+        "description": "false = no base64 decode required"
+      },
+      "C4": {
+        "note": "architectural asymmetry: MCP requires GITLAB_TOKEN unconditionally; not scored per-run"
+      },
+      "C5": {
+        "source": "agent",
+        "field": "error_graceful",
+        "description": "clear actionable error on missing token AND on 404"
+      }
+    },
+    "win_threshold": ">=4/5 runs (C2 uses median; C1/C3/C5 use run scores)"
+  },
+  "targets": ["T1", "T1b", "T2", "T3", "T4"],
+  "conditions": {
+    "E": "MCP remote tools",
+    "F": "curl"
+  },
+  "runs": []
+}

--- a/scripts/bench-v15-run.sh
+++ b/scripts/bench-v15-run.sh
@@ -1,0 +1,367 @@
+#!/bin/bash
+set -euo pipefail
+
+# v15 Benchmark Harness: MCP remote_file/remote_tree vs curl
+# Usage: bash scripts/bench-v15-run.sh <CONDITION_ID> <TARGET_ID> <RUN_ID> [--error-type <type>]
+# CONDITION_ID: E (MCP) or F (curl)
+# TARGET_ID: T1, T1b, T2, T3, T4, error
+# RUN_ID: e.g. E-T1-pilot, F-T1-scored-1
+# --error-type: missing_token or not_found (for error target only)
+
+# ============================================================================
+# Argument Validation
+# ============================================================================
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <CONDITION_ID> <TARGET_ID> <RUN_ID> [--error-type <type>]" >&2
+  exit 1
+fi
+
+CONDITION_ID="$1"
+TARGET_ID="$2"
+RUN_ID="$3"
+ERROR_TYPE=""
+
+if [[ $# -ge 5 && "$4" == "--error-type" ]]; then
+  ERROR_TYPE="$5"
+fi
+
+# Validate condition
+if [[ "$CONDITION_ID" != "E" && "$CONDITION_ID" != "F" ]]; then
+  echo "ERROR: CONDITION_ID must be E or F, got: $CONDITION_ID" >&2
+  exit 1
+fi
+
+# Validate target
+if [[ ! "$TARGET_ID" =~ ^(T1|T1b|T2|T3|T4|error)$ ]]; then
+  echo "ERROR: TARGET_ID must be T1, T1b, T2, T3, T4, or error, got: $TARGET_ID" >&2
+  exit 1
+fi
+
+# Validate error type if error target
+if [[ "$TARGET_ID" == "error" ]]; then
+  if [[ -z "$ERROR_TYPE" ]]; then
+    echo "ERROR: --error-type required for error target" >&2
+    exit 1
+  fi
+  if [[ ! "$ERROR_TYPE" =~ ^(missing_token|not_found)$ ]]; then
+    echo "ERROR: --error-type must be missing_token or not_found, got: $ERROR_TYPE" >&2
+    exit 1
+  fi
+fi
+
+# ============================================================================
+# Environment Setup
+# ============================================================================
+
+# GITLAB_TOKEN check: fail fast unless this is a missing_token error sub-task.
+# Missing-token error sub-task: intentionally omits GITLAB_TOKEN to test tool error handling.
+if [[ ! ("$TARGET_ID" == "error" && "$ERROR_TYPE" == "missing_token") ]]; then
+  if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+    echo "ERROR: GITLAB_TOKEN environment variable is not set" >&2
+    exit 1
+  fi
+fi
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BENCH_DIR="$REPO_ROOT/docs/benchmarks/v15"
+RESULTS_DIR="$BENCH_DIR/results"
+PROMPTS_DIR="$BENCH_DIR/prompts"
+
+# Create results directory if needed
+mkdir -p "$RESULTS_DIR"
+
+# ============================================================================
+# Timing Functions
+# ============================================================================
+
+# millis_now() returns current time in milliseconds using the most portable method available.
+# Fallback chain: (1) bash $EPOCHREALTIME (bash 5+, Linux/macOS), (2) date +%s%N with awk
+# division (Linux nanoseconds, no coreutils needed), (3) gdate +%s%3N (macOS with coreutils).
+millis_now() {
+  if [[ -n "${EPOCHREALTIME:-}" ]]; then
+    # bash 5+ provides $EPOCHREALTIME as seconds.nanoseconds
+    # Convert to integer milliseconds: seconds*1000 + nanoseconds/1000000
+    awk "BEGIN { print int(${EPOCHREALTIME} * 1000) }"
+  elif date +%s%N &>/dev/null; then
+    # Linux: date +%s%N returns seconds and nanoseconds concatenated
+    # Divide by 1000000 to convert nanoseconds to milliseconds
+    date +%s%N | awk '{ print int($1 / 1000000) }'
+  elif command -v gdate &>/dev/null; then
+    # macOS with coreutils: gdate +%s%3N returns seconds and milliseconds
+    gdate +%s%3N
+  else
+    # Fallback: return 0 if no timing method available
+    echo "0"
+  fi
+}
+
+# ============================================================================
+# Load Prompts
+# ============================================================================
+
+load_system_prompt() {
+  local condition="$1"
+  if [[ "$condition" == "E" ]]; then
+    cat "$PROMPTS_DIR/condition-e-mcp.md"
+  else
+    cat "$PROMPTS_DIR/condition-f-curl.md"
+  fi
+}
+
+load_task_prompt() {
+  local target="$1"
+  case "$target" in
+    T1|T1b)
+      cat "$PROMPTS_DIR/task-T1.md"
+      ;;
+    T2|T3)
+      cat "$PROMPTS_DIR/task-T2.md"
+      ;;
+    T4)
+      cat "$PROMPTS_DIR/task-T4.md"
+      ;;
+    error)
+      cat "$PROMPTS_DIR/task-error.md"
+      ;;
+    *)
+      echo "ERROR: Unknown target: $target" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# ============================================================================
+# Placeholder Substitution
+# ============================================================================
+
+substitute_placeholders() {
+  local text="$1"
+  local target="$2"
+  local run_id="$3"
+  local condition="$4"
+  local error_type="${5:-}"
+
+  # Substitute TARGET_ID_PLACEHOLDER
+  text="${text//TARGET_ID_PLACEHOLDER/$target}"
+
+  # Substitute RUN_ID_PLACEHOLDER
+  text="${text//RUN_ID_PLACEHOLDER/$run_id}"
+
+  # Substitute CONDITION_PLACEHOLDER
+  text="${text//CONDITION_PLACEHOLDER/$condition}"
+
+  # Substitute ERROR_TYPE_PLACEHOLDER
+  if [[ -n "$error_type" ]]; then
+    text="${text//ERROR_TYPE_PLACEHOLDER/$error_type}"
+  fi
+
+  # Substitute TOOL_OR_COMMAND_PLACEHOLDER
+  if [[ "$condition" == "E" ]]; then
+    text="${text//TOOL_OR_COMMAND_PLACEHOLDER/mcp__aptu-coder__remote_file}"
+  else
+    text="${text//TOOL_OR_COMMAND_PLACEHOLDER/curl}"
+  fi
+
+  echo "$text"
+}
+
+# ============================================================================
+# JSON Extraction
+# ============================================================================
+
+extract_json_from_output() {
+  local output_file="$1"
+  
+  # Use Python to extract the last valid JSON object from the output
+  python3 << 'PYTHON_EOF'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1], 'r') as f:
+        output = f.read()
+except Exception as e:
+    print(f"ERROR: Could not read output file: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# Find all {...} blocks that might be JSON
+pattern = r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}'
+matches = list(re.finditer(pattern, output, re.DOTALL))
+
+# Try to parse from the end (most recent JSON)
+for m in reversed(matches):
+    try:
+        data = json.loads(m.group())
+        # Verify it has the expected structure (at least run_id, condition, target_id)
+        if 'run_id' in data and 'condition' in data and 'target_id' in data:
+            print(json.dumps(data))
+            sys.exit(0)
+    except json.JSONDecodeError:
+        continue
+
+print("ERROR: No valid JSON report found in output", file=sys.stderr)
+sys.exit(1)
+PYTHON_EOF
+  
+  return $?
+}
+
+# ============================================================================
+# Goose Profile Creation
+# ============================================================================
+
+create_goose_profile() {
+  local condition="$1"
+  local profile_file="/tmp/bench-v15-profile-${condition}-$$.yaml"
+
+  if [[ "$condition" == "E" ]]; then
+    # MCP profile with aptu-coder remote tools
+    cat > "$profile_file" << 'PROFILE_EOF'
+provider: gcp_vertex_ai
+model: claude-haiku-4-5@20251001
+extensions:
+  - type: stdio
+    name: aptu-coder
+    cmd: aptu-coder
+    args: []
+    env_keys: []
+    envs:
+      APTU_CODER_PROFILE: remote
+PROFILE_EOF
+  else
+    # Bash-only profile (no MCP)
+    cat > "$profile_file" << 'PROFILE_EOF'
+provider: gcp_vertex_ai
+model: claude-haiku-4-5@20251001
+extensions: []
+PROFILE_EOF
+  fi
+
+  echo "$profile_file"
+}
+
+# ============================================================================
+# Curl Pre-Timing (Condition F only)
+# ============================================================================
+
+run_curl_baseline() {
+  local target="$1"
+  local start_ms end_ms latency_ms
+  
+  start_ms=$(millis_now)
+  
+  # Run a simple curl to gitlab.com to measure baseline latency
+  # This is a HEAD request to minimize data transfer
+  curl -s -I -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+    "https://gitlab.com/api/v4/projects/gnome%2Fgtk/repository/files/gtk%2Fgtkwidget.c?ref=HEAD" \
+    > /dev/null 2>&1 || true
+  
+  end_ms=$(millis_now)
+  latency_ms=$(( end_ms - start_ms ))
+  
+  echo "$latency_ms"
+}
+
+# ============================================================================
+# Main Run
+# ============================================================================
+
+main() {
+  local start_time_ms end_time_ms total_latency_ms
+  local system_prompt task_prompt combined_prompt
+  local profile_file log_file output_file report_file harness_file
+  local json_output
+
+  # Load prompts
+  system_prompt=$(load_system_prompt "$CONDITION_ID")
+  task_prompt=$(load_task_prompt "$TARGET_ID")
+
+  # Substitute placeholders
+  task_prompt=$(substitute_placeholders "$task_prompt" "$TARGET_ID" "$RUN_ID" "$CONDITION_ID" "$ERROR_TYPE")
+
+  # Combine prompts
+  combined_prompt="$system_prompt
+
+$task_prompt"
+
+  # Create goose profile
+  profile_file=$(create_goose_profile "$CONDITION_ID")
+  trap "rm -f '$profile_file'" EXIT
+
+  # Output files
+  log_file="$RESULTS_DIR/${RUN_ID}.log"
+  output_file="$RESULTS_DIR/${RUN_ID}-output.txt"
+  report_file="$RESULTS_DIR/${RUN_ID}-report.json"
+  harness_file="$RESULTS_DIR/${RUN_ID}-harness.json"
+
+  # Record start time
+  start_time_ms=$(millis_now)
+
+  # Run goose
+  DISABLE_PROMPT_CACHING=1 goose run \
+    --profile "$profile_file" \
+    --text "$combined_prompt" \
+    --no-session \
+    > "$output_file" 2> "$log_file" || true
+
+  # Record end time
+  end_time_ms=$(millis_now)
+  total_latency_ms=$(( end_time_ms - start_time_ms ))
+
+  # Check for timeout (>30s)
+  if [[ $total_latency_ms -gt 30000 ]]; then
+    echo "DISCARD: run exceeded 30s (${total_latency_ms}ms), re-run required" >&2
+    exit 2
+  fi
+
+  # Extract JSON from output
+  if ! json_output=$(extract_json_from_output "$output_file"); then
+    echo "ERROR: Failed to extract JSON from goose output" >&2
+    cat "$output_file" >&2
+    exit 1
+  fi
+
+  # Save report
+  echo "$json_output" > "$report_file"
+
+  # Create harness telemetry
+  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local content_chars=$(echo "$json_output" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('content_chars', 0))" 2>/dev/null || echo "0")
+  local est_tokens=$(( content_chars / 4 ))
+
+  cat > "$harness_file" << HARNESS_JSON
+{
+  "run_id": "$RUN_ID",
+  "condition": "$CONDITION_ID",
+  "target_id": "$TARGET_ID",
+  "latency_ms": $total_latency_ms,
+  "raw_bytes": 0,
+  "content_chars": $content_chars,
+  "est_tokens": $est_tokens,
+  "timestamp": "$timestamp",
+  "timing_method": "$TIMING_METHOD"
+}
+HARNESS_JSON
+
+  # Print summary
+  echo "=========================================="
+  echo "Run: $RUN_ID"
+  echo "Condition: $CONDITION_ID"
+  echo "Target: $TARGET_ID"
+  echo "Latency: ${total_latency_ms}ms"
+  echo "Content chars: $content_chars"
+  echo "Est. tokens: $est_tokens"
+  echo "Report: $report_file"
+  echo "Harness: $harness_file"
+  echo "=========================================="
+
+  # Print extracted JSON for verification
+  echo "Agent output:"
+  echo "$json_output" | python3 -m json.tool 2>/dev/null || echo "$json_output"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds the v15 benchmark harness comparing `remote_file` and `remote_tree` MCP tools against `curl` on GitLab under identical authenticated conditions, as specified in #934.

Two conditions are defined. Condition E uses the MCP tools (`remote_file`, `remote_tree`) with `APTU_CODER_PROFILE=remote`. Condition F uses `curl` with a `PRIVATE-TOKEN` header against the same GitLab Files API endpoints. Both conditions share the same `GITLAB_TOKEN`, the same target repositories, and the same JSON output schema so results are directly comparable.

Five test targets are included: T1 (full 350 KB file fetch of `gtk/gtkwidget.c`), T1b (same file with `line_range=1-50` to measure token-cost divergence), T2 (14-entry root tree on gnome/gtk), T3 (101-entry `gtk/` subtree), and T4 (depth=2 stress on `gitlab-org/gitlab`, reproducing the #856 latency pattern).

The rubric is pre-registered in `scores-template.json` before any runs: C1 (content correctness, agent-reported), C2 (median latency ≤ 2000 ms, harness-measured), C3 (no base64 decode required, agent-reported), C4 (architectural note: MCP requires `GITLAB_TOKEN` unconditionally; not scored per-run), and C5 (graceful error on missing token and on 404, agent-reported).

## Changes

- `docs/benchmarks/v15/methodology.md` -- full benchmark design, targets table, rubric, API notes, acceptance criteria
- `docs/benchmarks/v15/mcp-remote-only.json` -- MCP server config with `APTU_CODER_PROFILE=remote`
- `docs/benchmarks/v15/prompts/condition-e-mcp.md` -- system prompt for condition E
- `docs/benchmarks/v15/prompts/condition-f-curl.md` -- system prompt for condition F (includes `PRIVATE-TOKEN` header usage and base64 decode step)
- `docs/benchmarks/v15/prompts/task-T1.md`, `task-T2.md`, `task-T4.md`, `task-error.md` -- task prompts with JSON output schema and expected first-line anchors
- `docs/benchmarks/v15/scores-template.json` -- pre-registered rubric
- `docs/benchmarks/v15/run-order.txt` -- 64-run manifest: 2 pilots + 10 scored runs per target + 4 error sub-tasks
- `scripts/bench-v15-run.sh` -- bash harness: arg/env validation, `$EPOCHREALTIME`/`gdate` timing, goose invocation with per-condition profile, JSON extraction, per-run output files, 30 s discard logic

## Test plan

- [x] `bash -n scripts/bench-v15-run.sh` passes (syntax clean)
- [x] `mcp-remote-only.json` and `scores-template.json` parse as valid JSON
- [x] No modifications to any existing file (`git diff --name-only` shows only new files)
- [x] No credentials hard-coded; `GITLAB_TOKEN` referenced as env var only
- [ ] Pilot runs (E-T1-pilot, F-T1-pilot) to be executed manually per `run-order.txt` before scored runs proceed

Closes #934
