### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "aptu-coder-core",
  "async-trait",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.4"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.15", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.16", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Minor release adding bearer token authentication for the HTTP MCP transport and four new built-in output filter rules for `git show`, `git commit`, `git diff`, and `git add`. No changes to public tool APIs or structured output schemas.

## What's Changed

### Features

- **Bearer token auth for HTTP transport**: When `APTU_CODER_BEARER_TOKEN` is set, the HTTP MCP server (`--port` mode) requires every `/mcp` request to carry `Authorization: Bearer <token>`. Token comparison uses `blake3::hash` with constant-time equality (`constant_time_eq_32`) to prevent timing side-channels. A startup warning is emitted when the token is shorter than the recommended minimum. Without the env var the server behavior is unchanged. (#1007)

- **Four new built-in `exec_command` filter rules**: `build_builtin_filter_rules()` gains entries for `git show`, `git commit`, `git diff`, and `git add`. These join the seven existing rules introduced in v0.15.0 and apply the same success-only, exit-code-gated semantics. (#1014)
  - `git show`: strips patch hunks (`@@` headers and `+`/`-` diff lines); caps at 200 lines
  - `git commit`: strips GPG signing output and gitleaks hook progress lines; caps at 10 lines; `on_empty` returns `ok committed`
  - `git diff`: strips ANSI escape sequences; caps at 100 lines; `on_empty` returns `ok (working tree clean)`
  - `git add`: strips gitleaks hook progress lines; caps at 5 lines; `on_empty` returns `ok staged`

### Documentation

- **README filter table corrected and extended**: Existing rule descriptions for `git pull`, `git fetch`, `git push`, and `cargo build` were updated to match actual implementation (no arg injection on pull; correct strip patterns; `on_empty` values documented). Four new rows added for the rules above. (#1014)
- **`validate_path_in_dir` doc comment**: Fixed a stale doc comment that still described the pre-#996 restriction requiring `working_dir` to be within the server CWD. (#1012)

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.15.4...v0.16.0
