### PR TITLE
feat(metrics): add file_ext to MetricEvent and emit on error paths

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1694,6 +1694,32 @@ impl CodeAnalyzer {
             Err(e) => {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                let error_type = match e.code {
+                    rmcp::model::ErrorCode::INVALID_PARAMS => Some("invalid_params".to_string()),
+                    rmcp::model::ErrorCode::INTERNAL_ERROR => Some("internal_error".to_string()),
+                    _ => None,
+                };
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "analyze_file",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type,
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                    cache_write_failure: None,
+                    cache_tier: None,
+                    exit_code: None,
+                    timed_out: false,
+                    output_truncated: None,
+                    file_ext: crate::metrics::path_file_ext(&param_path),
+                    ..Default::default()
+                });
                 return Ok(err_to_tool_result(e));
             }
         };
@@ -1863,6 +1889,7 @@ impl CodeAnalyzer {
             exit_code: None,
             timed_out: false,
             output_truncated: None,
+            file_ext: crate::metrics::path_file_ext(&param_path),
             ..Default::default()
         });
         Ok(result)
@@ -2430,21 +2457,49 @@ impl CodeAnalyzer {
         // Route through handle_file_details_mode to inherit L1+L2 caching
         let mut analyze_file_params: AnalyzeFileParams = Default::default();
         analyze_file_params.path = params.path.clone();
-        let (arc_output, module_tier) =
-            match self.handle_file_details_mode(&analyze_file_params).await {
-                Ok((output, tier)) => (output, tier),
-                Err(e) => {
-                    let error_data = match e.code {
-                        rmcp::model::ErrorCode::INVALID_PARAMS => e,
-                        _ => ErrorData::new(
-                            rmcp::model::ErrorCode::INTERNAL_ERROR,
-                            format!("Failed to analyze module: {}", e.message),
-                            Some(error_meta("internal", false, "report this as a bug")),
-                        ),
-                    };
-                    return Ok(err_to_tool_result(error_data));
-                }
-            };
+        let (arc_output, module_tier) = match self
+            .handle_file_details_mode(&analyze_file_params)
+            .await
+        {
+            Ok((output, tier)) => (output, tier),
+            Err(e) => {
+                let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+                let error_type = match e.code {
+                    rmcp::model::ErrorCode::INVALID_PARAMS => Some("invalid_params".to_string()),
+                    rmcp::model::ErrorCode::INTERNAL_ERROR => Some("internal_error".to_string()),
+                    _ => None,
+                };
+                self.metrics_tx.send(crate::metrics::MetricEvent {
+                    ts: crate::metrics::unix_ms(),
+                    tool: "analyze_module",
+                    duration_ms: dur,
+                    output_chars: 0,
+                    param_path_depth: crate::metrics::path_component_count(&param_path),
+                    max_depth: None,
+                    result: "error",
+                    error_type,
+                    session_id: sid.clone(),
+                    seq: Some(seq),
+                    cache_hit: None,
+                    cache_write_failure: None,
+                    cache_tier: None,
+                    exit_code: None,
+                    timed_out: false,
+                    output_truncated: None,
+                    file_ext: crate::metrics::path_file_ext(&param_path),
+                    ..Default::default()
+                });
+                let error_data = match e.code {
+                    rmcp::model::ErrorCode::INVALID_PARAMS => e,
+                    _ => ErrorData::new(
+                        rmcp::model::ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to analyze module: {}", e.message),
+                        Some(error_meta("internal", false, "report this as a bug")),
+                    ),
+                };
+                return Ok(err_to_tool_result(error_data));
+            }
+        };
 
         // Reconstruct ModuleInfo from FileAnalysisOutput
         let file_path = std::path::Path::new(&params.path);
@@ -2528,6 +2583,7 @@ impl CodeAnalyzer {
             exit_code: None,
             timed_out: false,
             output_truncated: None,
+            file_ext: crate::metrics::path_file_ext(&param_path),
             ..Default::default()
         });
         Ok(result)
