### PR TITLE
docs: document exec_command output caps, filter table, and INVALID_PARAMS for analyze tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,18 +166,18 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | Tool | Purpose | Languages |
 |------|---------|-----------|
 | `analyze_directory` | Directory tree with LOC, function, and class counts; respects `.gitignore` | all |
-| `analyze_file` | Functions, classes, and imports with signatures and line ranges | all |
-| `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`) | all |
+| `analyze_file` | Functions, classes, and imports with signatures and line ranges; returns `INVALID_PARAMS` for unsupported extensions | all |
+| `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`); returns `INVALID_PARAMS` for unsupported extensions | all |
 | `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |
 | `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches | all |
-| `exec_command` | Run a shell command; returns stdout, stderr, exit code, and timeout status; supports progress notifications | any |
+| `exec_command` | Run a shell command; returns stdout, stderr, exit code, and timeout status; supports progress notifications; output capped and filtered automatically | any |
 
 Tool parameters, constraints, and examples are available via your MCP client's tool inspector or `tools/list` response.
 
 ## Output Management
 
-For large codebases, two mechanisms prevent context overflow:
+For large codebases, several mechanisms prevent context overflow.
 
 **Pagination**
 
@@ -190,6 +190,34 @@ NEXT_CURSOR: eyJvZmZzZXQiOjUwfQ==
 # Fetch next page:
 analyze_symbol path: /my/project symbol: my_function cursor: eyJvZmZzZXQiOjUwfQ==
 ```
+
+**exec_command output caps**
+
+`exec_command` applies three independent byte-level caps to prevent large command outputs from flooding the context:
+
+| Stream | Cap | Behavior |
+|--------|-----|----------|
+| stdout | 30,000 chars | Tail-preserving; keeps the last 30k chars |
+| stderr | 10,000 chars | Tail-preserving; errors appear at the end |
+| combined `output_text` | 50,000 chars | Safety net after interleaving |
+
+The 30k stdout cap is data-driven: analysis of 27,981 observed `exec_command` calls shows only 0.33% exceed this limit. When any cap fires, `output_truncated: true` is set in the response and recorded in the JSONL metrics.
+
+**exec_command output filters**
+
+A built-in filter table suppresses per-file noise from chatty CLI tools before output reaches the model. Filters apply on success only; raw output is always preserved on failure.
+
+| Command | Behavior |
+|---------|----------|
+| `git pull` | Injects `--no-stat` before execution; strips diff-stat noise |
+| `git fetch` | Strips `From` / ref lines; caps at 10 lines |
+| `git push` | Strips `remote:` lines; caps at 10 lines |
+| `git log` | Caps at 20 lines |
+| `git status` | Caps at 20 lines |
+| `cargo build` | Strips `Compiling` / `Checking` / `Downloading` / `Fresh` lines |
+| `cargo test` | Strips `Compiling` / `Checking` / `Fresh` lines |
+
+Project-local rules can be added in `.aptu/filters.toml`. Parse errors fall back to the built-in table (no crash). When a filter fires, `filter_applied` in `structuredContent` identifies which rule matched.
 
 ## Non-Interactive Pipelines
 

--- a/crates/aptu-coder-core/README.md
+++ b/crates/aptu-coder-core/README.md
@@ -14,9 +14,9 @@ Core library for code structure analysis using tree-sitter.
 ## Features
 
 - **Directory analysis** - File tree with LOC, function, and class counts
-- **File analysis** - Functions, classes, and imports with signatures and line ranges
+- **File analysis** - Functions, classes, and imports with signatures and line ranges; returns `INVALID_PARAMS` for unsupported extensions
 - **Symbol call graphs** - Callers and callees across a directory with configurable depth
-- **Module index** - Lightweight function and import index (~75% smaller than full file analysis)
+- **Module index** - Lightweight function and import index (~75% smaller than full file analysis); returns `INVALID_PARAMS` for unsupported extensions
 - **Edit operations** - In-file edits: overwrite, exact-block replace
 - **In-memory analysis** - `analyze_str` parses source text directly without a file path; returns the same `FileAnalysisOutput` as `analyze_file`
 - **Multi-language** - Rust, Python, TypeScript, TSX, Go, Java, Kotlin, Fortran, JavaScript, C/C++, C#

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,13 +70,14 @@ graph TD
     B6 --> F2["edit_overwrite_content"]
     B7 --> F3["edit_replace_block"]
     B10 --> F6["exec_sh_command"]
+    F6 --> F7["output_filter + byte_caps"]
     P --> Q["MCP Response"]
     L --> Q
     T --> Q
     I --> Q
     F2 --> Q
     F3 --> Q
-    F6 --> Q
+    F7 --> Q
     Q --> Z1["MetricEvent channel"]
     Z1 --> Z2["MetricsWriter JSONL"]
     Q --> Z3["OTel span end"]
@@ -96,13 +97,13 @@ When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the
 
 ### analyze_file (File Details)
 
-1. Detect language from extension
+1. Detect language from extension; return `INVALID_PARAMS` immediately if the extension is not in the supported set
 2. SemanticExtractor parses the file: functions with signatures, classes/structs with fields, imports, type references
 3. Format as structured sections
 
 ### analyze_module (Module Index)
 
-1. Detect language from extension
+1. Detect language from extension; return `INVALID_PARAMS` immediately if the extension is not in the supported set
 2. `analyze_module_file` in `src/analyze.rs` reads the file and dispatches to `SemanticExtractor`
 3. Returns a minimal fixed schema: `name`, `line_count`, `language`, `functions[{name, line}]`, `imports[{module, items}]`
 4. No call graph, no type references, no field accesses -- output is ~75% smaller than `analyze_file`

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -42,6 +42,7 @@ Each line in the JSONL file is one JSON object:
 | `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable |
 | `timed_out` | `bool` | `true` if the call timed out; `false` otherwise |
 | `output_truncated` | `bool \| null` | `true` if any truncation occurred (line cap, per-stream byte cap, or combined cap); `false` if the command completed without truncation; `null` for all non-`exec_command` tools and for `exec_command` calls emitted by older server versions |
