### PR TITLE
chore(release): bump version to 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Patch release bumping the version to 0.14.2 following the fix landed in #955.

## Changes

- `Cargo.toml`: version `0.14.1` -> `0.14.2`
- `Cargo.lock`: updated accordingly

## Test plan

- [x] All tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
