### PR TITLE
ci: pin clouatre-labs/aptu to v0.8.1

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Aptu Triage
-        uses: clouatre-labs/aptu@cb08760ef7f38176359a4b1713297cced31b76f5 # v0.7.0
+        uses: clouatre-labs/aptu@475e47a210fc7c10bf9a5a4d453c0eeb0e97f9fc # v0.8.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@cb08760ef7f38176359a4b1713297cced31b76f5 # v0.7.0
+        uses: clouatre-labs/aptu@475e47a210fc7c10bf9a5a4d453c0eeb0e97f9fc # v0.8.1
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin `clouatre-labs/aptu` action from `v0.7.0` to `v0.8.1` in both CI workflows that invoke it.

## Changes

- `.github/workflows/issue-triage.yml` -- updated SHA and version comment
- `.github/workflows/pr-review.yml` -- updated SHA and version comment

New pin: `475e47a210fc7c10bf9a5a4d453c0eeb0e97f9fc` (verified against the annotated tag object via `gh api`)
