### PR TITLE
docs(bench): add v17 OpenFAST benchmark with tool-isolation fix and model updates

### DIFF
--- a/docs/benchmarks/v17/mcp-aptu-coder-full.json
+++ b/docs/benchmarks/v17/mcp-aptu-coder-full.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "aptu-coder": {
+      "type": "stdio",
+      "command": "aptu-coder",
+      "args": []
+    }
+  }
+}

--- a/docs/benchmarks/v17/methodology.md
+++ b/docs/benchmarks/v17/methodology.md
@@ -1,0 +1,185 @@
+# v17: OpenFAST AeroDyn Integration Audit -- MCP Full (exec_command, isolation fixed)
+
+## Overview
+
+v17 re-runs the MCP+exec_command conditions from v16 with the tool-isolation regression fixed.
+v16 dropped `--allowedTools` from the CLI and relied on agent frontmatter `tools:` as the
+enforcement mechanism. That mechanism does not work when `--dangerously-skip-permissions` is
+active: the permission layer -- and the allowlist filter it enforces -- is bypassed entirely.
+Every v16 run used native Bash/Grep/Read exclusively, making v16 results invalid as MCP measurements.
+
+v17 restores the v13 enforcement pattern: `--allowedTools` is passed as an explicit CLI flag,
+which is enforced before the permission layer. The `--agent` invocation style is dropped in favour
+of `--model` + `--system-prompt` + `--allowedTools`, matching the proven v13 runner.
+
+Models are updated to the latest available at time of execution:
+- Condition A: `claude-sonnet-4-6` (unchanged from v13/v16)
+- Condition C: `claude-haiku-4-5-20251001` (explicit version pin; v16 used the `claude-haiku-4-5`
+  alias which resolves to the same model but is less reproducible across CLI versions)
+
+All other methodology parameters (task, repo, commit, rubric, N, output schema) are identical
+to v13 so the native baseline (conditions B and D) can be reused directly.
+
+## v16 Post-mortem
+
+**Root cause:** `--dangerously-skip-permissions` bypasses all permission checks, including the
+`--allowedTools` filter. v16 moved the allowlist into agent frontmatter (`tools:`), which is
+parsed by the CLI but not enforced once permissions are skipped. The model received the full
+native tool set and ignored the frontmatter instruction on every run.
+
+**Evidence:** Session JSONL analysis of all 6 v16 runs shows 14-25 native tool calls (Bash, Grep,
+Read) per run and exactly 1 MCP call (`analyze_module`) per run -- almost certainly the
+ToolSearch discovery call, not intentional analysis. Zero `analyze_directory`, `analyze_file`,
+or `analyze_symbol` calls appear in any v16 session.
+
+**Fix:** Restore `--allowedTools "$ALLOWED_TOOLS"` as an explicit CLI flag in the runner script,
+built from the condition's tool list at dispatch time. This is the v13 pattern and is confirmed
+to work. The `--agent` invocation style is retired for benchmark use.
+
+**Canary check:** The runner's isolation validator reads the session JSONL and fails loudly if
+any native tool appears. Run pilots first and confirm ISOLATION PASS before proceeding to scored
+runs.
+
+## Background
+
+v13 established MCP advantage on Fortran scientific HPC code (OpenFAST, 344 files):
+- Sonnet MCP: 472k tokens avg, $1.65 avg vs 877k tokens, $2.85 native (46% fewer tokens, 42% cheaper)
+- Haiku MCP: 687k tokens avg, $0.72 avg vs 2162k tokens, $2.21 native (68% fewer tokens, 68% cheaper)
+
+v16 intended to measure whether adding `exec_command` to the MCP tool set changes those numbers.
+v16 results are invalid (see post-mortem above) and are not used as a baseline here.
+
+v17 answers the same question as v16 with a valid experimental design.
+
+## Repository
+
+Identical to v13:
+
+- **Repository:** `OpenFAST/openfast`
+- **Commit:** `2895884d2be01862173c88d70f86b358d2f1a50a` (pinned for reproducibility)
+- **Language:** Fortran 90/95/03
+- **Size:** 344 `.f90`/`.F90` source files, ~342 MB total (including test data)
+
+## Design
+
+### Factorial structure
+
+v17 runs only the two MCP conditions. Native conditions (B and D) are reused from v13 as the
+baseline; the task, repo, commit, and models are identical.
+
+| Condition | Model | Tool Set | Description |
+|---|---|---|---|
+| A | claude-sonnet-4-6 | MCP (full) | analyze_directory, analyze_file, analyze_symbol, analyze_module, exec_command |
+| C | claude-haiku-4-5-20251001 | MCP (full) | Same tools as A |
+| B (v13) | claude-sonnet-4-6 | native | Reused from v13 -- Glob, Grep, Read, Bash |
+| D (v13) | claude-haiku-4-5 | native | Reused from v13 -- Glob, Grep, Read, Bash |
+
+### Sample design
+
+- **N = 2 scored runs per condition** (4 total scored)
+- **N = 1 pilot run per condition** (2 total pilots)
+- **Total new runs: 6** (conditions A and C only)
+
+### Native baseline (reused from v13)
+
+| Run | Input tokens | Cost | Score |
+|---|---|---|---|
+| B-scored-1 | 582,097 | $1.97 | 9/9 |
+| B-scored-2 | 1,170,929 | $3.74 | 8/9 |
+| D-scored-1 | 2,188,829 | $2.23 | 7/9 |
+| D-scored-2 | 2,135,038 | $2.18 | 7/9 |
+
+Sonnet native median: 876,513 input tokens, $2.85 cost
+Haiku native median: 2,161,934 input tokens, $2.21 cost
+
+## Task
+
+Identical to v13. See [v17/prompts/task.md](prompts/task.md).
+
+## Execution
+
+All runs are executed via `scripts/bench-v17-run.sh`.
+
+**Key differences from v16 runner:**
+
+- `--model`, `--system-prompt`, and `--allowedTools` are all explicit CLI flags (v13 pattern)
+- `--agent` is not used; agent frontmatter `tools:` is not the enforcement mechanism
+- `ALLOWED_TOOLS` is built at condition-dispatch time and passed verbatim to `--allowedTools`
+- Haiku model pinned to `claude-haiku-4-5-20251001` for reproducibility
+
+**Tool isolation:**
+
+MCP conditions (A, C) enforce:
+
+```
+--allowedTools "mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module,mcp__aptu-coder__exec_command"
+```
+
+The session JSONL validator checks for native tool use after each run and exits non-zero on
+ISOLATION FAIL. Pilot run isolation must be confirmed before scored runs proceed.
+
+## Conditions
+
+### Condition A -- Sonnet + MCP full
+
+**Model:** `claude-sonnet-4-6`
+
+**Allowed tools:**
+- `mcp__aptu-coder__analyze_directory`
+- `mcp__aptu-coder__analyze_file`
+- `mcp__aptu-coder__analyze_symbol`
+- `mcp__aptu-coder__analyze_module`
+- `mcp__aptu-coder__exec_command`
+
+**Forbidden:** Glob, Grep, Read, Bash, Write, and any other native Claude Code tools
+
+### Condition C -- Haiku + MCP full
+
+**Model:** `claude-haiku-4-5-20251001`
+
+**Allowed tools:** identical to Condition A
+
+**Forbidden:** identical to Condition A
+
+### Recommended call sequence (both conditions)
+
+1. `analyze_directory` on `<repo>/modules/aerodyn/src` (max_depth=2, summary=true) -- orient (1 call)
+2. `exec_command`: `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" AeroDyn.f90` -- line numbers
+3. `analyze_symbol` on `<repo>/modules/aerodyn/src`, symbol=AD_CalcOutput, follow_depth=2 -- callee tree
+4. `analyze_directory` on `<repo>/modules/nwtc-library/src` (max_depth=1, summary=true) -- NWTC types
+5. `analyze_module` on each NWTC file needed; escalate to `analyze_file` only if TYPE definitions absent
+6. `analyze_module` on `<repo>/modules/openfast-library/src/FAST_Subs.f90` -- glue code index
+
+`exec_command` is permitted for targeted single-result lookups only (line numbers, symbol grep).
+It must not be used to explore directory trees or dump file content.
+
+## Rubric
+
+Identical to v13. Three dimensions, each scored 0-3 (max total = 9).
+
+See [v13/methodology.md](../v13/methodology.md) for full rubric text and calibration anchors.
+
+## Analysis
+
+- Compare v17 MCP (A, C) token counts and costs against v13 MCP (A, C) and v13 native (B, D)
+- Report absolute and percentage change in input tokens and cost vs v13 MCP baseline
+- Report savings vs native baseline (reused from v13)
+- No statistical inference (n too small); report descriptive statistics only
+- Record rubric scores; flag any regression vs v13 MCP scores
+- v16 results are excluded from all comparisons (invalid experimental design)
+
+## Run Order
+
+See [v17/run-order.txt](run-order.txt).
+
+## File References
+
+- Methodology: This file
+- Task description: [v17/prompts/task.md](prompts/task.md) (identical to v13)
+- Condition A (Sonnet + MCP full): [v17/prompts/condition-a-mcp-sonnet.md](prompts/condition-a-mcp-sonnet.md)
+- Condition C (Haiku + MCP full): [v17/prompts/condition-c-mcp-haiku.md](prompts/condition-c-mcp-haiku.md)
+- Runner script: [scripts/bench-v17-run.sh](../../scripts/bench-v17-run.sh)
+- Scores template: [v17/scores-template.json](scores-template.json)
+- OpenFAST commit: 2895884d2be01862173c88d70f86b358d2f1a50a
+- v13 native baseline: [v13/scores-template.json](../v13/scores-template.json)
+- v16 post-mortem: See v16 regression in this document and [v16/methodology.md](../v16/methodology.md)

