### PR TITLE
chore(release): bump version to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Maintenance release bumping the Rust toolchain to 1.96.0 (which includes security fixes for CVE-2026-5222 and CVE-2026-5223), modernizing code patterns to Edition 2024 let chains, improving test diagnostics with `assert_matches!`, and pulling in 26 dependency updates including a major bump of the `toml` crate from 0.9 to 1.0.

## Changes

- `Cargo.toml`: version 0.15.1 → 0.15.2
- `Cargo.lock`: updated

## Test plan

- [ ] Tests pass (`cargo test`)
- [ ] Linter clean (`cargo clippy -- -D warnings`)
- [ ] Formatter clean (`cargo fmt --check`)

Closes #981
Closes #982
Closes #983
