### PR TITLE
feat(http): bearer token auth middleware for HTTP MCP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -49,3 +49,4 @@ tracing-opentelemetry = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }
 serial_test = "=3.5.0"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -5,6 +5,10 @@ use aptu_coder::{
     logging::McpLoggingLayer,
     metrics::{MetricEvent, MetricsSender, MetricsWriter},
 };
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
 use rmcp::serve_server;
 use rmcp::transport::stdio;
 use rmcp::transport::streamable_http_server::session::never::NeverSessionManager;
@@ -19,7 +23,31 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 mod otel;
 
+/// Authentication middleware that validates Bearer tokens using constant-time comparison.
+/// The token comparison uses blake3::Hash PartialEq which calls constant_time_eq_32 internally,
+/// preventing timing side-channels.
+async fn auth_middleware(
+    State(expected): State<String>,
+    request: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    let incoming = request
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    if blake3::hash(expected.as_bytes()) == blake3::hash(incoming.as_bytes()) {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+    }
+}
+
 async fn run_http(analyzer: CodeAnalyzer, port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let bearer_token = std::env::var("APTU_CODER_BEARER_TOKEN").ok();
+
     let ct = CancellationToken::new();
     let ct_signal = ct.clone();
     tokio::spawn(async move {
@@ -54,7 +82,20 @@ async fn run_http(analyzer: CodeAnalyzer, port: u16) -> Result<(), Box<dyn std::
             config,
         );
 
-    let router = axum::Router::new().nest_service("/mcp", service);
+    let base_router = axum::Router::new().nest_service("/mcp", service);
+    let router = if let Some(token) = bearer_token {
+        if token.len() < 32 {
+            tracing::warn!(
+                token_len = token.len(),
+                "APTU_CODER_BEARER_TOKEN is shorter than 32 characters; \
+                 use a random token of at least 32 characters for production deployments"
+            );
+        }
+        base_router.layer(axum::middleware::from_fn_with_state(token, auth_middleware))
+    } else {
+        base_router
+    };
+
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}")).await?;
     eprintln!("Listening on http://127.0.0.1:{port}/mcp");
 
@@ -194,4 +235,69 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn make_test_router(token: &str) -> axum::Router {
+        axum::Router::new()
+            .route("/ping", axum::routing::get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                token.to_owned(),
+                auth_middleware,
+            ))
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_valid_token() {
+        // Arrange
+        let router = make_test_router("secret");
+        let request = Request::builder()
+            .uri("/ping")
+            .header("Authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+
+        // Act
+        let response = router.oneshot(request).await.unwrap();
+
+        // Assert
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_invalid_token() {
+        // Arrange
+        let router = make_test_router("secret");
+        let request = Request::builder()
+            .uri("/ping")
+            .header("Authorization", "Bearer wrong")
+            .body(Body::empty())
+            .unwrap();
+
+        // Act
+        let response = router.oneshot(request).await.unwrap();
+
+        // Assert
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_no_header() {
+        // Arrange
+        let router = make_test_router("secret");
+        let request = Request::builder().uri("/ping").body(Body::empty()).unwrap();
+
+        // Act
+        let response = router.oneshot(request).await.unwrap();
+
+        // Assert
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
 }

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -24,21 +24,25 @@ use tracing_subscriber::util::SubscriberInitExt;
 mod otel;
 
 /// Authentication middleware that validates Bearer tokens using constant-time comparison.
-/// The token comparison uses blake3::Hash PartialEq which calls constant_time_eq_32 internally,
-/// preventing timing side-channels.
+///
+/// `expected` is the blake3 hash of the token computed once at startup. Per-request, only the
+/// incoming token is hashed and compared via `blake3::Hash`'s `PartialEq`, which uses
+/// `constant_time_eq_32` internally, preventing timing side-channels.
 async fn auth_middleware(
-    State(expected): State<String>,
+    State(expected): State<blake3::Hash>,
     request: axum::extract::Request,
     next: Next,
 ) -> axum::response::Response {
-    let incoming = request
+    let Some(incoming) = request
         .headers()
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .unwrap_or("");
+    else {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    };
 
-    if blake3::hash(expected.as_bytes()) == blake3::hash(incoming.as_bytes()) {
+    if expected == blake3::hash(incoming.as_bytes()) {
         next.run(request).await
     } else {
         (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
@@ -91,13 +95,17 @@ async fn run_http(analyzer: CodeAnalyzer, port: u16) -> Result<(), Box<dyn std::
                  use a random token of at least 32 characters for production deployments"
             );
         }
-        base_router.layer(axum::middleware::from_fn_with_state(token, auth_middleware))
+        let expected_hash = blake3::hash(token.as_bytes());
+        base_router.layer(axum::middleware::from_fn_with_state(
+            expected_hash,
+            auth_middleware,
+        ))
     } else {
         base_router
     };
 
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}")).await?;
-    eprintln!("Listening on http://127.0.0.1:{port}/mcp");
+    tracing::info!(port, "Listening on http://127.0.0.1:{port}/mcp");
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move { ct.cancelled().await })
@@ -249,7 +257,7 @@ mod tests {
         axum::Router::new()
             .route("/ping", axum::routing::get(|| async { "ok" }))
             .layer(axum::middleware::from_fn_with_state(
-                token.to_owned(),
+                blake3::hash(token.as_bytes()),
                 auth_middleware,
             ))
     }


### PR DESCRIPTION
## What

Add optional static bearer token authentication to the HTTP MCP transport (`--port` mode).

## Why

Required for any publicly-exposed deployment of aptu-coder as an HTTP MCP server. Without
authentication, any client with network access to the port can invoke all tools.

## How

- Read `APTU_CODER_BEARER_TOKEN` from env at startup in `run_http()`
- If set: apply `axum::middleware::from_fn_with_state` before the rmcp `StreamableHttpService`
- Every request to `/mcp` must carry `Authorization: Bearer <token>`; returns `401 Unauthorized` on mismatch or missing header
- Token comparison: `blake3::hash(expected) == blake3::hash(incoming)` -- `blake3::Hash` `PartialEq` uses `constant_time_eq_32` internally, preventing timing side-channels
- Startup warning emitted when token is shorter than 32 characters
- No layer applied when env var is unset -- local stdio and unauthenticated HTTP use cases unchanged

## Security

- Constant-time comparison via blake3 (already a workspace dep); no new runtime dependencies
- Token never logged, never emitted in metrics or spans
- `tower` declared explicitly in `[dev-dependencies]` for test helpers; already a transitive dep, no new crate in the graph

## Tests

Three unit tests in `main.rs` using `axum` + `tower::ServiceExt::oneshot`:
- `test_auth_middleware_valid_token` -- matching token returns 200
- `test_auth_middleware_invalid_token` -- wrong token returns 401
- `test_auth_middleware_no_header` -- missing `Authorization` header returns 401

## Out of scope

Rayon wasm cfg-gate, `event_rx` doc comment, and wasm-check CI job were considered and
removed as YAGNI. Tracked in a separate issue.

Closes #1008
