### PR TITLE
ci(pr-review): replace gemini-3.1-flash-lite-preview with gemini-3.1-flash-lite

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -32,7 +32,7 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
-          model: gemini-3.1-flash-lite-preview
+          model: gemini-3.1-flash-lite
           skip-labeled: 'false'
           fallback-provider: 'openrouter'
           fallback-model: 'inception/mercury-2'


### PR DESCRIPTION
Replace `gemini-3.1-flash-lite-preview` with the stable `gemini-3.1-flash-lite` model in the PR review workflow. The preview variant is being retired on 2026-07-09.

No behavior change; `gemini-3.1-flash-lite` is the GA equivalent of the preview.
