### PR TITLE
fix(edit): remove artificial CWD restriction on working_dir for edit_overwrite and edit_replace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `import_lookup=true` on `analyze_symbol` requires a non-empty `symbol` (the module path to search for); returns INVALID_PARAMS if symbol is empty. Mutually exclusive with normal call-graph lookup.
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
-- `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution; must be within the server CWD.
+- `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution (default: server CWD). The resolved target path must be within working_dir.
 - `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (3 tools); `analyze` disables edit_* tools (5 tools); absent/unknown enables all 7 tools. By default, all 7 tools are available.
 
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -347,31 +347,15 @@ fn validate_path_in_dir(
         ));
     }
 
-    // Verify working_dir is within the server CWD (same bounds check as validate_path)
-    let allowed_root = std::fs::canonicalize(std::env::current_dir().map_err(|_| {
-        ErrorData::new(
-            rmcp::model::ErrorCode::INVALID_PARAMS,
-            "path is outside the allowed root".to_string(),
-            Some(error_meta(
-                "validation",
-                false,
-                "ensure the working directory is accessible",
-            )),
-        )
-    })?)
-    .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
-
-    if !canonical_working_dir.starts_with(&allowed_root) {
-        return Err(ErrorData::new(
-            rmcp::model::ErrorCode::INVALID_PARAMS,
-            "working_dir is outside the allowed root".to_string(),
-            Some(error_meta(
-                "validation",
-                false,
-                "provide a working directory within the current working directory",
-            )),
-        ));
-    }
+    // working_dir is intentionally not restricted to the server CWD here.
+    // The security boundary is the inner PathBuf::starts_with check below,
+    // which ensures the resolved path cannot escape working_dir regardless
+    // of where working_dir itself lives on disk.  Restricting working_dir to
+    // server CWD was the original design but it prevented legitimate
+    // cross-repository edits (e.g. orchestrators writing to a sibling repo)
+    // while exec_command already allows arbitrary paths via `cd`.  The
+    // operator sets the scope at server launch; per-call working_dir is a
+    // convenience override within that operator-controlled process.
 
     // Now resolve the target path relative to working_dir
     let canonical_path = if require_exists {
@@ -384,7 +368,11 @@ fn validate_path_in_dir(
             )
         })?
     } else {
-        // For non-existent files, walk up the path until we find an existing ancestor
+        // For non-existent files, walk up the path until we find an existing ancestor.
+        // `..` components are safe here: file_name() returns None for `..`, so the
+        // loop hits the else branch and resets ancestor to PathBuf::new(), anchoring
+        // the resolved path inside canonical_working_dir.  The starts_with check
+        // below catches any residual traversal regardless.
         let p = std::path::Path::new(path);
         let mut ancestor = p.to_path_buf();
         let mut suffix = std::path::PathBuf::new();
@@ -400,7 +388,8 @@ fn validate_path_in_dir(
                 suffix = std::path::PathBuf::from(file_name).join(&suffix);
                 ancestor = parent.to_path_buf();
             } else {
-                // No existing ancestor found — use working_dir as anchor
+                // No existing ancestor found (or path contains `..`) --
+                // use working_dir as anchor; starts_with below enforces the boundary.
                 ancestor = std::path::PathBuf::new();
                 break;
             }
@@ -4645,6 +4634,31 @@ mod tests {
             "Resolved path should be within working_dir: {:?} should start with {:?}",
             resolved,
             temp_path
+        );
+    }
+
+    #[test]
+    fn test_validate_path_in_dir_accepts_outside_cwd() {
+        // Arrange: use temp_dir() which is guaranteed to be outside CWD
+        let temp_dir = std::env::temp_dir();
+        let canonical_temp_dir =
+            std::fs::canonicalize(&temp_dir).expect("should canonicalize temp_dir");
+
+        // Act: call validate_path_in_dir with a relative filename
+        let result = validate_path_in_dir("probe.txt", false, &temp_dir);
+
+        // Assert: should accept working_dir outside CWD
+        assert!(
+            result.is_ok(),
+            "validate_path_in_dir should accept working_dir outside CWD: {:?}",
+            result.err()
+        );
+        let resolved = result.unwrap();
+        assert!(
+            resolved.starts_with(&canonical_temp_dir),
+            "Resolved path should be within working_dir: {:?} should start with {:?}",
+            resolved,
+            canonical_temp_dir
         );
     }
 


### PR DESCRIPTION
## Summary

Removes the outer CWD containment check from `validate_path_in_dir` so that `working_dir` on `edit_overwrite` and `edit_replace` can be any absolute path on disk, not just a subdirectory of the server CWD.

## Problem

When aptu-coder was launched from repo A and an orchestrator supplied `working_dir` pointing to repo B (e.g., a worktree or a sibling repository), both edit tools rejected the call with `invalid_params: working_dir is outside the allowed root`. The only workaround was to fall back to `exec_command`, which already allows arbitrary paths via `cd`. This asymmetry forced orchestrators into an inferior code path.

## Root cause

`validate_path_in_dir` enforced two nested containment checks:

1. **Outer (removed):** `working_dir` must be inside server CWD
2. **Inner (kept):** resolved `path` must be inside `working_dir` via `PathBuf::starts_with`

The outer check was the blocker. The inner check is the real CVE-2025-53110 protection and is untouched.

## Changes

- `crates/aptu-coder/src/lib.rs`: delete the outer `allowed_root` block from `validate_path_in_dir` (~27 lines)
- `crates/aptu-coder/src/lib.rs`: update `edit_overwrite` and `edit_replace` description strings to remove the CWD restriction implication
- `crates/aptu-coder/src/lib.rs`: add `test_validate_path_in_dir_accepts_outside_cwd` using `std::env::temp_dir()` as working_dir
- `AGENTS.md`: correct the `working_dir` documentation bullet

## Security

- `PathBuf::starts_with` inner check (component-level, not string-prefix) is preserved -- CVE-2025-53110 protection remains intact
- `validate_path` (bare-path case, no `working_dir`) is unchanged and retains its own CWD boundary
- `test_validate_path_in_dir_rejects_sibling_prefix` and `test_edit_overwrite_working_dir_traversal` both still pass

Closes #995
