### PR TITLE
docs(edit): fix stale doc comment on validate_path_in_dir

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -319,8 +319,8 @@ fn io_error_to_path_error(
 }
 
 /// Validates a path relative to a working directory.
-/// The working_dir itself must be within the server CWD.
-/// The resolved path must also be within the working_dir.
+/// The working_dir may be anywhere on disk; it is not restricted to the server CWD.
+/// The resolved path must be within the working_dir.
 fn validate_path_in_dir(
     path: &str,
     require_exists: bool,


### PR DESCRIPTION
Fix stale doc comment on validate_path_in_dir

PR #996 removed the restriction that `working_dir` must be within the server CWD, but the doc comment on `validate_path_in_dir` was not updated. This leaves the comment contradicting the implementation and the inline explanation at line 350.

This PR updates the two-line doc comment to reflect the current behaviour.