+| `filter_applied` | `string \| null` | Name of the filter rule that matched and transformed the output (e.g., `"git pull"`, `"cargo build"`); `null` when no filter fired or for non-`exec_command` tools. Present in `structuredContent` only; not recorded in JSONL. |
 | `chars_threshold_breach` | `bool` | `true` when `output_chars > 30,000`; fires for the top ~0.33% of `exec_command` calls (p99.7 of 27,981 observed calls). Early-warning signal for responses approaching the per-stream byte-cap threshold (MAX_STDOUT_BYTES = 30,000). Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`); defaults to `false` on parse for backward compatibility. |
 
 ### Example record
@@ -58,7 +59,7 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 |---|---|---|
 | `session_id` | early | `null` |
 | `seq` | early | `null` |
-| `output_truncated` | v0.9.0 | `null` (treat as unknown; does not mean truncation did not occur) |
+| `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
 | `chars_threshold_breach` | current | `false` (omitted from JSONL when false; safe to query with `// false`) |
 
 The five jq one-liners in `AGENTS.md` do not reference `output_truncated` and are unaffected. To query truncation events across all retained JSONL files:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,6 +154,18 @@ Added `--port N` flag. When set, aptu-coder binds to `127.0.0.1:N` and serves al
 
 ---
 
+### [Complete] exec_command output management (v0.14.2)
+
+Four PRs shipped together to make `exec_command` output safe for large contexts:
+
+- **#955**: `analyze_file` and `analyze_module` return `INVALID_PARAMS` for unsupported file extensions instead of a generic error; `inputSchema` pattern constraint added so MCP clients surface the restriction before calling.
+- **#957**: CI runners migrated to `ubuntu-24.04-arm` everywhere (ARM64).
+- **#961**: Byte-level output caps on `exec_command`: stdout 30k chars (tail-preserving), stderr 10k chars (tail-preserving), combined `output_text` 50k chars. Cap thresholds are data-driven from 27,981 observed calls (0.33% exceed 30k stdout). `output_truncated: Option<bool>` added to `MetricEvent` and the JSONL schema.
+- **#962**: Command-pattern output filter table: 7 built-in rules (git pull/fetch/push/log/status, cargo build/test) suppress per-file noise before output reaches the model. `git pull` additionally injects `--no-stat` before execution. Project-local rules via `.aptu/filters.toml`. `filter_applied` field in `structuredContent` identifies which rule fired. Filters apply on success only; raw output preserved on failure.
+- **#964**: Regression test suite for output volume and filter correctness.
+
+---
+
 ## Direction (Tentative)
 
 Unimplemented and pertinent:


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the four PRs merged today (#955, #961, #962, #964): `exec_command` output caps and filter table, `INVALID_PARAMS` for unsupported extensions in `analyze_file` / `analyze_module`, and CI runner migration.

## Changes

- `README.md`: exec_command output caps section (stdout 30k, stderr 10k, combined 50k; tail-preserving; `output_truncated` note); exec_command filter table (7 built-in rules, `.aptu/filters.toml` override, `filter_applied` field); `INVALID_PARAMS` note on `analyze_file` and `analyze_module` tool descriptions
- `crates/aptu-coder-core/README.md`: `INVALID_PARAMS` note on file analysis and module index feature bullets
- `docs/OBSERVABILITY.md`: `filter_applied` field added to metric record schema table; `output_truncated` backward-compat version corrected to `v0.14.2`
- `docs/ARCHITECTURE.md`: `output_filter + byte_caps` node added to `exec_command` data flow diagram; `INVALID_PARAMS` early-return documented in `analyze_file` and `analyze_module` analysis mode descriptions
- `docs/ROADMAP.md`: new `[Complete]` entry for v0.14.2 exec_command output management covering #955, #957, #961, #962, #964

## Test plan

- [ ] Documentation only; no code changes
