### PR TITLE
fix(exec): apply filter rules to interleaved output in run_exec_impl

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3663,6 +3663,13 @@ async fn run_exec_impl(
             if compiled_rule.pattern.is_match(&command) {
                 let filtered_stdout = apply_filter(compiled_rule, &output.stdout);
                 output.stdout = filtered_stdout;
+                // Also filter interleaved: the response handler prefers interleaved when
+                // non-empty (which it always is for commands that write to both streams),
+                // so filtering only stdout would leave the LLM-visible output unfiltered.
+                // apply_filter is called separately on each field; there is no double-filtering
+                // because stdout and interleaved are independent strings assembled from the
+                // same source lines -- updating one does not affect the other.
+                output.interleaved = apply_filter(compiled_rule, &output.interleaved);
                 output.filter_applied = compiled_rule
                     .rule
                     .description
@@ -5549,6 +5556,73 @@ mod tests {
             filters::apply_filter(&compiled, ""),
             "ok (working tree clean)",
             "on_empty should fire on empty input"
+        );
+    }
+
+    #[test]
+    fn test_filter_applied_to_interleaved_with_both_streams() {
+        // Happy path: apply_filter on an interleaved string that mixes stdout and stderr lines.
+        // Lines matching the strip pattern are removed; stderr-origin lines are preserved.
+        let compiled = filters::CompiledRule {
+            pattern: Regex::new("^git\\s+pull").unwrap(),
+            strip_patterns: vec![Regex::new("^\\s*\\|\\s*\\d+\\s*[+\\-]+").unwrap()],
+            keep_patterns: vec![],
+            rule: types::FilterRule {
+                match_command: "^git\\s+pull".to_string(),
+                description: None,
+                strip_ansi: false,
+                strip_lines_matching: vec!["^\\s*\\|\\s*\\d+\\s*[+\\-]+".to_string()],
+                keep_lines_matching: vec![],
+                max_lines: None,
+                on_empty: None,
+            },
+        };
+
+        // Arrange: interleaved with one stdout-origin strip-matched line and one stderr-origin line
+        let interleaved = " | 42  ++++++++++++\nFrom https://github.com/example/repo\n";
+
+        // Act
+        let result = filters::apply_filter(&compiled, interleaved);
+
+        // Assert: strip-matched line gone; stderr-origin line present
+        assert!(
+            !result.contains("| 42"),
+            "strip-matched line should be absent from filtered interleaved"
+        );
+        assert!(
+            result.contains("From https://github.com/example/repo"),
+            "stderr-origin line should be preserved in filtered interleaved"
+        );
+    }
+
+    #[test]
+    fn test_on_empty_substitution_in_interleaved() {
+        // Edge case: when filter strips all lines in interleaved, on_empty text is returned.
+        let compiled = filters::CompiledRule {
+            pattern: Regex::new("^git\\s+pull").unwrap(),
+            strip_patterns: vec![Regex::new(".*").unwrap()],
+            keep_patterns: vec![],
+            rule: types::FilterRule {
+                match_command: "^git\\s+pull".to_string(),
+                description: None,
+                strip_ansi: false,
+                strip_lines_matching: vec![".*".to_string()],
+                keep_lines_matching: vec![],
+                max_lines: None,
+                on_empty: Some("ok (up-to-date)".to_string()),
+            },
+        };
+
+        // Arrange: interleaved where every line matches the strip pattern
+        let interleaved = "Already up to date.\nFrom https://github.com/example/repo\n";
+
+        // Act
+        let result = filters::apply_filter(&compiled, interleaved);
+
+        // Assert: on_empty substitution text returned
+        assert_eq!(
+            result, "ok (up-to-date)",
+            "on_empty should be returned when filter strips all lines in interleaved"
         );
     }
 


### PR DESCRIPTION
## Problem

All `exec_command` filter rules were silently bypassed for any command that writes to both stdout and stderr -- which includes virtually every `git` command.

In `run_exec_impl`, `apply_filter` updated only `output.stdout`. The response handler at the call site prefers `output.interleaved` when non-empty:

```rust
let output_text = if output.interleaved.is_empty() {
    format!("Stdout:\n{}\n\nStderr:\n{}", output.stdout, output.stderr)
} else {
    format!("Output:\n{}", output.interleaved)
};
```

`output.interleaved` is never empty for commands that write fetch progress to stderr and diff output to stdout (e.g. `git pull`). The LLM therefore always received the unfiltered interleaved stream, rendering every filter rule -- including the `--no-stat` injection added in #1014 -- ineffective.

Root cause confirmed by inspection: `filter_applied` was set correctly, but the content the LLM consumed was sourced from `output.interleaved`, which was never passed through `apply_filter`.

## Fix

In the existing filter application block in `run_exec_impl`, after updating `output.stdout`, apply the same compiled rule to `output.interleaved`:

```rust
output.stdout = filtered_stdout;
// Also filter interleaved: the response handler prefers interleaved when
// non-empty (which it always is for commands that write to both streams),
// so filtering only stdout would leave the LLM-visible output unfiltered.
// apply_filter is called separately on each field; there is no double-filtering
// because stdout and interleaved are independent strings assembled from the
// same source lines -- updating one does not affect the other.
output.interleaved = apply_filter(compiled_rule, &output.interleaved);
```

Single-site change. Reuses the already-matched `compiled_rule`. No signature changes to `apply_filter`, no new struct fields on `ShellOutput`.

## Verification

Smoke-tested against the patched binary: `git pull` on an up-to-date repo returns `filter_applied: "git pull: strip diff-stat noise"` and a clean interleaved string with no diff-stat table lines. The unit tests below cover the stripping path with actual diff-stat content.

## Tests

- `test_filter_applied_to_interleaved_with_both_streams`: strip pattern removes `| 42 +++` lines from interleaved while preserving stderr-origin lines (`From https://...`).
- `test_on_empty_substitution_in_interleaved`: when the filter strips all lines from interleaved, the `on_empty` substitution text is returned rather than an empty string.

Closes #1016
