### PR TITLE
test: replace assert!(matches!()) with assert_matches! (stable 1.96)

### DIFF
--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -134,7 +134,7 @@ mod tests {
     fn edit_overwrite_content_directory_guard() {
         let dir = tempfile::tempdir().unwrap();
         let err = edit_overwrite_content(dir.path(), "content").unwrap_err();
-        assert!(matches!(err, EditError::NotAFile(_)));
+        std::assert_matches!(err, EditError::NotAFile(_));
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod tests {
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo bar baz").unwrap();
         let err = edit_replace_block(&path, "missing", "x").unwrap_err();
-        assert!(matches!(err, EditError::NotFound { .. }));
+        std::assert_matches!(err, EditError::NotFound { .. });
     }
 
     #[test]
@@ -163,13 +163,13 @@ mod tests {
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo foo baz").unwrap();
         let err = edit_replace_block(&path, "foo", "x").unwrap_err();
-        assert!(matches!(err, EditError::Ambiguous { count: 2, .. }));
+        std::assert_matches!(err, EditError::Ambiguous { count: 2, .. });
     }
 
     #[test]
     fn edit_replace_block_directory_guard() {
         let dir = tempfile::tempdir().unwrap();
         let err = edit_replace_block(dir.path(), "old", "new").unwrap_err();
-        assert!(matches!(err, EditError::NotAFile(_)));
+        std::assert_matches!(err, EditError::NotAFile(_));
     }
 }

--- a/crates/aptu-coder-core/src/graph.rs
+++ b/crates/aptu-coder-core/src/graph.rs
@@ -985,7 +985,7 @@ mod tests {
     fn test_resolve_symbol_exact_no_match() {
         let syms = known(&["ParseConfig"]);
         let err = resolve_symbol(syms.iter(), "parse_config", &SymbolMatchMode::Exact).unwrap_err();
-        assert!(matches!(err, GraphError::SymbolNotFound { .. }));
+        std::assert_matches!(err, GraphError::SymbolNotFound { .. });
     }
 
     #[test]
@@ -1000,7 +1000,7 @@ mod tests {
         let syms = known(&["unrelated"]);
         let err =
             resolve_symbol(syms.iter(), "parseconfig", &SymbolMatchMode::Insensitive).unwrap_err();
-        assert!(matches!(err, GraphError::SymbolNotFound { .. }));
+        std::assert_matches!(err, GraphError::SymbolNotFound { .. });
     }
 
     #[test]
@@ -1014,7 +1014,7 @@ mod tests {
     fn test_resolve_symbol_prefix_multiple_candidates() {
         let syms = known(&["parse_config", "parse_args", "build"]);
         let err = resolve_symbol(syms.iter(), "parse", &SymbolMatchMode::Prefix).unwrap_err();
-        assert!(matches!(&err, GraphError::MultipleCandidates { .. }));
+        std::assert_matches!(&err, GraphError::MultipleCandidates { .. });
         if let GraphError::MultipleCandidates { candidates, .. } = err {
             assert_eq!(candidates.len(), 2);
         }
@@ -1031,7 +1031,7 @@ mod tests {
     fn test_resolve_symbol_contains_no_match() {
         let syms = known(&["parse_config", "build_artifact"]);
         let err = resolve_symbol(syms.iter(), "deploy", &SymbolMatchMode::Contains).unwrap_err();
-        assert!(matches!(err, GraphError::SymbolNotFound { .. }));
+        std::assert_matches!(err, GraphError::SymbolNotFound { .. });
     }
 
     #[test]
@@ -1123,7 +1123,7 @@ mod tests {
             .unwrap_err();
 
         // Assert: multiple candidates found
-        assert!(matches!(&err, GraphError::MultipleCandidates { .. }));
+        std::assert_matches!(&err, GraphError::MultipleCandidates { .. });
         if let GraphError::MultipleCandidates { candidates, .. } = err {
             assert_eq!(candidates.len(), 2);
         }
@@ -1143,7 +1143,7 @@ mod tests {
             .unwrap_err();
 
         // Assert: MultipleCandidates returned for case collision
-        assert!(matches!(&err, GraphError::MultipleCandidates { .. }));
+        std::assert_matches!(&err, GraphError::MultipleCandidates { .. });
         if let GraphError::MultipleCandidates { candidates, .. } = err {
             assert_eq!(candidates.len(), 2);
         }
@@ -1166,7 +1166,7 @@ mod tests {
             .unwrap_err();
 
         // Assert: both matching symbols returned as MultipleCandidates
-        assert!(matches!(&err, GraphError::MultipleCandidates { .. }));
+        std::assert_matches!(&err, GraphError::MultipleCandidates { .. });
         if let GraphError::MultipleCandidates { candidates, .. } = err {
             let mut sorted = candidates.clone();
             sorted.sort();

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -1296,7 +1296,7 @@ fn test_cancellation_during_directory_walk() {
     let result = analyze_directory_with_progress(root, entries, counter, ct);
 
     // Assert: Should return Cancelled error
-    assert!(matches!(result, Err(AnalyzeError::Cancelled)));
+    std::assert_matches!(result, Err(AnalyzeError::Cancelled));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replaces all 12 `assert!(matches!(...))` calls with `std::assert_matches!(...)` using the macro stabilized in Rust 1.96.0. The improvement is diagnostic: `assert_matches!` prints the actual value on failure, whereas `assert!(matches!())` only prints `assertion failed` with no context.

## Changes

- `crates/aptu-coder-core/src/edit.rs` -- 4 instances in `#[cfg(test)]` mod
- `crates/aptu-coder-core/src/graph.rs` -- 7 instances in `#[cfg(test)]` mod
- `crates/aptu-coder-core/tests/integration_tests.rs` -- 1 instance

3 files changed, 12 insertions(+), 12 deletions(-). Test-only scope; no production code touched.

**Implementation note:** Used the fully-qualified path `std::assert_matches!(...)` rather than a `use` import. On Rust 1.96.0 stable, `std::assert_matches` is not importable as a module path (E0432), but the macro is callable via its qualified path, which compiles correctly and provides the same diagnostic benefit.

## Test plan

- [x] 540 tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Zero `assert!(matches!` occurrences remain (`rg "assert!(matches!" --type rust` returns nothing)

Closes #983
