### PR TITLE
chore(release): bump version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Version bump to 0.14.1. Patch release covering CI hardening, observability fixes, and action pin updates merged since v0.14.0.

## Changes

- `Cargo.toml`, `Cargo.lock` — version bumped from 0.14.0 to 0.14.1

## Included since v0.14.0

- fix(metrics): normalize `cache_hit`/`cache_tier` in `analyze_symbol`; add two regression tests (#953)
- ci: add `attestations: read` permission to pr-review workflow; expand pr-review instructions (#946)
- ci: use `ubuntu-24.04-arm` runner for issue-triage, consistent with all other jobs (#947)
- chore(deps): pin and bump `clouatre-labs/aptu` action from v0.8.1 to v0.8.4 (#945, #948, #949)
