### PR TITLE
ci(pr-review): fix action SHA pinned to tag object instead of commit

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@4e67919a1ad42b4ae81cb92df951711c2ec1b64f # v0.8.4
+        uses: clouatre-labs/aptu@b505a0c3144c113c77f1607025c0cc7f60c654d6 # v0.8.4
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `aptu pr review` step in `pr-review.yml` has been silently broken since the v0.8.4 pin was set. The action was pinned to `4e67919` -- the annotated tag object SHA -- not the commit SHA. GitHub Actions cannot resolve a tag object SHA to executable code, so the step fell back to broken behaviour and failed with a spurious "write access" error.

## Root cause

`clouatre-labs/aptu` v0.8.4 uses an annotated tag. An annotated tag creates two objects: the tag object (`4e67919`) and the commit it points to (`b505a0c`). GitHub Actions `uses: owner/repo@<sha>` requires the commit SHA. Pinning the tag object SHA is silently mishandled.

Evidence: `clouatre-labs/clouatre.ca` pins `b505a0c` (the commit SHA) for the same v0.8.4 release and the action works correctly there.

## Change

```
- uses: clouatre-labs/aptu@4e67919a1ad42b4ae81cb92df951711c2ec1b64f # v0.8.4
+ uses: clouatre-labs/aptu@b505a0c3144c113c77f1607025c0cc7f60c654d6 # v0.8.4
```

Closes #963
