### PR TITLE
docs(bench): add v16 OpenFAST Fortran benchmark (full MCP tool set)

### DIFF
--- a/docs/benchmarks/v16/mcp-aptu-coder-full.json
+++ b/docs/benchmarks/v16/mcp-aptu-coder-full.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "aptu-coder": {
+      "type": "stdio",
+      "command": "aptu-coder",
+      "args": []
+    }
+  }
+}

--- a/docs/benchmarks/v16/methodology.md
+++ b/docs/benchmarks/v16/methodology.md
@@ -98,7 +98,9 @@ differences:
 4. `analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true)` -- NWTC types
 5. `analyze_file` on 1-2 NWTC type/utility files
 6. `analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
-7. `exec_command` for targeted line-number lookups or cross-checks as needed
+7. `exec_command` for targeted line-number lookups or cross-checks as needed; non-zero exit
+   codes are passed through to the agent as-is (exit_code field in the tool result) -- the
+   agent is expected to fall back to an `analyze_*` call if a shell command fails
 
 ## Rubric
 

--- a/docs/benchmarks/v16/methodology.md
+++ b/docs/benchmarks/v16/methodology.md
@@ -1,0 +1,129 @@
+# v16: OpenFAST AeroDyn Integration Audit -- Full MCP (exec_command added)
+
+## Overview
+
+v16 re-runs the MCP conditions from v13 (OpenFAST AeroDyn integration audit on Fortran) with one
+change: `exec_command` is now available alongside the four `analyze_*` tools. This isolates the
+effect of shell access on an already-MCP-capable agent. All other methodology parameters are
+identical to v13 so the native baseline (conditions B and D) can be reused directly.
+
+The target repository, task, rubric, models, N, runner, and commit pin are unchanged from v13.
+Only the MCP allowed-tools list changes (two conditions, A and C).
+
+## Background
+
+v13 established MCP advantage on Fortran scientific HPC code (OpenFAST, 344 files):
+- Sonnet 4.6 MCP: 472k tokens, $1.65 vs 877k tokens, $2.85 native (46% fewer tokens, 42% cheaper)
+- Haiku 4.5 MCP: 687k tokens, $0.72 vs 2162k tokens, $2.21 native (68% fewer tokens, 68% cheaper)
+
+Since v13, `exec_command` was added to aptu-coder. With it, the agent can perform targeted shell
+queries (e.g., `grep -n "subroutine AD_CalcOutput"`, `wc -l`) without any native Claude Code tools.
+v16 tests whether adding shell access to an already-MCP-capable agent further reduces token usage.
+
+## Repository
+
+Identical to v13:
+
+- **Repository:** `OpenFAST/openfast`
+- **Commit:** `2895884d2be01862173c88d70f86b358d2f1a50a` (pinned for reproducibility)
+- **Language:** Fortran 90/95/03
+- **Size:** 344 `.f90`/`.F90` source files, ~342 MB total (including test data)
+
+## Design
+
+### Factorial structure
+
+v16 runs only the two MCP conditions. Native conditions (B and D) are reused from v13 as the
+baseline; the task, repo, commit, and models are identical.
+
+| Condition | Model | Tool Set | Description |
+|---|---|---|---|
+| A | claude-sonnet-4-6 | MCP (full) | analyze_directory, analyze_file, analyze_symbol, analyze_module, exec_command |
+| C | claude-haiku-4-5 | MCP (full) | Same tools as A |
+| B (v13) | claude-sonnet-4-6 | native | Reused from v13 -- Glob, Grep, Read, Bash |
+| D (v13) | claude-haiku-4-5 | native | Reused from v13 -- Glob, Grep, Read, Bash |
+
+### Sample design
+
+- **N = 2 scored runs per condition** (4 total scored)
+- **N = 1 pilot run per condition** (2 total pilots)
+- **Total new runs: 6** (conditions A and C only)
+
+### Native baseline (reused from v13)
+
+| Run | Input tokens | Cost | Score |
+|---|---|---|---|
+| B-scored-1 | 582,097 | $1.97 | 9/9 |
+| B-scored-2 | 1,170,929 | $3.74 | 8/9 |
+| D-scored-1 | 2,188,829 | $2.23 | 7/9 |
+| D-scored-2 | 2,135,038 | $2.18 | 7/9 |
+
+Sonnet native median: 876,513 input tokens, $2.85 cost
+Haiku native median: 2,161,934 input tokens, $2.21 cost
+
+## Task
+
+Identical to v13. See [v13/prompts/task.md](../v13/prompts/task.md) (symlinked as v16/prompts/task.md).
+
+## Execution
+
+All runs are executed via `scripts/bench-v16-run.sh`. Same runner pattern as v13 with the following
+differences:
+
+- `MCP_TOOLS` includes `mcp__aptu-coder__exec_command`
+- `RUNS_DIR` and `PROMPTS_DIR` point to `v16`
+- No native conditions (B/D) -- script only accepts A and C
+
+**Tool isolation:**
+- MCP conditions (A, C): `--mcp-config docs/benchmarks/v16/mcp-aptu-coder-full.json --strict-mcp-config --allowedTools "mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module,mcp__aptu-coder__exec_command"`
+
+## Conditions
+
+### MCP conditions (A, C)
+
+**Allowed tools:**
+- `analyze_directory`
+- `analyze_file`
+- `analyze_symbol`
+- `analyze_module`
+- `exec_command`
+
+**Forbidden:**
+- Glob, Grep, Read, Bash, and any other Claude Code native tools
+
+**Recommended call sequence:**
+1. `analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true)` -- orient (1 call)
+2. `analyze_file` on `AeroDyn.f90` -- find `AD_CalcOutput` and `AD_UpdateStates`; or use `exec_command` with `grep -n "subroutine AD_" AeroDyn.f90` for a single-line result
+3. `analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees
+4. `analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true)` -- NWTC types
+5. `analyze_file` on 1-2 NWTC type/utility files
+6. `analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
+7. `exec_command` for targeted line-number lookups or cross-checks as needed
+
+## Rubric
+
+Identical to v13. Three dimensions, each scored 0-3 (max total = 9).
+
+See [v13/methodology.md](../v13/methodology.md) for full rubric text and calibration anchors.
+
+## Analysis
+
+- Compare v16 MCP (A, C) token counts and costs against v13 MCP (A, C) and v13 native (B, D)
+- Report absolute and percentage change in input tokens and cost vs v13 MCP
+- Report savings vs native baseline (reused from v13)
+- No statistical inference (n too small); report descriptive statistics only
+- Record rubric scores; flag any regression vs v13 MCP scores
+
+## Run Order
+
+See [v16/run-order.txt](run-order.txt).
+
+## File References
+
+- Methodology: This file
+- Task description: [v16/prompts/task.md](prompts/task.md) (identical to v13)
+- Condition A (Sonnet+MCP full): [v16/prompts/condition-a-mcp-sonnet.md](prompts/condition-a-mcp-sonnet.md)
+- Condition C (Haiku+MCP full): [v16/prompts/condition-c-mcp-haiku.md](prompts/condition-c-mcp-haiku.md)
+- Scores template: [v16/scores-template.json](scores-template.json)
+- OpenFAST commit: 2895884d2be01862173c88d70f86b358d2f1a50a
+- v13 native baseline: [v13/scores-template.json](../v13/scores-template.json)

--- a/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
@@ -1,54 +1,23 @@
-[SYSTEM PROMPT BEGIN - Condition A: Sonnet + MCP full]
+---
+name: bench-v16-condition-a
+model: claude-sonnet-4-6
+tools: ["mcp__aptu-coder__analyze_directory", "mcp__aptu-coder__analyze_file", "mcp__aptu-coder__analyze_symbol", "mcp__aptu-coder__analyze_module", "mcp__aptu-coder__exec_command"]
+---
 
-You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
-an integration audit.
+You are a code analysis agent auditing an OpenFAST (Fortran) repository. Produce a structured JSON report. No prose, no explanation outside the JSON.
 
 Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+Repository path: substituted at runtime via RUN_ID_PLACEHOLDER / REPO_PATH_PLACEHOLDER
 
-ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
-FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
+## Chain of thought
 
-## MCP Tool Workflow
+Follow this sequence exactly. Do not skip steps. Do not read files not identified in a prior step.
 
-Tool selection rules:
-- `analyze_module` first for any file where you only need function names and line numbers (~75%
-  smaller than `analyze_file`). Escalate to `analyze_file` only when you need signatures, types,
-  or class details.
-- `analyze_file(fields=["functions"])` when you need function line ranges but not imports or classes.
-- `exec_command` with a targeted `grep -n` for exact line-number confirmation in one call (e.g.,
-  `grep -n "^[[:space:]]*subroutine AD_CalcOutput" <file>`). Faster than paginating a large file.
-- `analyze_symbol` for all call-graph traversal -- returns structured callers/callees in one call.
-  Do not use `exec_command` grep loops to reconstruct call chains.
-- `analyze_directory(summary=true, max_depth=2)` to orient on any unfamiliar directory tree. Do
-  not call `analyze_file` or `analyze_module` on files you have not first located via a directory
-  survey or symbol lookup.
+1. `analyze_directory` on `<repo>/modules/aerodyn/src` (max_depth=2, summary=true) -- locate AeroDyn files
+2. `exec_command`: `grep -n "^[[:space:]]*subroutine AD_CalcOutput\|^[[:space:]]*subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` -- exact entry-point line numbers in one call
+3. `analyze_symbol` on `<repo>/modules/aerodyn/src`, symbol=AD_CalcOutput, follow_depth=2 -- full callee tree into NWTC library; do not grep for call chains
+4. `analyze_directory` on `<repo>/modules/nwtc-library/src` (max_depth=2, summary=true) -- locate NWTC type files
+5. `analyze_module` on each NWTC file needed for type declarations; escalate to `analyze_file` only if TYPE definitions are absent from module output
+6. `analyze_module` on `<repo>/modules/openfast-library/src/FAST_Subs.f90` -- glue-code function index; escalate to `analyze_file(fields=["functions"])` only if line ranges are missing
 
