### PR TITLE
chore(release): bump version to 0.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.3"
+version = "0.15.4"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump version to 0.15.4.

## Changes since v0.15.3

- feat(metrics): add `total_output_chars` to `APTU_CODER_METRICS_EXPORT_FILE` JSON summary (#1001)
- refactor(lib): remove `profile_meta` staging Arc, replace with `OnceLock<String>` (#999)

Closes #1001
