### PR TITLE
chore(toolchain): bump Rust to 1.96.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 version = "0.15.1"
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]
 license = "Apache-2.0"
 repository = "https://github.com/clouatre-labs/aptu-coder"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Bump the pinned Rust toolchain channel and workspace `rust-version` from `1.95.0` to `1.96.0`. Rust 1.96.0 was released 2026-05-28 and includes security fixes (CVE-2026-5222 and CVE-2026-5223).

## Changes

- `rust-toolchain.toml`: `channel = "1.96.0"`
- `Cargo.toml`: `rust-version = "1.96.0"`

## Compatibility audit

Two 1.96 compatibility items from the issue were audited before merging:

- `uninhabited_static` lint is now deny-by-default: no `static` definitions with uninhabited types exist in the codebase (all statics use `OnceLock<T>`, `AtomicU64`, `Mutex`, `LazyLock`, `RefCell`).
- `#[export_name]` / `#[link_name]` first-attribute-wins change: no FFI boundaries or uses of these attributes exist in the codebase.
- All unsafe blocks carry `SAFETY:` comments, enforced by `clippy::undocumented_unsafe_blocks = "deny"`.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (240 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check advisories licenses` clean

Closes #981