-Recommended call sequence:
-
-1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true)`
-   -- orient on AeroDyn module structure (1 call)
-
-2. `mcp__aptu-coder__exec_command(command="grep -n \"^[[:space:]]*subroutine AD_CalcOutput\\|^[[:space:]]*subroutine AD_UpdateStates\" <repo>/modules/aerodyn/src/AeroDyn.f90")`
-   -- exact line numbers for both entry points in one call; or use
-   `mcp__aptu-coder__analyze_module(path="<repo>/modules/aerodyn/src/AeroDyn.f90")` for a full
-   function index at minimal token cost
-
-3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)`
-   -- trace callees into NWTC library (1 call; do not grep for this)
-
-4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=2, summary=true)`
-   -- orient on NWTC library structure
-
-5. `mcp__aptu-coder__analyze_module` on 1-2 NWTC type/utility files identified above
-   -- function and import index; escalate to `analyze_file` only if type definitions are needed
-
-6. `mcp__aptu-coder__analyze_module(path="<repo>/modules/openfast-library/src/FAST_Subs.f90")`
-   -- glue-code function index; escalate to
-   `mcp__aptu-coder__analyze_file(path="...", fields=["functions"])` if line ranges are needed
-
-7. Use `exec_command` for any remaining targeted lookups (exact line numbers, cross-checks) where
-   a single `grep -n` returns a one-line answer
-
-Use `cursor`/`page_size` to paginate large results if needed.
-
-[SYSTEM PROMPT END - Condition A: Sonnet + MCP full]
+Stop after step 6 unless a specific gap requires one additional targeted call. Emit the JSON output.

--- a/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
@@ -10,19 +10,45 @@ FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
 
 ## MCP Tool Workflow
 
-Recommended call sequence for efficient analysis:
+Tool selection rules:
+- `analyze_module` first for any file where you only need function names and line numbers (~75%
+  smaller than `analyze_file`). Escalate to `analyze_file` only when you need signatures, types,
+  or class details.
+- `analyze_file(fields=["functions"])` when you need function line ranges but not imports or classes.
+- `exec_command` with a targeted `grep -n` for exact line-number confirmation in one call (e.g.,
+  `grep -n "^[[:space:]]*subroutine AD_CalcOutput" <file>`). Faster than paginating a large file.
+- `analyze_symbol` for all call-graph traversal -- returns structured callers/callees in one call.
+  Do not use `exec_command` grep loops to reconstruct call chains.
+- `analyze_directory(summary=true, max_depth=2)` to orient on any unfamiliar directory tree. Do
+  not call `analyze_file` or `analyze_module` on files you have not first located via a directory
+  survey or symbol lookup.
 
-1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
-2. `mcp__aptu-coder__analyze_file` on `AeroDyn.f90` -- find `AD_CalcOutput` and `AD_UpdateStates`; or use `exec_command` with `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` for exact line numbers in one call
-3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
-4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
-5. `mcp__aptu-coder__analyze_file` on 1-2 NWTC type/utility files identified above
-6. `mcp__aptu-coder__analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
-7. Use `exec_command` for targeted lookups (e.g., exact line numbers, cross-checks) where a single grep is faster than paginating a large file
+Recommended call sequence:
 
-Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
-results. Do not call `analyze_file` on every file discovered; start with directory overview.
-Prefer `analyze_symbol` over `exec_command` for call graph traversal -- it returns structured output
-in one call. Reserve `exec_command` for targeted line-number confirmation and cross-checks.
+1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true)`
+   -- orient on AeroDyn module structure (1 call)
+
+2. `mcp__aptu-coder__exec_command(command="grep -n \"^[[:space:]]*subroutine AD_CalcOutput\\|^[[:space:]]*subroutine AD_UpdateStates\" <repo>/modules/aerodyn/src/AeroDyn.f90")`
+   -- exact line numbers for both entry points in one call; or use
+   `mcp__aptu-coder__analyze_module(path="<repo>/modules/aerodyn/src/AeroDyn.f90")` for a full
+   function index at minimal token cost
+
+3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)`
+   -- trace callees into NWTC library (1 call; do not grep for this)
+
+4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=2, summary=true)`
+   -- orient on NWTC library structure
+
+5. `mcp__aptu-coder__analyze_module` on 1-2 NWTC type/utility files identified above
+   -- function and import index; escalate to `analyze_file` only if type definitions are needed
+
+6. `mcp__aptu-coder__analyze_module(path="<repo>/modules/openfast-library/src/FAST_Subs.f90")`
+   -- glue-code function index; escalate to
+   `mcp__aptu-coder__analyze_file(path="...", fields=["functions"])` if line ranges are needed
+
+7. Use `exec_command` for any remaining targeted lookups (exact line numbers, cross-checks) where
+   a single `grep -n` returns a one-line answer
+
+Use `cursor`/`page_size` to paginate large results if needed.
 
 [SYSTEM PROMPT END - Condition A: Sonnet + MCP full]

--- a/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md
@@ -1,0 +1,28 @@
+[SYSTEM PROMPT BEGIN - Condition A: Sonnet + MCP full]
+
+You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
+an integration audit.
+
+Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
+FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence for efficient analysis:
+
+1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
+2. `mcp__aptu-coder__analyze_file` on `AeroDyn.f90` -- find `AD_CalcOutput` and `AD_UpdateStates`; or use `exec_command` with `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` for exact line numbers in one call
+3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
+4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
+5. `mcp__aptu-coder__analyze_file` on 1-2 NWTC type/utility files identified above
+6. `mcp__aptu-coder__analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
+7. Use `exec_command` for targeted lookups (e.g., exact line numbers, cross-checks) where a single grep is faster than paginating a large file
+
+Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
+results. Do not call `analyze_file` on every file discovered; start with directory overview.
+Prefer `analyze_symbol` over `exec_command` for call graph traversal -- it returns structured output
+in one call. Reserve `exec_command` for targeted line-number confirmation and cross-checks.
+
+[SYSTEM PROMPT END - Condition A: Sonnet + MCP full]

--- a/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
@@ -1,54 +1,23 @@
-[SYSTEM PROMPT BEGIN - Condition C: Haiku + MCP full]
+---
+name: bench-v16-condition-c
+model: claude-haiku-4-5
+tools: ["mcp__aptu-coder__analyze_directory", "mcp__aptu-coder__analyze_file", "mcp__aptu-coder__analyze_symbol", "mcp__aptu-coder__analyze_module", "mcp__aptu-coder__exec_command"]
+---
 
-You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
-an integration audit.
+You are a code analysis agent auditing an OpenFAST (Fortran) repository. Produce a structured JSON report. No prose, no explanation outside the JSON.
 
 Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+Repository path: substituted at runtime via RUN_ID_PLACEHOLDER / REPO_PATH_PLACEHOLDER
 
-ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
-FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
+## Chain of thought
 
-## MCP Tool Workflow
+Follow this sequence exactly. Do not skip steps. Do not read files not identified in a prior step.
 
-Tool selection rules:
-- `analyze_module` first for any file where you only need function names and line numbers (~75%
-  smaller than `analyze_file`). Escalate to `analyze_file` only when you need signatures, types,
-  or class details.
-- `analyze_file(fields=["functions"])` when you need function line ranges but not imports or classes.
-- `exec_command` with a targeted `grep -n` for exact line-number confirmation in one call (e.g.,
-  `grep -n "^[[:space:]]*subroutine AD_CalcOutput" <file>`). Faster than paginating a large file.
-- `analyze_symbol` for all call-graph traversal -- returns structured callers/callees in one call.
-  Do not use `exec_command` grep loops to reconstruct call chains.
-- `analyze_directory(summary=true, max_depth=2)` to orient on any unfamiliar directory tree. Do
-  not call `analyze_file` or `analyze_module` on files you have not first located via a directory
-  survey or symbol lookup.
+1. `analyze_directory` on `<repo>/modules/aerodyn/src` (max_depth=2, summary=true) -- locate AeroDyn files
+2. `exec_command`: `grep -n "^[[:space:]]*subroutine AD_CalcOutput\|^[[:space:]]*subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` -- exact entry-point line numbers in one call
+3. `analyze_symbol` on `<repo>/modules/aerodyn/src`, symbol=AD_CalcOutput, follow_depth=2 -- full callee tree into NWTC library; do not grep for call chains
+4. `analyze_directory` on `<repo>/modules/nwtc-library/src` (max_depth=2, summary=true) -- locate NWTC type files
+5. `analyze_module` on each NWTC file needed for type declarations; escalate to `analyze_file` only if TYPE definitions are absent from module output
+6. `analyze_module` on `<repo>/modules/openfast-library/src/FAST_Subs.f90` -- glue-code function index; escalate to `analyze_file(fields=["functions"])` only if line ranges are missing
 
-Recommended call sequence:
-
-1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true)`
-   -- orient on AeroDyn module structure (1 call)
-
-2. `mcp__aptu-coder__exec_command(command="grep -n \"^[[:space:]]*subroutine AD_CalcOutput\\|^[[:space:]]*subroutine AD_UpdateStates\" <repo>/modules/aerodyn/src/AeroDyn.f90")`
-   -- exact line numbers for both entry points in one call; or use
-   `mcp__aptu-coder__analyze_module(path="<repo>/modules/aerodyn/src/AeroDyn.f90")` for a full
-   function index at minimal token cost
-
-3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)`
-   -- trace callees into NWTC library (1 call; do not grep for this)
-
-4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=2, summary=true)`
-   -- orient on NWTC library structure
-
-5. `mcp__aptu-coder__analyze_module` on 1-2 NWTC type/utility files identified above
-   -- function and import index; escalate to `analyze_file` only if type definitions are needed
-
-6. `mcp__aptu-coder__analyze_module(path="<repo>/modules/openfast-library/src/FAST_Subs.f90")`
-   -- glue-code function index; escalate to
-   `mcp__aptu-coder__analyze_file(path="...", fields=["functions"])` if line ranges are needed
-
-7. Use `exec_command` for any remaining targeted lookups (exact line numbers, cross-checks) where
-   a single `grep -n` returns a one-line answer
-
-Use `cursor`/`page_size` to paginate large results if needed.
-
-[SYSTEM PROMPT END - Condition C: Haiku + MCP full]
+Stop after step 6 unless a specific gap requires one additional targeted call. Emit the JSON output.

--- a/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
@@ -1,0 +1,28 @@
+[SYSTEM PROMPT BEGIN - Condition C: Haiku + MCP full]
+
+You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
+an integration audit.
+
+Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
+FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence for efficient analysis:
+
+1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
+2. `mcp__aptu-coder__analyze_file` on `AeroDyn.f90` -- find `AD_CalcOutput` and `AD_UpdateStates`; or use `exec_command` with `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` for exact line numbers in one call
+3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
+4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
+5. `mcp__aptu-coder__analyze_file` on 1-2 NWTC type/utility files identified above
+6. `mcp__aptu-coder__analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
+7. Use `exec_command` for targeted lookups (e.g., exact line numbers, cross-checks) where a single grep is faster than paginating a large file
+
+Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
+results. Do not call `analyze_file` on every file discovered; start with directory overview.
+Prefer `analyze_symbol` over `exec_command` for call graph traversal -- it returns structured output
+in one call. Reserve `exec_command` for targeted line-number confirmation and cross-checks.
+
+[SYSTEM PROMPT END - Condition C: Haiku + MCP full]

