### PR TITLE
docs(cleanup): remove remote_* refs, nine-tools narrative, and compact profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 - `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution; must be within the server CWD.
-- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (3 tools); `analyze` disables edit_* tools (5 tools); `compact` enables all 7 tools; absent/unknown enables all 7 tools. By default, all 7 tools are available.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (3 tools); `analyze` disables edit_* tools (5 tools); absent/unknown enables all 7 tools. By default, all 7 tools are available.
 
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3703,7 +3703,7 @@ impl ServerHandler for CodeAnalyzer {
         // feature. The spec-compliant way to restrict tools is for the orchestrator to pass
         // a filtered `tools` array in the API call, or for clients to use tool annotations
         // (readOnlyHint/destructiveHint) to apply their own policy.
-        // Profiles: "edit" (3 tools), "analyze" (5 tools), "compact" (7 tools), absent/unknown (7 tools).
+        // Two profiles: "edit" (3 tools), "analyze" (5 tools); absent/unknown = all 7 tools.
         // _meta key "io.clouatre-labs/profile" takes precedence over APTU_CODER_PROFILE env var.
         let meta_lock = self.profile_meta.lock().await;
         let meta_profile = meta_lock
@@ -3720,7 +3720,7 @@ impl ServerHandler for CodeAnalyzer {
             let mut router = self.tool_router.write().await;
 
             // Default: all 7 tools enabled unless profile explicitly disables them.
-            // Profiles: "edit" (3 tools), "analyze" (5 tools), "compact" (7 tools), absent/unknown (7 tools).
+            // Two profiles: "edit" (3 tools), "analyze" (5 tools); absent/unknown = all 7 tools.
 
             if let Some(ref profile) = active_profile {
                 match profile.as_str() {
@@ -3739,9 +3739,6 @@ impl ServerHandler for CodeAnalyzer {
                     "analyze" => {
                         // Enable only: analyze_directory, analyze_file, analyze_module, analyze_symbol, exec_command
                         disable_routes(&mut router, &["edit_replace", "edit_overwrite"]);
-                    }
-                    "compact" => {
-                        // Enable all 7 tools
                     }
                     _ => {
                         // Unknown profile: all 7 tools enabled (lenient fallback)

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -291,30 +291,6 @@ async fn test_analyze_profile_tool_count() {
 }
 
 #[tokio::test]
-async fn test_compact_profile_tool_count() {
-    let _guard = env_var_lock();
-    // Arrange: initialize with compact profile
-    let resp = call_tools_list_with_profile(Some("compact")).await;
-
-    // Act: extract tool count from response
-    let tools = &resp["result"]["tools"];
-    let tool_count = tools.as_array().map(|a| a.len()).unwrap_or(0);
-    let tool_names: Vec<String> = tools
-        .as_array()
-        .unwrap_or(&vec![])
-        .iter()
-        .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
-        .collect();
-
-    // Assert: compact profile should have exactly 7 tools
-    assert_eq!(
-        tool_count, 7,
-        "compact profile should enable exactly 7 tools, got: {:?}",
-        tool_names
-    );
-}
-
-#[tokio::test]
 async fn test_no_profile_tool_count() {
     let _guard = env_var_lock();
     // Arrange: initialize with no profile metadata; env var must be absent.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 
 - **Minimize token usage**: Return only structured, relevant context - no prose, no noise
 - **Language-agnostic parsing via tree-sitter**: Support 12 languages (Rust, Go, Java, Kotlin, Python, TypeScript, TSX, Fortran, JavaScript, C, C++, C#) with a unified query-based extraction system; TypeScript and TSX use distinct grammars (`LANGUAGE_TYPESCRIPT` and `LANGUAGE_TSX`) but share the same queries in `crates/aptu-coder-core/src/languages/typescript.rs`
-- **Nine focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family); `remote_tree`, `remote_file` (remote_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
+- **Seven focused MCP tools**: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family) -- each with a clear, explicit interface rather than a single tool with auto-detected modes
 - **Compatible with any MCP orchestrator**: Designed to work with any standards-compliant MCP host
 - **Performance via parallelism**: Use rayon for parallel file processing and ignore crate for efficient .gitignore-aware directory walking
 
@@ -29,7 +29,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
-| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all nine tools |
+| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all seven tools |
 | `traversal` | `crates/aptu-coder-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
 | `types` | `crates/aptu-coder-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -17,11 +17,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the module map, [MCP-BEST-PRACTICES.m
 
 ## 2. Tool Architecture Decisions
 
-### Why Nine Tools Instead of One
+### Why Seven Tools Instead of One
 
 **Principle:** Each tool does one thing well. Non-overlapping interfaces eliminate ambiguous routing. When two tools can satisfy the same request, the model must guess; that is a reliability failure, not a model failure. (See [MCP-BEST-PRACTICES.md](MCP-BEST-PRACTICES.md), section 3.2.)
 
-*Example: This server has nine tools — `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analysis family); `edit_overwrite`, `edit_replace` (editing family); `exec_command` (exec family); `remote_tree`, `remote_file` (remote family) — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
+*Example: This server has seven tools — `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analysis family); `edit_overwrite`, `edit_replace` (editing family); `exec_command` (exec family) — each with a distinct, non-overlapping responsibility. A single auto-detecting tool was rejected because it required the model to infer the correct mode from context, which failed under small models.*
 
 ```mermaid
 graph TD
