### PR TITLE
ci: use ubuntu-24.04-arm runner for issue-triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       issues: write
       contents: read


### PR DESCRIPTION
## Summary

Use `ubuntu-24.04-arm` for issue-triage, consistent with pr-review and all other clouatre-labs repos.

## Changes

- `.github/workflows/issue-triage.yml`: `ubuntu-24.04` -> `ubuntu-24.04-arm`

## Test plan

- [ ] Linter clean (workflow-only change)