--- a/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md
@@ -10,19 +10,45 @@ FORBIDDEN TOOLS: Glob, Grep, Read, Bash, and any tools not listed above
 
 ## MCP Tool Workflow
 
-Recommended call sequence for efficient analysis:
+Tool selection rules:
+- `analyze_module` first for any file where you only need function names and line numbers (~75%
+  smaller than `analyze_file`). Escalate to `analyze_file` only when you need signatures, types,
+  or class details.
+- `analyze_file(fields=["functions"])` when you need function line ranges but not imports or classes.
+- `exec_command` with a targeted `grep -n` for exact line-number confirmation in one call (e.g.,
+  `grep -n "^[[:space:]]*subroutine AD_CalcOutput" <file>`). Faster than paginating a large file.
+- `analyze_symbol` for all call-graph traversal -- returns structured callers/callees in one call.
+  Do not use `exec_command` grep loops to reconstruct call chains.
+- `analyze_directory(summary=true, max_depth=2)` to orient on any unfamiliar directory tree. Do
+  not call `analyze_file` or `analyze_module` on files you have not first located via a directory
+  survey or symbol lookup.
 
-1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
-2. `mcp__aptu-coder__analyze_file` on `AeroDyn.f90` -- find `AD_CalcOutput` and `AD_UpdateStates`; or use `exec_command` with `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` for exact line numbers in one call
-3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
-4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
-5. `mcp__aptu-coder__analyze_file` on 1-2 NWTC type/utility files identified above
-6. `mcp__aptu-coder__analyze_file` on `modules/openfast-library/src/FAST_Subs.f90` -- glue code entry point
-7. Use `exec_command` for targeted lookups (e.g., exact line numbers, cross-checks) where a single grep is faster than paginating a large file
+Recommended call sequence:
 
-Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
-results. Do not call `analyze_file` on every file discovered; start with directory overview.
-Prefer `analyze_symbol` over `exec_command` for call graph traversal -- it returns structured output
-in one call. Reserve `exec_command` for targeted line-number confirmation and cross-checks.
+1. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true)`
+   -- orient on AeroDyn module structure (1 call)
+
+2. `mcp__aptu-coder__exec_command(command="grep -n \"^[[:space:]]*subroutine AD_CalcOutput\\|^[[:space:]]*subroutine AD_UpdateStates\" <repo>/modules/aerodyn/src/AeroDyn.f90")`
+   -- exact line numbers for both entry points in one call; or use
+   `mcp__aptu-coder__analyze_module(path="<repo>/modules/aerodyn/src/AeroDyn.f90")` for a full
+   function index at minimal token cost
+
+3. `mcp__aptu-coder__analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)`
+   -- trace callees into NWTC library (1 call; do not grep for this)
+
+4. `mcp__aptu-coder__analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=2, summary=true)`
+   -- orient on NWTC library structure
+
+5. `mcp__aptu-coder__analyze_module` on 1-2 NWTC type/utility files identified above
+   -- function and import index; escalate to `analyze_file` only if type definitions are needed
+
+6. `mcp__aptu-coder__analyze_module(path="<repo>/modules/openfast-library/src/FAST_Subs.f90")`
+   -- glue-code function index; escalate to
+   `mcp__aptu-coder__analyze_file(path="...", fields=["functions"])` if line ranges are needed
+
+7. Use `exec_command` for any remaining targeted lookups (exact line numbers, cross-checks) where
+   a single `grep -n` returns a one-line answer
+
+Use `cursor`/`page_size` to paginate large results if needed.
 
 [SYSTEM PROMPT END - Condition C: Haiku + MCP full]

--- a/docs/benchmarks/v16/prompts/task.md
+++ b/docs/benchmarks/v16/prompts/task.md
@@ -1,0 +1,43 @@
+## Task: OpenFAST AeroDyn Integration Point Audit
+
+You are onboarding to the OpenFAST codebase to extend the AeroDyn module with a new blade-load
+correction factor. OpenFAST is a physics-based wind turbine simulation framework. AeroDyn is the
+aerodynamics module responsible for computing blade loads. It follows the FAST modular framework
+interface: every physics module exposes `Init`, `CalcOutput`, `UpdateStates`, and `End` subroutines
+with module-prefixed names (e.g., `AD_CalcOutput`).
+
+Your task:
+1. Identify the exact Fortran files and subroutine names (with line numbers) that define AeroDyn's
+   top-level `CalcOutput` and `UpdateStates` routines. These are named `AD_CalcOutput` and
+   `AD_UpdateStates` (module-prefixed) and live in `modules/aerodyn/src/AeroDyn.f90`.
+2. Trace which NWTC library routines (from `modules/nwtc-library/src/`) are called within
+   `AD_CalcOutput` -- up to 2 call levels deep. For each routine, name it and the file it is defined in.
+3. Identify which derived types (Fortran `TYPE` definitions) from `modules/nwtc-library/src/` are
+   used by AeroDyn. For each type, name the file and approximate line number where it is declared.
+4. Produce an integration map: which files and line ranges must change to inject a new scalar
+   correction-factor parameter (`BladeLoadCorrFactor`) through the call stack -- from the glue-code
+   entry point in `modules/openfast-library/src/FAST_Subs.f90` down to the blade-element calculation
+   inside AeroDyn.
+
+Output must be valid JSON. Example structure:
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "aerodyn_entry_points": [
+    {"subroutine": "AD_CalcOutput", "file": "path/relative/to/openfast/root", "line": 0},
+    {"subroutine": "AD_UpdateStates", "file": "path/relative/to/openfast/root", "line": 0}
+  ],
+  "nwtc_callees": [
+    {"routine": "name", "file": "path/relative/to/openfast/root", "call_depth": 1},
+    {"routine": "name2", "file": "path/relative/to/openfast/root", "call_depth": 2}
+  ],
+  "nwtc_types_used": [
+    {"type_name": "TypeName", "declared_in": "path/relative/to/openfast/root", "approx_line": 0}
+  ],
+  "integration_map": [
+    {"file": "path/relative/to/openfast/root", "line_range": "start-end", "change": "description"}
+  ],
+  "tool_calls_total": 0
+}
+```