@@ -3350,6 +3406,7 @@ impl CodeAnalyzer {
             timed_out,
             output_truncated: Some(output_truncated),
             chars_threshold_breach: text.len() > 30_000,
+            file_ext: None,
         });
         Ok(result)
     }
@@ -5560,6 +5617,7 @@ mod tests {
             timed_out: false,
             output_truncated: None,
             chars_threshold_breach: output_chars > 30_000,
+            file_ext: None,
         };
         assert!(
             event.chars_threshold_breach,
@@ -5589,6 +5647,7 @@ mod tests {
             timed_out: false,
             output_truncated: None,
             chars_threshold_breach: output_chars > 30_000,
+            file_ext: None,
         };
         assert!(
             !event.chars_threshold_breach,

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -7,6 +7,7 @@
 //! under the XDG data directory (`~/.local/share/aptu-coder/metrics-YYYY-MM-DD.jsonl`).
 //! Files older than 30 days are deleted on startup.
 
+use aptu_coder_core::lang::language_for_extension;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -49,6 +50,11 @@ pub struct MetricEvent {
     /// the per-stream byte-cap threshold.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub chars_threshold_breach: bool,
+    /// File extension of the analyzed path, lowercased. `Some("rs")` for known extensions,
+    /// `Some("other")` for unrecognized extensions, `None` when the path has no extension.
+    /// Only populated for `analyze_file` and `analyze_module`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_ext: Option<&'static str>,
 }
 
 /// Sender half of the metrics channel; cloned and passed to tools for event emission.
@@ -273,6 +279,29 @@ pub fn unix_ms() -> u64 {
 #[must_use]
 pub fn path_component_count(path: &str) -> usize {
     Path::new(path).components().count()
+}
+
+/// Returns the lowercased file extension of `path` as a `&'static str`.
+///
+/// - Returns `Some(ext)` for extensions recognized by [`language_for_extension`] (e.g. `"rs"`).
+/// - Returns `Some("other")` for paths that have an extension but it is not in the known set.
+/// - Returns `None` for paths with no extension or an empty extension.
+#[must_use]
+pub fn path_file_ext(path: &str) -> Option<&'static str> {
+    let ext_os = Path::new(path).extension()?;
+    let ext_str = ext_os.to_str()?;
+    if ext_str.is_empty() {
+        return None;
+    }
+    // language_for_extension does case-insensitive lookup; if found, return the
+    // canonical (lowercased) extension key from EXTENSION_MAP via supported_extensions().
+    if language_for_extension(ext_str).is_some() {
+        aptu_coder_core::lang::supported_extensions()
+            .into_iter()
+            .find(|e| e.eq_ignore_ascii_case(ext_str))
+    } else {
+        Some("other")
+    }
 }
 
 fn xdg_metrics_dir() -> PathBuf {
@@ -524,6 +553,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         };
         tx.send(make_event()).unwrap();
         tx.send(make_event()).unwrap();
@@ -580,6 +610,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("analyze_directory"));
@@ -607,6 +638,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""result":"error""#));
@@ -635,10 +667,41 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         };
         let serialized = serde_json::to_string(&event).unwrap();
         let json_str = r#"{"ts":1700000000000,"tool":"analyze_file","duration_ms":100,"output_chars":500,"param_path_depth":2,"max_depth":3,"result":"ok","error_type":null,"session_id":"1742468880123-42","seq":5}"#;
         assert_eq!(serialized, json_str);
