### PR TITLE
chore(deps): bump aptu action to v0.8.4

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Aptu Triage
-        uses: clouatre-labs/aptu@8c21f970ddc71cb2955a3434d594cc4a7f27830c # v0.8.2
+        uses: clouatre-labs/aptu@4e67919a1ad42b4ae81cb92df951711c2ec1b64f # v0.8.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@8c21f970ddc71cb2955a3434d594cc4a7f27830c # v0.8.2
+        uses: clouatre-labs/aptu@4e67919a1ad42b4ae81cb92df951711c2ec1b64f # v0.8.4
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `clouatre-labs/aptu` action pin from v0.8.2 to v0.8.4 in `pr-review.yml` and `issue-triage.yml`.