### PR TITLE
chore: remove unused dependencies and stale lint suppressions (#1019, #1020)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,6 @@ name = "aptu-coder"
 version = "0.16.1"
 dependencies = [
  "aptu-coder-core",
- "async-trait",
  "axum",
  "blake3",
  "nix",
@@ -94,7 +93,6 @@ dependencies = [
  "ignore",
  "lru",
  "rayon",
- "regex",
  "schemars",
  "serde",
  "serde_json",
@@ -103,7 +101,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "toml",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ tracing = "0.1"
 tokio-util = "0.7"
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "transport-streamable-http-server"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "process", "signal"] }
-async-trait = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 schemars = { version = "1", features = ["derive"] }
 tempfile = "=3.27.0"
@@ -51,7 +50,6 @@ opentelemetry-appender-tracing = { version = "0.32", features = ["log"] }
 tracing-opentelemetry = "0.33"
 
 rustls = "0.23"
-url = "2"
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false }
 
 [workspace.lints.clippy]

--- a/crates/aptu-coder-core/Cargo.toml
+++ b/crates/aptu-coder-core/Cargo.toml
@@ -49,8 +49,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio-util = { workspace = true }
 tempfile = { workspace = true }
-regex = { workspace = true }
-toml = { workspace = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-cpp = { workspace = true, optional = true }

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -865,7 +865,7 @@ pub struct EditReplaceOutput {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ExecCommandParams {
     /// Shell command to execute via sh -c (or $SHELL if set).
@@ -896,21 +896,6 @@ impl ExecCommandParams {
             timeout_secs,
             working_dir,
             ..Default::default()
-        }
-    }
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for ExecCommandParams {
-    fn default() -> Self {
-        Self {
-            command: String::new(),
-            timeout_secs: None,
-            working_dir: None,
-            memory_limit_mb: None,
-            cpu_limit_secs: None,
-            stdin: None,
-            cache: None,
         }
     }
 }

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -29,7 +29,6 @@ tokio = { workspace = true }
 axum = { workspace = true }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { workspace = true }
-async-trait = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -504,7 +504,6 @@ pub struct CodeAnalyzer {
     // IMPORTANT: Do not perform long-running I/O while holding the write lock in
     // on_initialized. The write lock blocks all concurrent list_tools/call_tool calls
     // for the duration. Keep the critical section to disable_route() calls only.
-    #[allow(dead_code)]
     pub(crate) tool_router: Arc<RwLock<ToolRouter<Self>>>,
     cache: AnalysisCache,
     disk_cache: std::sync::Arc<cache::DiskCache>,


### PR DESCRIPTION
## Summary

Resolves two audit findings from the June 2026 dependency and code quality audit (docs/AUDIT-2026-06.md).

## Changes

### chore(deps): Remove unused dependencies (closes #1019)

Four vestigial Cargo entries confirmed at zero call sites by both Scout and Guard:

| Finding | Entry | Location | Reason |
|---|---|---|---|
| F1 | `async-trait` | workspace + `aptu-coder` | rmcp 1.x handles async natively; zero `#[async_trait]` usage |
| F2 | `regex` | `aptu-coder-core` | Only used in `aptu-coder/src/filters.rs`; wrong crate |
| F10 | `url = "2"` | workspace | Orphan; neither crate declares it |
| F11 | `toml` | `aptu-coder-core` | Only used in `aptu-coder/src/filters.rs`; wrong crate |

### chore(lint): Remove stale lint suppressions (closes #1020)

Two `#[allow(...)]` attributes that no longer reflect reality:

| Finding | Attribute | Location | Reason |
|---|---|---|---|
| F3 | `#[allow(dead_code)]` | `lib.rs:507` (`tool_router` field) | Field is live: read in `list_tools`, `call_tool`, `on_initialized` |
| F9 | `#[allow(clippy::derivable_impls)]` | `types.rs:902` (`ExecCommandParams`) | Manual `impl Default` is byte-for-byte derivable; replaced with `#[derive(Default)]` |

## Verification

- `cargo build`: clean
- `cargo test`: 540 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo deny check advisories licenses`: clean

Closes #1019
Closes #1020