@@ -47,14 +47,12 @@ graph TD
 | `edit_overwrite` | Create or overwrite a file | AST awareness, incremental updates |
 | `edit_replace` | Replace exact text block in a file | AST awareness, directory-wide changes |
 | `exec_command` | Execute arbitrary shell commands | Output parsing, scripting language support, interactive sessions |
-| `remote_file` | Fetch a single file from a remote GitHub or GitLab repository | Local filesystem access, directory walking |
-| `remote_tree` | Directory structure of a remote GitHub or GitLab repository without cloning | Local filesystem access, symbol analysis |
 
-*Table 1: The nine tools, their purpose, and what each intentionally excludes.*
+*Table 1: The seven tools, their purpose, and what each intentionally excludes.*
 
 ### Single Responsibility Trade-off
 
-Splitting into nine tools adds surface area (nine tool descriptions to maintain, nine output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
+Splitting into seven tools adds surface area (seven tool descriptions to maintain, seven output schemas). The benefit is deterministic routing: an agent that asks about a symbol never accidentally triggers a directory walk, and an agent orienting on a codebase never waits for a full semantic parse. Write tools are separated from analysis tools to allow clients to apply different confirmation policies.
 
 ## 3. Designing for Small Models
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -27,7 +27,7 @@ Each line in the JSONL file is one JSON object:
 | Field | Type | Description |
 |---|---|---|
 | `ts` | `u64` | Unix timestamp in milliseconds at handler return |
-| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command`, `remote_tree`, `remote_file` |
+| `tool` | `string` | One of: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command` |
 | `duration_ms` | `u64` | Wall-clock time from handler entry to return |
 | `output_chars` | `usize` | Byte length (`str::len()`) of the final text returned; `0` on error paths |
 | `param_path_depth` | `usize` | `Path::components().count()` on `params.path` |


### PR DESCRIPTION
## Summary

The `remote_tree` and `remote_file` tools were removed in #943, but several documentation files and a dead code path were not cleaned up in that PR. This PR completes the removal.

The `compact` profile was a no-op match arm in `list_tools` -- it enabled all 7 tools, identical to the absent/unknown fallback. No behavior change to remove it.

## Changes

- **`crates/aptu-coder/src/lib.rs`** -- removed the `"compact"` match arm; updated profile comments to document only the two meaningful profiles: `edit` (3 tools) and `analyze` (5 tools)
- **`crates/aptu-coder/tests/profiles.rs`** -- deleted `test_compact_profile_tool_count` (was testing dead code)
- **`docs/ARCHITECTURE.md`** -- "Nine focused MCP tools" -> "Seven focused MCP tools"; removed `remote_tree`/`remote_file` from tool list and formatter row
- **`docs/DESIGN-GUIDE.md`** -- section title, example sentence, table rows for remote tools, caption, and body paragraph all updated from nine to seven
- **`docs/OBSERVABILITY.md`** -- removed `remote_tree` and `remote_file` from the `tool` field enum
- **`AGENTS.md`** -- removed `compact` variant from `APTU_CODER_PROFILE` description

## Test plan

- [x] Tests pass (45 tests, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] No stale "nine" or `remote_*` references remain in modified files
- [x] `README.md` and `docs/benchmarks/v15/` untouched (historical data preserved)

Closes #943 cleanup follow-up.