--- a/docs/benchmarks/v16/run-order.txt
+++ b/docs/benchmarks/v16/run-order.txt
@@ -1,0 +1,17 @@
+# v16 Run Order (seed=42)
+# Pilots run first (2 runs) to verify exec_command integration before scoring.
+# Scored runs follow in randomized order (4 runs, seed=42).
+# Native conditions (B/D) are reused from v13; do not re-run them.
+#
+# Usage: bash scripts/bench-v16-run.sh <CONDITION_ID> <RUN_ID>
+# CONDITION_ID: A or C only
+
+# --- Pilot runs (execute in order before any scored run) ---
+1. bash scripts/bench-v16-run.sh A A-pilot
+2. bash scripts/bench-v16-run.sh C C-pilot
+
+# --- Scored runs (randomized, seed=42) ---
+3. bash scripts/bench-v16-run.sh C C-scored-1
+4. bash scripts/bench-v16-run.sh A A-scored-1
+5. bash scripts/bench-v16-run.sh A A-scored-2
+6. bash scripts/bench-v16-run.sh C C-scored-2

--- a/docs/benchmarks/v16/scores-template.json
+++ b/docs/benchmarks/v16/scores-template.json
@@ -1,0 +1,171 @@
+{
+  "version": "v16",
+  "rubric": {
+    "dimensions": [
+      "structural_accuracy",
+      "call_chain_tracing",
+      "integration_map_quality"
+    ],
+    "max_per_dimension": 3,
+    "max_total": 9
+  },
+  "native_baseline_source": "v13",
+  "native_baseline": {
+    "sonnet": {
+      "input_tokens_median": 876513,
+      "cost_usd_median": 2.85,
+      "runs": ["B-scored-1", "B-scored-2"]
+    },
+    "haiku": {
+      "input_tokens_median": 2161934,
+      "cost_usd_median": 2.21,
+      "runs": ["D-scored-1", "D-scored-2"]
+    }
+  },
+  "runs": [
+    {
+      "run_id": "A-pilot",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    },
+    {
+      "run_id": "A-scored-1",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    },
+    {
+      "run_id": "A-scored-2",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    },
+    {
+      "run_id": "C-pilot",
+      "condition": "C",
+      "model": "claude-haiku-4-5",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    },
+    {
+      "run_id": "C-scored-1",
+      "condition": "C",
+      "model": "claude-haiku-4-5",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    },
+    {
+      "run_id": "C-scored-2",
+      "condition": "C",
+      "model": "claude-haiku-4-5",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {
+        "wall_time_ms": null,
+        "api_time_ms": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_tokens": null,
+        "cache_creation_tokens": null,
+        "cost_usd": null,
+        "num_turns": null
+      }
+    }
+  ]
+}

--- a/scripts/bench-v16-run.sh
+++ b/scripts/bench-v16-run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # v16 Benchmark Runner
 # Runs MCP-full conditions (A and C) only. Native conditions (B/D) are reused from v13.
-# Condition A uses claude-sonnet-4-6, C uses claude-haiku-4-5.
-# Both conditions use: analyze_directory, analyze_file, analyze_symbol, analyze_module, exec_command.
+# Model and tool allowlist are declared in agent frontmatter (prompts/condition-*.md);
+# the runner expands repo-path/run-id placeholders into a temp agent file and passes
+# it via --agent. No --model or --allowedTools flags needed.
 #
 # Usage:
 #   bash scripts/bench-v16-run.sh <CONDITION_ID> <RUN_ID>
@@ -13,13 +14,8 @@
 #   bash scripts/bench-v16-run.sh A A-scored-2
 #
 # Environment variables:
-#   BENCH_MAX_BUDGET_USD           -- cap spend per run (optional, e.g. "2.00")
-#   OPENFAST_REPO                  -- local path to openfast clone
-#                                     (default: /tmp/openfast-benchmark)
-#   ANTHROPIC_DEFAULT_SONNET_MODEL -- model ID for condition A
-#                                     (default: claude-sonnet-4-6)
-#   ANTHROPIC_DEFAULT_HAIKU_MODEL  -- model ID for condition C
-#                                     (default: claude-haiku-4-5)
+#   BENCH_MAX_BUDGET_USD  -- cap spend per run (optional, e.g. "2.00")
+#   OPENFAST_REPO         -- local path to openfast clone (default: /tmp/openfast-benchmark)
 
 set -euo pipefail
 
@@ -114,18 +110,9 @@ fi
 # ---------------------------------------------------------------------------
 # Condition dispatch
 # ---------------------------------------------------------------------------
-SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-6}"
-HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5}"
-
 case "$CONDITION_ID" in
-  A)
-    MODEL="$SONNET_MODEL"
-    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-a-mcp-sonnet.md"
-    ;;
-  C)
-    MODEL="$HAIKU_MODEL"
-    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-c-mcp-haiku.md"
-    ;;
+  A) AGENT_SOURCE="$PROMPTS_DIR/condition-a-mcp-sonnet.md" ;;
+  C) AGENT_SOURCE="$PROMPTS_DIR/condition-c-mcp-haiku.md" ;;
 esac
 
 # ---------------------------------------------------------------------------
@@ -135,12 +122,19 @@ OUTPUT_FILE="$RUNS_DIR/${RUN_ID}-report.json"
 TELEMETRY_FILE="$RUNS_DIR/${RUN_ID}-telemetry.json"
 LOG_FILE="$RUNS_DIR/${RUN_ID}.log"
 SCRATCH_FILE=$(mktemp /tmp/bench-v16-XXXXXX.json)
-trap 'rm -f "$SCRATCH_FILE"' EXIT
+# Expand repo path and run-id placeholders into a temp agent file
+AGENT_FILE=$(mktemp /tmp/bench-v16-agent-XXXXXX.md)
+sed \
+  -e "s|<repo>|$OPENFAST_REPO|g" \
+  -e "s|REPO_PATH_PLACEHOLDER|$OPENFAST_REPO|g" \
+  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
+  -e "s|CONDITION_PLACEHOLDER|$CONDITION_ID|g" \
+  "$AGENT_SOURCE" > "$AGENT_FILE"
+trap 'rm -f "$SCRATCH_FILE" "$AGENT_FILE"' EXIT
 
 # ---------------------------------------------------------------------------
-# Tool isolation flags
+# MCP config flag (server registration only; tool allowlist lives in agent frontmatter)
 # ---------------------------------------------------------------------------
-MCP_TOOLS="mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module,mcp__aptu-coder__exec_command"
 MCP_FLAGS="--mcp-config $MCP_CONFIG --strict-mcp-config"
 
 # ---------------------------------------------------------------------------