+    }
+
+    #[test]
+    fn test_path_file_ext_known() {
+        // Arrange / Act / Assert: known extension returns the lowercased extension key
+        assert_eq!(path_file_ext("src/main.rs"), Some("rs"));
+    }
+
+    #[test]
+    fn test_path_file_ext_unknown() {
+        // Arrange / Act / Assert: unrecognized extension returns Some("other")
+        assert_eq!(path_file_ext("file.xyz"), Some("other"));
+    }
+
+    #[test]
+    fn test_path_file_ext_no_ext() {
+        // Arrange / Act / Assert: path with no extension returns None
+        assert_eq!(path_file_ext("Makefile"), None);
+    }
+
+    #[test]
+    fn test_path_file_ext_case_insensitive() {
+        // Arrange / Act / Assert: uppercase extension is normalized to lowercase key
+        assert_eq!(path_file_ext("src/main.RS"), Some("rs"));
+    }
+
+    #[test]
+    fn test_path_file_ext_multi_dot() {
+        // Arrange / Act / Assert: multi-dot filename uses the last extension
+        assert_eq!(path_file_ext("file.test.rs"), Some("rs"));
     }
 
     #[tokio::test]
@@ -676,6 +739,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         })
         .unwrap();
         tx.send(MetricEvent {
@@ -696,6 +760,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         })
         .unwrap();
         drop(tx);
@@ -769,6 +834,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         })
         .unwrap();
         drop(tx);
@@ -829,6 +895,7 @@ mod tests {
             cache_tier: None,
             output_truncated: None,
             chars_threshold_breach: false,
+            file_ext: None,
         })
         .unwrap();
         drop(tx);

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -31,6 +31,7 @@ Each line in the JSONL file is one JSON object:
 | `duration_ms` | `u64` | Wall-clock time from handler entry to return |
 | `output_chars` | `usize` | Byte length (`str::len()`) of the final text returned; `0` on error paths |
 | `param_path_depth` | `usize` | `Path::components().count()` on `params.path` |
+| `file_ext` | `string \| null` | Lowercased file extension of `params.path`: known extension key (e.g. `"rs"`), `"other"` for unrecognized extensions, `null` when the path has no extension. Only populated for `analyze_file` and `analyze_module`. |
 | `max_depth` | `u32 \| null` | The `max_depth` param if present; `null` for `analyze_file` and `analyze_module` |
 | `result` | `string` | `"ok"` on success, `"error"` on early-exit error paths |
 | `error_type` | `string \| null` | On error: `invalid_params`, `parse`, or `unknown`; `null` on success |


### PR DESCRIPTION
## Summary

Closes #973.

Two gaps in the JSONL metrics channel:

1. `analyze_file` and `analyze_module` error paths returned early without emitting a `MetricEvent`. Errors from those tools were invisible in JSONL data (and therefore in `scripts/mcp-metrics.py` reliability queries).
2. `MetricEvent` had no field for the file extension of the path parameter, blocking per-extension error breakdown queries.

## Changes

**`crates/aptu-coder/src/metrics.rs`**

- Added `file_ext: Option<&'static str>` field to `MetricEvent` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. Backward-compatible: existing JSONL files parse without the field.
- Added `pub fn path_file_ext(path: &str) -> Option<&'static str>` using `std::path::Path::extension()` + `language_for_extension` lookup. Zero-allocation: returns a `&'static str` from the supported-extension registry, `Some("other")` for unrecognised extensions, `None` for paths with no extension.
- Added 5 unit tests covering known extension, unknown extension, no extension, case-insensitive lookup, and multi-dot filenames.

**`crates/aptu-coder/src/lib.rs`**

- `analyze_file` error branch: added `metrics_tx.send` with `result: "error"`, `error_type` from `ErrorCode`, and `file_ext` before `err_to_tool_result`.
- `analyze_file` success path: populated `file_ext: crate::metrics::path_file_ext(&param_path)`.
- `analyze_module` `handle_file_details_mode` error branch: same pattern.
- `analyze_module` success path: populated `file_ext`.
- `analyze_directory` and `analyze_symbol` not modified (file extension is not meaningful for directories or symbols).

**`docs/OBSERVABILITY.md`**

- Added `file_ext` row to the JSONL schema table.

## Test plan

- [x] `cargo test` passes (541 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Unit tests for `path_file_ext`: known, unknown, no extension, case-insensitive, multi-dot
- [x] `handle_file_details_mode` signature unchanged