--- a/docs/benchmarks/v17/prompts/condition-a-mcp-sonnet.md
+++ b/docs/benchmarks/v17/prompts/condition-a-mcp-sonnet.md
@@ -1,0 +1,27 @@
+[SYSTEM PROMPT BEGIN - Condition A: Sonnet + MCP full]
+
+You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
+an integration audit.
+
+Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
+FORBIDDEN TOOLS: Glob, Grep, Read, Bash, Write, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence for efficient analysis:
+
+1. `analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
+2. `exec_command`: `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` -- exact line numbers in one call
+3. `analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
+4. `analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
+5. `analyze_module` on each NWTC file needed for type declarations; escalate to `analyze_file` only if TYPE definitions are absent
+6. `analyze_module` on `<repo>/modules/openfast-library/src/FAST_Subs.f90` -- glue-code function index
+
+Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
+results. Do not call `analyze_file` on every file discovered; start with directory overview.
+Use `exec_command` only for targeted lookups (line numbers, grep for a specific symbol) that
+require less than one full file read. Do not use it to explore directory trees or dump file content.
+
+[SYSTEM PROMPT END - Condition A: Sonnet + MCP full]

--- a/docs/benchmarks/v17/prompts/condition-c-mcp-haiku.md
+++ b/docs/benchmarks/v17/prompts/condition-c-mcp-haiku.md
@@ -1,0 +1,27 @@
+[SYSTEM PROMPT BEGIN - Condition C: Haiku + MCP full]
+
+You are a code analysis agent. Your task is to analyze an OpenFAST (Fortran) repository and produce
+an integration audit.
+
+Repository: OpenFAST/openfast at commit 2895884d2be01862173c88d70f86b358d2f1a50a
+
+ALLOWED TOOLS: mcp__aptu-coder__analyze_directory, mcp__aptu-coder__analyze_file, mcp__aptu-coder__analyze_symbol, mcp__aptu-coder__analyze_module, mcp__aptu-coder__exec_command
+FORBIDDEN TOOLS: Glob, Grep, Read, Bash, Write, and any tools not listed above
+
+## MCP Tool Workflow
+
+Recommended call sequence for efficient analysis:
+
+1. `analyze_directory(path="<repo>/modules/aerodyn/src", max_depth=2, summary=true, page_size=50)` -- orient on AeroDyn (1 call)
+2. `exec_command`: `grep -n "subroutine AD_CalcOutput\|subroutine AD_UpdateStates" <repo>/modules/aerodyn/src/AeroDyn.f90` -- exact line numbers in one call
+3. `analyze_symbol(path="<repo>/modules/aerodyn/src", symbol="AD_CalcOutput", follow_depth=2)` -- trace callees into NWTC library
+4. `analyze_directory(path="<repo>/modules/nwtc-library/src", max_depth=1, summary=true, page_size=50)` -- orient on NWTC types
+5. `analyze_module` on each NWTC file needed for type declarations; escalate to `analyze_file` only if TYPE definitions are absent
+6. `analyze_module` on `<repo>/modules/openfast-library/src/FAST_Subs.f90` -- glue-code function index
+
+Use `summary=true` and `max_depth=2` on directory calls. Use `cursor`/`page_size` to paginate large
+results. Do not call `analyze_file` on every file discovered; start with directory overview.
+Use `exec_command` only for targeted lookups (line numbers, grep for a specific symbol) that
+require less than one full file read. Do not use it to explore directory trees or dump file content.
+
+[SYSTEM PROMPT END - Condition C: Haiku + MCP full]

--- a/docs/benchmarks/v17/prompts/task.md
+++ b/docs/benchmarks/v17/prompts/task.md
@@ -1,0 +1,43 @@
+## Task: OpenFAST AeroDyn Integration Point Audit
+
+You are onboarding to the OpenFAST codebase to extend the AeroDyn module with a new blade-load
+correction factor. OpenFAST is a physics-based wind turbine simulation framework. AeroDyn is the
+aerodynamics module responsible for computing blade loads. It follows the FAST modular framework
+interface: every physics module exposes `Init`, `CalcOutput`, `UpdateStates`, and `End` subroutines
+with module-prefixed names (e.g., `AD_CalcOutput`).
+
+Your task:
+1. Identify the exact Fortran files and subroutine names (with line numbers) that define AeroDyn's
+   top-level `CalcOutput` and `UpdateStates` routines. These are named `AD_CalcOutput` and
+   `AD_UpdateStates` (module-prefixed) and live in `modules/aerodyn/src/AeroDyn.f90`.
+2. Trace which NWTC library routines (from `modules/nwtc-library/src/`) are called within
+   `AD_CalcOutput` -- up to 2 call levels deep. For each routine, name it and the file it is defined in.
+3. Identify which derived types (Fortran `TYPE` definitions) from `modules/nwtc-library/src/` are
+   used by AeroDyn. For each type, name the file and approximate line number where it is declared.
+4. Produce an integration map: which files and line ranges must change to inject a new scalar
+   correction-factor parameter (`BladeLoadCorrFactor`) through the call stack -- from the glue-code
+   entry point in `modules/openfast-library/src/FAST_Subs.f90` down to the blade-element calculation
+   inside AeroDyn.
+
+Output must be valid JSON. Example structure:
+```json
+{
+  "run_id": "RUN_ID_PLACEHOLDER",
+  "condition": "CONDITION_PLACEHOLDER",
+  "aerodyn_entry_points": [
+    {"subroutine": "AD_CalcOutput", "file": "path/relative/to/openfast/root", "line": 0},
+    {"subroutine": "AD_UpdateStates", "file": "path/relative/to/openfast/root", "line": 0}
+  ],
+  "nwtc_callees": [
+    {"routine": "name", "file": "path/relative/to/openfast/root", "call_depth": 1},
+    {"routine": "name2", "file": "path/relative/to/openfast/root", "call_depth": 2}
+  ],
+  "nwtc_types_used": [
+    {"type_name": "TypeName", "declared_in": "path/relative/to/openfast/root", "approx_line": 0}
+  ],
+  "integration_map": [
+    {"file": "path/relative/to/openfast/root", "line_range": "start-end", "change": "description"}
+  ],
+  "tool_calls_total": 0
+}
+```

--- a/docs/benchmarks/v17/run-order.txt
+++ b/docs/benchmarks/v17/run-order.txt
@@ -1,0 +1,20 @@
+# v17 Run Order (seed=42)
+# Pilots run first (2 runs) to verify tool isolation before scoring.
+# Scored runs follow in randomized order (4 runs, seed=42).
+# Native conditions (B/D) are reused from v13; do not re-run them.
+#
+# IMPORTANT: Before starting scored runs, verify isolation holds in pilot
+# session JSONLs -- confirm no Bash/Grep/Read/Glob appear in tools_used.
+#
+# Usage: bash scripts/bench-v17-run.sh <CONDITION_ID> <RUN_ID>
+# CONDITION_ID: A or C only
+
+# --- Pilot runs (execute in order; verify isolation before proceeding) ---
+1. bash scripts/bench-v17-run.sh A A-pilot
+2. bash scripts/bench-v17-run.sh C C-pilot
+
+# --- Scored runs (randomized, seed=42) ---
+3. bash scripts/bench-v17-run.sh C C-scored-1
+4. bash scripts/bench-v17-run.sh A A-scored-1
+5. bash scripts/bench-v17-run.sh A A-scored-2
+6. bash scripts/bench-v17-run.sh C C-scored-2

--- a/docs/benchmarks/v17/scores-template.json
+++ b/docs/benchmarks/v17/scores-template.json
@@ -1,0 +1,104 @@
+{
+  "version": "v17",
+  "rubric": {
+    "dimensions": [
+      "structural_accuracy",
+      "call_chain_tracing",
+      "integration_map_quality"
+    ],
+    "max_per_dimension": 3,
+    "max_total": 9
+  },
+  "runs": [
+    {
+      "run_id": "A-pilot",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    },
+    {
+      "run_id": "A-scored-1",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    },
+    {
+      "run_id": "A-scored-2",
+      "condition": "A",
+      "model": "claude-sonnet-4-6",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    },
+    {
+      "run_id": "C-pilot",
+      "condition": "C",
+      "model": "claude-haiku-4-5-20251001",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    },
+    {
+      "run_id": "C-scored-1",
+      "condition": "C",
+      "model": "claude-haiku-4-5-20251001",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    },
+    {
+      "run_id": "C-scored-2",
+      "condition": "C",
+      "model": "claude-haiku-4-5-20251001",
+      "tool_set": "mcp-full",
+      "scores": {
+        "structural_accuracy": null,
+        "call_chain_tracing": null,
+        "integration_map_quality": null,
+        "total": null
+      },
+      "notes": "",
+      "tool_calls_total": null,
+      "telemetry": {}
+    }
+  ]
+}

--- a/scripts/bench-v17-run.sh
+++ b/scripts/bench-v17-run.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# v17 Benchmark Runner
+# Runs MCP conditions (A and C) only. Native conditions (B/D) are reused from v13.
+# Tool isolation is enforced via --allowedTools on the CLI (not agent frontmatter).
+# --allowedTools is the only reliable mechanism; agent frontmatter tools: is ignored
+# when --dangerously-skip-permissions is active (v16 regression, fixed here).
+#
+# Usage:
+#   bash scripts/bench-v17-run.sh <CONDITION_ID> <RUN_ID>
+#
+# Examples:
+#   bash scripts/bench-v17-run.sh A A-pilot
+#   bash scripts/bench-v17-run.sh C C-scored-1
+#
+# Environment variables:
+#   BENCH_MAX_BUDGET_USD  -- cap spend per run (optional, e.g. "2.00")
+#   OPENFAST_REPO         -- local path to openfast clone (default: /tmp/openfast-benchmark)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNS_DIR="$REPO_ROOT/docs/benchmarks/v17/results/runs"
+PROMPTS_DIR="$REPO_ROOT/docs/benchmarks/v17/prompts"
+MCP_CONFIG="$REPO_ROOT/docs/benchmarks/v17/mcp-aptu-coder-full.json"
+
+mkdir -p "$RUNS_DIR"
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <CONDITION_ID> <RUN_ID>" >&2
+  echo "CONDITION_ID: A or C" >&2
+  echo "RUN_ID: e.g. A-pilot, C-scored-1" >&2
+  exit 1
+fi
+
+CONDITION_ID="$1"
+RUN_ID="$2"
+
+if [[ ! "$CONDITION_ID" =~ ^[AC]$ ]]; then
+  echo "ERROR: CONDITION_ID must be A or C (native conditions B/D are reused from v13)" >&2
+  exit 1
+fi
+
+if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: RUN_ID must contain only alphanumeric characters, dots, underscores, and hyphens" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# OpenFAST repo setup
+# ---------------------------------------------------------------------------
+OPENFAST_REPO="${OPENFAST_REPO:-/tmp/openfast-benchmark}"
+OPENFAST_COMMIT="2895884d2be01862173c88d70f86b358d2f1a50a"
+
+if [[ -d "$OPENFAST_REPO" ]] && { find "$OPENFAST_REPO" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .; }; then
+  if ! git -C "$OPENFAST_REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: OPENFAST_REPO ('$OPENFAST_REPO') exists but is not a git repository." >&2
+    echo "       Remove the directory or set OPENFAST_REPO to an empty/absent path." >&2
+    exit 1
+  fi
+  REMOTE_URL=$(git -C "$OPENFAST_REPO" remote get-url origin 2>/dev/null || echo "")
+  REMOTE_URL_LOWER=$(echo "$REMOTE_URL" | tr '[:upper:]' '[:lower:]')
+  if [[ -z "$REMOTE_URL" ]]; then
+    echo "WARNING: OPENFAST_REPO has no origin remote. Proceeding with local-only repo." >&2
+  elif [[ "$REMOTE_URL_LOWER" != *openfast* ]]; then
+    echo "ERROR: OPENFAST_REPO remote URL ('$REMOTE_URL') does not contain 'openfast'." >&2
+    echo "       This does not appear to be the OpenFAST repository." >&2
+    exit 1
+  fi
+elif [[ ! -d "$OPENFAST_REPO/modules/aerodyn" ]]; then
+  echo "Cloning OpenFAST (shallow) into $OPENFAST_REPO ..."
+  git clone --depth=1 https://github.com/OpenFAST/openfast.git "$OPENFAST_REPO"
+fi
+
+if ! git -C "$OPENFAST_REPO" rev-parse --verify "${OPENFAST_COMMIT}^{commit}" >/dev/null 2>&1; then
+  echo "Fetching pinned OpenFAST commit $OPENFAST_COMMIT ..." >&2
+  if ! git -C "$OPENFAST_REPO" fetch --depth=1 origin "$OPENFAST_COMMIT" 2>/dev/null; then
+    if [[ "$RUN_ID" == *scored* ]]; then
+      echo "ERROR: Failed to fetch pinned commit $OPENFAST_COMMIT for scored run $RUN_ID." >&2
+      exit 1
+    else
+      echo "WARNING: Failed to fetch pinned commit $OPENFAST_COMMIT; proceeding with existing clone." >&2
+    fi
+  fi
+fi
+
+if git -C "$OPENFAST_REPO" rev-parse --verify "${OPENFAST_COMMIT}^{commit}" >/dev/null 2>&1; then
+  git -C "$OPENFAST_REPO" -c advice.detachedHead=false checkout "$OPENFAST_COMMIT" >/dev/null 2>&1 || true
+fi
+
+ACTUAL_COMMIT=$(git -C "$OPENFAST_REPO" rev-parse HEAD)
+if [[ "$ACTUAL_COMMIT" != "$OPENFAST_COMMIT" ]]; then
+  if [[ "$RUN_ID" == *scored* ]]; then
+    echo "ERROR: OpenFAST HEAD is $ACTUAL_COMMIT, expected $OPENFAST_COMMIT." >&2
+    echo "       Scored runs require the pinned commit for reproducibility." >&2
+    exit 1
+  else
+    echo "WARNING: OpenFAST HEAD is $ACTUAL_COMMIT, expected $OPENFAST_COMMIT." >&2
+    echo "         Pilot runs may proceed; scored runs must use the pinned commit." >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Condition dispatch
+# Model and allowed-tool list are set here and passed as explicit CLI flags.
+# Agent frontmatter tools: is NOT the enforcement mechanism; --allowedTools is.
+# ---------------------------------------------------------------------------
+# Resolve model IDs: prefer env vars set by local config, fall back to aliases.
+SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-claude-sonnet-4-6}"
+HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-claude-haiku-4-5-20251001}"
+
+MCP_TOOLS="mcp__aptu-coder__analyze_directory,mcp__aptu-coder__analyze_file,mcp__aptu-coder__analyze_symbol,mcp__aptu-coder__analyze_module,mcp__aptu-coder__exec_command"
+
+case "$CONDITION_ID" in
+  A)
+    MODEL="$SONNET_MODEL"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-a-mcp-sonnet.md"
+    ALLOWED_TOOLS="$MCP_TOOLS"
+    ;;
+  C)
+    MODEL="$HAIKU_MODEL"
+    SYSTEM_PROMPT_FILE="$PROMPTS_DIR/condition-c-mcp-haiku.md"
+    ALLOWED_TOOLS="$MCP_TOOLS"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Output files
+# ---------------------------------------------------------------------------
+OUTPUT_FILE="$RUNS_DIR/${RUN_ID}-report.json"
+TELEMETRY_FILE="$RUNS_DIR/${RUN_ID}-telemetry.json"
+LOG_FILE="$RUNS_DIR/${RUN_ID}.log"
+SCRATCH_FILE=$(mktemp /tmp/bench-v17-XXXXXX.json)
+trap 'rm -f "$SCRATCH_FILE"' EXIT
+
+# ---------------------------------------------------------------------------
+# System prompt: substitute repo path and run-id placeholders
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT=$(sed \
+  -e "s|<repo>|$OPENFAST_REPO|g" \
+  -e "s|REPO_PATH_PLACEHOLDER|$OPENFAST_REPO|g" \
+  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
+  -e "s|CONDITION_PLACEHOLDER|$CONDITION_ID|g" \
+  "$SYSTEM_PROMPT_FILE")
+
+# ---------------------------------------------------------------------------
+# MCP config flag
+# ---------------------------------------------------------------------------
+MCP_FLAGS="--mcp-config $MCP_CONFIG --strict-mcp-config"
+
+# ---------------------------------------------------------------------------
+# Output schema (identical to v13/v16)
+# ---------------------------------------------------------------------------
+OUTPUT_SCHEMA=$(cat <<'SCHEMA'
+{
+  "type": "object",
+  "properties": {
+    "run_id":               { "type": "string" },
+    "condition":            { "type": "string" },
+    "aerodyn_entry_points": { "type": "array", "items": { "type": "object" } },
+    "nwtc_callees":         { "type": "array", "items": { "type": "object" } },
+    "nwtc_types_used":      { "type": "array", "items": { "type": "object" } },
+    "integration_map":      { "type": "array", "items": { "type": "object" } },
+    "tool_calls_total":     { "type": "integer" }
+  },
+  "required": [
+    "run_id",
+    "condition",
+    "aerodyn_entry_points",
+    "nwtc_callees",
+    "nwtc_types_used",
+    "integration_map",
+    "tool_calls_total"
+  ]
+}
+SCHEMA
+)
+
+# Task user message
+TASK_CONTENT=$(sed \
+  -e "s|RUN_ID_PLACEHOLDER|$RUN_ID|g" \
+  -e "s|CONDITION_PLACEHOLDER|$CONDITION_ID|g" \
+  "$PROMPTS_DIR/task.md")
+
+TASK_CONTENT="$TASK_CONTENT
+
+Repository is cloned at: $OPENFAST_REPO
+All tool paths must use this absolute prefix."
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+cat <<EOF
+=== v17 Benchmark Run ===
+CONDITION:   $CONDITION_ID
+RUN_ID:      $RUN_ID
+MODEL:       $MODEL
+ALLOWED:     $ALLOWED_TOOLS
+OPENFAST:    $OPENFAST_REPO ($ACTUAL_COMMIT)
+BUDGET:      ${BENCH_MAX_BUDGET_USD:-unlimited} USD
+OUTPUT:      $OUTPUT_FILE
+TELEMETRY:   $TELEMETRY_FILE
+EOF
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+echo "Starting run at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+touch /tmp/.v17-run-marker
+
+BUDGET_FLAG=()
+if [[ -n "${BENCH_MAX_BUDGET_USD:-}" ]]; then
+  BUDGET_FLAG=(--max-budget-usd "$BENCH_MAX_BUDGET_USD")
+fi
+
+# Key fix vs v16: --model, --system-prompt, and --allowedTools are all explicit CLI flags.
+# --allowedTools enforces the tool allowlist regardless of --dangerously-skip-permissions.
+# Do NOT use --agent; agent frontmatter tools: is not enforced when permissions are skipped.
+DISABLE_PROMPT_CACHING=1 claude \
+  -p \
+  --model "$MODEL" \
+  --system-prompt "$SYSTEM_PROMPT" \
+  $MCP_FLAGS \
+  --allowedTools "$ALLOWED_TOOLS" \
+  --dangerously-skip-permissions \
+  --output-format json \
+  --json-schema "$OUTPUT_SCHEMA" \
+  ${BUDGET_FLAG:+"${BUDGET_FLAG[@]}"} \
+  "$TASK_CONTENT" \
+  > "$SCRATCH_FILE" \
+  2> "$LOG_FILE"
+
+echo "Run completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ---------------------------------------------------------------------------
+# Extract report and telemetry
+# ---------------------------------------------------------------------------
+python3 - "$SCRATCH_FILE" "$OUTPUT_FILE" "$TELEMETRY_FILE" << 'PYEOF'
+import json, sys
+
+scratch, out_path, tel_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(scratch) as f:
+    content = f.read().strip()
+
+if not content:
+    print("ERROR: output file is empty", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    messages = json.loads(content)
+    if not isinstance(messages, list):
+        messages = [messages]
+except json.JSONDecodeError as e:
+    print(f"ERROR: could not parse output as JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+result = next((m for m in messages if isinstance(m, dict) and m.get("type") == "result"), None)
+if result is None:
+    print("ERROR: no result message found in output", file=sys.stderr)
+    sys.exit(1)
+
+structured = result.get("structured_output")
+if structured is None:
+    print("ERROR: structured_output is null or missing", file=sys.stderr)
+    sys.exit(1)
+
+with open(out_path, "w") as f:
+    json.dump(structured, f, indent=2)
+
+usage = result.get("usage") or {}
+if not isinstance(usage, dict):
+    usage = {}
+telemetry = {
+    "wall_time_ms":          result.get("duration_ms"),
+    "api_time_ms":           result.get("duration_api_ms"),
+    "num_turns":             result.get("num_turns"),
+    "cost_usd":              result.get("total_cost_usd"),
+    "input_tokens":          usage.get("input_tokens"),
+    "output_tokens":         usage.get("output_tokens"),
+    "cache_read_tokens":     usage.get("cache_read_input_tokens"),
+    "cache_creation_tokens": usage.get("cache_creation_input_tokens"),
+}
+with open(tel_path, "w") as f:
+    json.dump(telemetry, f, indent=2)
+
+print(f"Report:    {out_path}")
+print(f"Telemetry: {tel_path}")
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Tool isolation validation
+# ---------------------------------------------------------------------------
+_REPO_SLUG="${REPO_ROOT//\//-}"
+SESSION_DIR="${CLAUDE_SESSION_DIR:-$HOME/.claude/projects/${_REPO_SLUG}}"
+
+_sessions=()
+while IFS= read -r f; do _sessions+=("$f"); done < <(find "$SESSION_DIR" -name "*.jsonl" -newer /tmp/.v17-run-marker 2>/dev/null || true)
+if [[ ${#_sessions[@]} -gt 0 ]]; then
+  LATEST_SESSION=$(ls -t "${_sessions[@]}" 2>/dev/null | head -1)
+  SESSION_COPY="$RUNS_DIR/${RUN_ID}-session.jsonl"
+  cp "$LATEST_SESSION" "$SESSION_COPY"
+  echo "Session JSONL: $SESSION_COPY"
+
+  python3 - "$SESSION_COPY" << 'PYEOF'
+import json, sys
+
+session_file = sys.argv[1]
+
+MCP_TOOLS = {
+    "mcp__aptu-coder__analyze_directory",
+    "mcp__aptu-coder__analyze_file",
+    "mcp__aptu-coder__analyze_symbol",
+    "mcp__aptu-coder__analyze_module",
+    "mcp__aptu-coder__exec_command",
+}
+NATIVE_TOOLS = {"Bash", "Glob", "Grep", "Read", "Write", "ToolSearch"}
+
+tools_used = set()
+with open(session_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("type") == "assistant":
+            for block in entry.get("message", {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tools_used.add(block["name"])
+
+print(f"Tools used: {sorted(tools_used)}")
+
+forbidden = tools_used & NATIVE_TOOLS
+if forbidden:
+    print(f"ISOLATION FAIL: native tools used in MCP condition: {forbidden}", file=sys.stderr)
+    sys.exit(1)
+print(f"MCP tools used: {sorted(tools_used & MCP_TOOLS)}")
+print("ISOLATION PASS")
+PYEOF
+else
+  echo "WARNING: could not find session JSONL for isolation validation" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Run complete ==="
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "Report:    $OUTPUT_FILE"
+  python3 -c "
+import json
+d = json.load(open('$OUTPUT_FILE'))
+ep  = len(d.get('aerodyn_entry_points', []))
+cal = len(d.get('nwtc_callees', []))
+typ = len(d.get('nwtc_types_used', []))
+imp = len(d.get('integration_map', []))
+tc  = d.get('tool_calls_total', '?')
+print(f'  entry_points={ep}  nwtc_callees={cal}  types={typ}  integration_map={imp}  tool_calls={tc}')
+"
+fi
+if [[ -f "$TELEMETRY_FILE" ]]; then
+  echo "Telemetry: $TELEMETRY_FILE"
+  python3 -c "
+import json
+t = json.load(open('$TELEMETRY_FILE'))
+print(f'  turns={t.get(\"num_turns\",\"?\")}  cost_usd={t.get(\"cost_usd\",\"?\")}  input_tokens={t.get(\"input_tokens\",\"?\")}')
+"
+fi
+if [[ -s "$LOG_FILE" ]]; then
+  echo "Log:       $LOG_FILE"
+fi


### PR DESCRIPTION
## Summary

v17 fixes the tool-isolation regression introduced in v16 and updates the Haiku model pin, making the benchmark methodology valid again for measuring MCP advantage over native tools.

## Root cause (v16)

v16 switched from explicit CLI flags to agent frontmatter (`tools:`) for tool allowlist enforcement. The frontmatter field is ignored when `--dangerously-skip-permissions` is active -- the permission layer is bypassed entirely, taking the allowlist filter with it.

Session JSONL analysis of all 6 v16 runs confirms the failure: every run made 14-25 native tool calls (Bash, Grep, Read) and exactly 1 MCP call (`analyze_module`). Zero `analyze_directory`, `analyze_file`, or `analyze_symbol` calls appear in any v16 session. The conditions were identical in behavior; v16 results are invalid as MCP measurements.

## Changes

**`scripts/bench-v17-run.sh`** restores the v13 enforcement pattern:
- `--model`, `--system-prompt`, and `--allowedTools` are explicit CLI flags (not agent frontmatter)
- `ALLOWED_TOOLS` is built at condition-dispatch time and passed verbatim to `--allowedTools`
- `--agent` invocation is dropped entirely
- Haiku model pinned to `claude-haiku-4-5-20251001` (explicit version; v16 used the unversioned alias)

**`docs/benchmarks/v17/prompts/condition-{a,c}-mcp-*.md`** condition system prompts without frontmatter; frontmatter is no longer the enforcement mechanism.

**`docs/benchmarks/v17/methodology.md`** documents the v16 post-mortem, the fix, and the rationale. v16 results are explicitly excluded from all comparisons.

**`docs/benchmarks/v17/{run-order.txt,scores-template.json,mcp-aptu-coder-full.json}`** runner support files. Task prompt copied unchanged from v13.

## Test plan

- [ ] `bash scripts/bench-v17-run.sh A A-pilot` produces ISOLATION PASS in session JSONL validator (no Bash/Grep/Read in tools_used)
- [ ] `bash scripts/bench-v17-run.sh C C-pilot` produces ISOLATION PASS
- [ ] Report and telemetry files written to `docs/benchmarks/v17/results/runs/`
- [ ] Scored runs proceed only after both pilot isolation checks pass