@@ -171,15 +165,7 @@ OUTPUT_SCHEMA=$(cat <<'SCHEMA'
 SCHEMA
 )
 
-# ---------------------------------------------------------------------------
-# Build prompts (substitute placeholders)
-# ---------------------------------------------------------------------------
-SYSTEM_PROMPT=$(sed \
-  -e "s|<repo>|$OPENFAST_REPO|g" \
-  -e "s|REPO_PATH_PLACEHOLDER|$OPENFAST_REPO|g" \
-  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
-  "$SYSTEM_PROMPT_FILE")
-
+# Task user message: repo path is the only runtime context needed (agent file has the rest)
 TASK_CONTENT=$(sed \
   -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
   -e "s|CONDITION_PLACEHOLDER|$CONDITION_ID|g" \
@@ -197,9 +183,7 @@ cat <<EOF
 === v16 Benchmark Run ===
 CONDITION:   $CONDITION_ID
 RUN_ID:      $RUN_ID
-MODEL:       $MODEL
-TOOL_SET:    mcp-full (analyze_* + exec_command)
-ALLOWED:     $MCP_TOOLS
+AGENT:       $AGENT_FILE
 OPENFAST:    $OPENFAST_REPO ($ACTUAL_COMMIT)
 BUDGET:      ${BENCH_MAX_BUDGET_USD:-unlimited} USD
 OUTPUT:      $OUTPUT_FILE
@@ -217,12 +201,12 @@ if [[ -n "${BENCH_MAX_BUDGET_USD:-}" ]]; then
   BUDGET_FLAG=(--max-budget-usd "$BENCH_MAX_BUDGET_USD")
 fi
 
+# --agent supplies model + tool allowlist via frontmatter; no --model/--allowedTools needed.
+# --strict-mcp-config ensures only the aptu-coder server is loaded regardless of user config.
 DISABLE_PROMPT_CACHING=1 claude \
   -p \
-  --model "$MODEL" \
-  --system-prompt "$SYSTEM_PROMPT" \
+  --agent "$AGENT_FILE" \
   $MCP_FLAGS \
-  --allowedTools "$MCP_TOOLS" \
   --dangerously-skip-permissions \
   --output-format json \
   --json-schema "$OUTPUT_SCHEMA" \

--- a/scripts/bench-v16-run.sh
+++ b/scripts/bench-v16-run.sh
@@ -20,6 +20,14 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: 'claude' CLI not found. Install Claude Code and authenticate before running." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -276,6 +284,9 @@ PYEOF
 # ---------------------------------------------------------------------------
 # Tool isolation validation
 # ---------------------------------------------------------------------------
+# Claude Code writes session JSONL to ~/.claude/projects/<slug>/ where <slug> is the
+# working directory path with slashes replaced by hyphens. Override with CLAUDE_SESSION_DIR
+# if your installation uses a different layout.
 _REPO_SLUG="${REPO_ROOT//\//-}"
 SESSION_DIR="${CLAUDE_SESSION_DIR:-$HOME/.claude/projects/${_REPO_SLUG}}"
 

--- a/scripts/bench-v16-run.sh
+++ b/scripts/bench-v16-run.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# v16 Benchmark Runner
+# Runs MCP-full conditions (A and C) only. Native conditions (B/D) are reused from v13.
+# Condition A uses claude-sonnet-4-6, C uses claude-haiku-4-5.
+# Both conditions use: analyze_directory, analyze_file, analyze_symbol, analyze_module, exec_command.
+#
+# Usage:
+#   bash scripts/bench-v16-run.sh <CONDITION_ID> <RUN_ID>
+#
+# Examples:
+#   bash scripts/bench-v16-run.sh A A-pilot
+#   bash scripts/bench-v16-run.sh C C-scored-1
+#   bash scripts/bench-v16-run.sh A A-scored-2
+#
+# Environment variables:
+#   BENCH_MAX_BUDGET_USD           -- cap spend per run (optional, e.g. "2.00")
+#   OPENFAST_REPO                  -- local path to openfast clone
+#                                     (default: /tmp/openfast-benchmark)
+#   ANTHROPIC_DEFAULT_SONNET_MODEL -- model ID for condition A
+#                                     (default: claude-sonnet-4-6)
+#   ANTHROPIC_DEFAULT_HAIKU_MODEL  -- model ID for condition C
+#                                     (default: claude-haiku-4-5)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNS_DIR="$REPO_ROOT/docs/benchmarks/v16/results/runs"
+PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/v16/prompts"
+MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v16/mcp-aptu-coder-full.json"
+
+mkdir -p "$RUNS_DIR"
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <CONDITION_ID> <RUN_ID>" >&2
+  echo "CONDITION_ID: A or C" >&2
+  echo "RUN_ID: e.g. A-pilot, C-scored-1" >&2
+  exit 1
+fi
+
+CONDITION_ID="$1"
+RUN_ID="$2"
+
+if [[ ! "$CONDITION_ID" =~ ^[AC]$ ]]; then
+  echo "ERROR: CONDITION_ID must be A or C (native conditions B/D are reused from v13)" >&2
+  exit 1
+fi
+
+if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: RUN_ID must contain only alphanumeric characters, dots, underscores, and hyphens" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# OpenFAST repo setup
+# ---------------------------------------------------------------------------
+OPENFAST_REPO="${OPENFAST_REPO:-/tmp/openfast-benchmark}"
+OPENFAST_COMMIT="2895884d2be01862173c88d70f86b358d2f1a50a"
+
+if [[ -d "$OPENFAST_REPO" ]] && { find "$OPENFAST_REPO" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .; }; then
+  if ! git -C "$OPENFAST_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: OPENFAST_REPO ('$OPENFAST_REPO') exists but is not a git repository." >&2
+    echo "       Remove the directory or set OPENFAST_REPO to an empty/absent path." >&2
+    exit 1
+  fi
+  REMOTE_URL=$(git -C "$OPENFAST_REPO" remote get-url origin 2>/dev/null || echo "")
+  REMOTE_URL_LOWER=$(echo "$REMOTE_URL" | tr '[:upper:]' '[:lower:]')
+  if [[ -z "$REMOTE_URL" ]]; then
+    echo "WARNING: OPENFAST_REPO has no origin remote. Proceeding with local-only repo." >&2
+  elif [[ "$REMOTE_URL_LOWER" != *openfast* ]]; then
+    echo "ERROR: OPENFAST_REPO remote URL ('$REMOTE_URL') does not contain 'openfast'." >&2
+    echo "       This does not appear to be the OpenFAST repository." >&2
+    exit 1
+  fi
+elif [[ ! -d "$OPENFAST_REPO/modules/aerodyn" ]]; then
+  echo "Cloning OpenFAST (shallow) into $OPENFAST_REPO ..."
+  git clone --depth=1 https://github.com/OpenFAST/openfast.git "$OPENFAST_REPO"
+fi
+
+if ! git -C "$OPENFAST_REPO" rev-parse --verify "${OPENFAST_COMMIT}^{commit}" >/dev/null 2>&1; then
+  echo "Fetching pinned OpenFAST commit $OPENFAST_COMMIT ..." >&2
+  if ! git -C "$OPENFAST_REPO" fetch --depth=1 origin "$OPENFAST_COMMIT" 2>/dev/null; then
+    if [[ "$RUN_ID" == *scored* ]]; then
+      echo "ERROR: Failed to fetch pinned commit $OPENFAST_COMMIT for scored run $RUN_ID." >&2
+      exit 1
+    else
+      echo "WARNING: Failed to fetch pinned commit $OPENFAST_COMMIT; proceeding with existing clone." >&2
+    fi
+  fi
+fi
+
+if git -C "$OPENFAST_REPO" rev-parse --verify "${OPENFAST_COMMIT}^{commit}" >/dev/null 2>&1; then
+  git -C "$OPENFAST_REPO" -c advice.detachedHead=false checkout "$OPENFAST_COMMIT" >/dev/null 2>&1 || true
+fi
+
+ACTUAL_COMMIT=$(git -C "$OPENFAST_REPO" rev-parse HEAD)
+if [[ "$ACTUAL_COMMIT" != "$OPENFAST_COMMIT" ]]; then
+  if [[ "$RUN_ID" == *scored* ]]; then
+    echo "ERROR: OpenFAST HEAD is $ACTUAL_COMMIT, expected $OPENFAST_COMMIT." >&2
+    echo "       Scored runs require the pinned commit for reproducibility." >&2
+    exit 1
+  else
+    echo "WARNING: OpenFAST HEAD is $ACTUAL_COMMIT, expected $OPENFAST_COMMIT." >&2
+    echo "         Pilot runs may proceed; scored runs must use the pinned commit." >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Condition dispatch
+# ---------------------------------------------------------------------------
+SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-6}"
+HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5}"
+
+case "$CONDITION_ID" in
+  A)
+    MODEL="$SONNET_MODEL"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-a-mcp-sonnet.md"
+    ;;
+  C)
+    MODEL="$HAIKU_MODEL"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-c-mcp-haiku.md"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Output files
+# ---------------------------------------------------------------------------
+OUTPUT_FILE="$RUNS_DIR/${RUN_ID}-report.json"
+TELEMETRY_FILE="$RUNS_DIR/${RUN_ID}-telemetry.json"
+LOG_FILE="$RUNS_DIR/${RUN_ID}.log"
+SCRATCH_FILE=$(mktemp /tmp/bench-v16-XXXXXX.json)
+trap 'rm -f "$SCRATCH_FILE"' EXIT
+
+# ---------------------------------------------------------------------------
+# Tool isolation flags
+# ---------------------------------------------------------------------------
+MCP_TOOLS="mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module,mcp__aptu-coder__exec_command"
+MCP_FLAGS="--mcp-config $MCP_CONFIG --strict-mcp-config"
+
+# ---------------------------------------------------------------------------
+# Output schema (identical to v13)
+# ---------------------------------------------------------------------------
+OUTPUT_SCHEMA=$(cat <<'SCHEMA'
+{
+  "type": "object",
+  "properties": {
+    "run_id":               { "type": "string" },
+    "condition":            { "type": "string" },
+    "aerodyn_entry_points": { "type": "array", "items": { "type": "object" } },
+    "nwtc_callees":         { "type": "array", "items": { "type": "object" } },
+    "nwtc_types_used":      { "type": "array", "items": { "type": "object" } },
+    "integration_map":      { "type": "array", "items": { "type": "object" } },
+    "tool_calls_total":     { "type": "integer" }
+  },
+  "required": [
+    "run_id",
+    "condition",
+    "aerodyn_entry_points",
+    "nwtc_callees",
+    "nwtc_types_used",
+    "integration_map",
+    "tool_calls_total"
+  ]
+}
+SCHEMA
+)
+
+# ---------------------------------------------------------------------------
+# Build prompts (substitute placeholders)
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT=$(sed \
+  -e "s|<repo>|$OPENFAST_REPO|g" \
+  -e "s|REPO_PATH_PLACEHOLDER|$OPENFAST_REPO|g" \
+  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
+  "$SYSTEM_PROMPT_FILE")
+
+TASK_CONTENT=$(sed \
+  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
+  -e "s|CONDITION_PLACEHOLDER|$CONDITION_ID|g" \
+  "$PROMPTS_DIR/task.md")
+
+TASK_CONTENT="$TASK_CONTENT
+
+Repository is cloned at: $OPENFAST_REPO
+All tool paths must use this absolute prefix."
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+cat <<EOF
+=== v16 Benchmark Run ===
+CONDITION:   $CONDITION_ID
+RUN_ID:      $RUN_ID
+MODEL:       $MODEL
+TOOL_SET:    mcp-full (analyze_* + exec_command)
+ALLOWED:     $MCP_TOOLS
+OPENFAST:    $OPENFAST_REPO ($ACTUAL_COMMIT)
+BUDGET:      ${BENCH_MAX_BUDGET_USD:-unlimited} USD
+OUTPUT:      $OUTPUT_FILE
+TELEMETRY:   $TELEMETRY_FILE
+EOF
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+echo "Starting run at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+touch /tmp/.v16-run-marker
+
+BUDGET_FLAG=()
+if [[ -n "${BENCH_MAX_BUDGET_USD:-}" ]]; then
+  BUDGET_FLAG=(--max-budget-usd "$BENCH_MAX_BUDGET_USD")
+fi
+
+DISABLE_PROMPT_CACHING=1 claude \
+  -p \
+  --model "$MODEL" \
+  --system-prompt "$SYSTEM_PROMPT" \
+  $MCP_FLAGS \
+  --allowedTools "$MCP_TOOLS" \
+  --dangerously-skip-permissions \
+  --output-format json \
+  --json-schema "$OUTPUT_SCHEMA" \
+  ${BUDGET_FLAG:+"${BUDGET_FLAG[@]}"} \
+  "$TASK_CONTENT" \
+  > "$SCRATCH_FILE" \
+  2> "$LOG_FILE"
+
+echo "Run completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ---------------------------------------------------------------------------
+# Extract report and telemetry
+# ---------------------------------------------------------------------------
+python3 - "$SCRATCH_FILE" "$OUTPUT_FILE" "$TELEMETRY_FILE" << 'PYEOF'
+import json, sys
+
+scratch, out_path, tel_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(scratch) as f:
+    content = f.read().strip()
+
+if not content:
+    print("ERROR: output file is empty", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    messages = json.loads(content)
+    if not isinstance(messages, list):
+        messages = [messages]
+except json.JSONDecodeError as e:
+    print(f"ERROR: could not parse output as JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+result = next((m for m in messages if isinstance(m, dict) and m.get("type") == "result"), None)
+if result is None:
+    print("ERROR: no result message found in output", file=sys.stderr)
+    sys.exit(1)
+
+structured = result.get("structured_output")
+if structured is None:
+    print("ERROR: structured_output is null or missing", file=sys.stderr)
+    sys.exit(1)
+
+with open(out_path, "w") as f:
+    json.dump(structured, f, indent=2)
+
+usage = result.get("usage") or {}
+if not isinstance(usage, dict):
+    usage = {}
+telemetry = {
+    "wall_time_ms":          result.get("duration_ms"),
+    "api_time_ms":           result.get("duration_api_ms"),
+    "num_turns":             result.get("num_turns"),
+    "cost_usd":              result.get("total_cost_usd"),
+    "input_tokens":          usage.get("input_tokens"),
+    "output_tokens":         usage.get("output_tokens"),
+    "cache_read_tokens":     usage.get("cache_read_input_tokens"),
+    "cache_creation_tokens": usage.get("cache_creation_input_tokens"),
+}
+with open(tel_path, "w") as f:
+    json.dump(telemetry, f, indent=2)
+
+print(f"Report:    {out_path}")
+print(f"Telemetry: {tel_path}")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Tool isolation validation
+# ---------------------------------------------------------------------------
+_REPO_SLUG="${REPO_ROOT//\//-}"
+SESSION_DIR="${CLAUDE_SESSION_DIR:-$HOME/.claude/projects/${_REPO_SLUG}}"
+
+_sessions=()
+while IFS= read -r f; do _sessions+=("$f"); done < <(find "$SESSION_DIR" -name "*.jsonl" -newer /tmp/.v16-run-marker 2>/dev/null || true)
+if [[ ${#_sessions[@]} -gt 0 ]]; then
+  LATEST_SESSION=$(ls -t "${_sessions[@]}" 2>/dev/null | head -1)
+  SESSION_COPY="$RUNS_DIR/${RUN_ID}-session.jsonl"
+  cp "$LATEST_SESSION" "$SESSION_COPY"
+  echo "Session JSONL: $SESSION_COPY"
+
+  python3 - "$SESSION_COPY" << 'PYEOF'
+import json, sys
+
+session_file = sys.argv[1]
+
+MCP_TOOLS = {
+    "mcp__aptu-coder__analyze_directory",
+    "mcp__aptu-coder__analyze_file",
+    "mcp__aptu-coder__analyze_symbol",
+    "mcp__aptu-coder__analyze_module",
+    "mcp__aptu-coder__exec_command",
+}
+NATIVE_TOOLS = {"Bash", "Glob", "Grep", "Read", "Write", "ToolSearch"}
+
+tools_used = set()
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("type") == "assistant":
+            for block in entry.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tools_used.add(block["name"])
+
+print(f"Tools used: {sorted(tools_used)}")
+
+forbidden = tools_used & NATIVE_TOOLS
+if forbidden:
+    print(f"ISOLATION FAIL: native tools used in MCP condition: {forbidden}", file=sys.stderr)
+    sys.exit(1)
+print(f"MCP tools used: {sorted(tools_used & MCP_TOOLS)}")
+print("ISOLATION PASS")
+PYEOF
+else
+  echo "WARNING: could not find session JSONL for isolation validation" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Run complete ==="
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "Report:    $OUTPUT_FILE"
+  python3 -c "
+import json
+d = json.load(open('$OUTPUT_FILE'))
+ep  = len(d.get('aerodyn_entry_points', []))
+cal = len(d.get('nwtc_callees', []))
+typ = len(d.get('nwtc_types_used', []))
+imp = len(d.get('integration_map', []))
+tc  = d.get('tool_calls_total', '?')
+print(f'  entry_points={ep}  nwtc_callees={cal}  types={typ}  integration_map={imp}  tool_calls={tc}')
+"
+fi
+if [[ -f "$TELEMETRY_FILE" ]]; then
+  echo "Telemetry: $TELEMETRY_FILE"
+  python3 -c "
+import json
+t = json.load(open('$TELEMETRY_FILE'))
+print(f'  turns={t.get(\"num_turns\",\"?\")}  cost_usd={t.get(\"cost_usd\",\"?\")}  input_tokens={t.get(\"input_tokens\",\"?\")}')
+"
+fi
+if [[ -s "$LOG_FILE" ]]; then
+  echo "Log:       $LOG_FILE"
+fi


### PR DESCRIPTION
## Summary

Add v16 benchmark for the OpenFAST AeroDyn integration audit task (Fortran). v16 re-runs the MCP conditions from v13 with `exec_command` added to the allowed tool set, isolating the effect of full shell access on an already-MCP-capable agent. Native conditions B/D are reused from v13 as the baseline -- the repo, commit, task, and models are identical.

## What changed vs v13

- **Tool set:** `analyze_directory`, `analyze_file`, `analyze_symbol`, `analyze_module`, `exec_command` (was analyze-only in v13)
- **Conditions run:** A (Sonnet) and C (Haiku) only; B/D native baseline reused from v13
- **New runs:** 6 total (2 pilots + 4 scored)

## Prompt optimizations (second commit)

The v16 prompts are updated for the current tool API, not just a mechanical copy of v13:

- `analyze_module` replaces `analyze_file` as the default for function-index lookups (~75% smaller)
- `fields=["functions"]` guidance added for `analyze_file` when only line ranges are needed
- `exec_command` pattern made concrete: `grep -n` with Fortran subroutine anchor regex, not generic "targeted lookup"
- `page_size=50` removed from `analyze_directory` calls (default 100 is correct; 50 forced unnecessary pagination)
- `max_depth` on NWTC directory survey corrected to 2 per server instructions
- Explicit rule: use `analyze_symbol` for call-graph traversal, not `exec_command` grep loops

## Files

- `docs/benchmarks/v16/methodology.md`
- `docs/benchmarks/v16/mcp-aptu-coder-full.json`
- `docs/benchmarks/v16/prompts/condition-a-mcp-sonnet.md`
- `docs/benchmarks/v16/prompts/condition-c-mcp-haiku.md`
- `docs/benchmarks/v16/prompts/task.md`
- `docs/benchmarks/v16/run-order.txt`
- `docs/benchmarks/v16/scores-template.json`
- `docs/benchmarks/v16/results/runs/.gitkeep`
- `scripts/bench-v16-run.sh`

## Test plan

- [ ] `bash scripts/bench-v16-run.sh A A-pilot` completes and writes `results/runs/A-pilot-report.json` and `A-pilot-telemetry.json`
- [ ] `bash scripts/bench-v16-run.sh C C-pilot` same
- [ ] Isolation validator reports `ISOLATION PASS` for both pilots (no native tools in session JSONL)
- [ ] Telemetry shows lower input tokens than v13 MCP baseline (A: 472k, C: 687k median)
