### PR TITLE
test: remove redundant empty-file tests; fix MutexGuard held across await (#1021)

### DIFF
--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -469,20 +469,6 @@ class MyClass:
     assert_eq!(output.semantic.classes[0].name, "MyClass");
 }
 
-#[cfg(feature = "lang-python")]
-#[test]
-fn test_python_edge_case_empty_file() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("empty.py");
-
-    fs::write(&file_path, "").unwrap();
-
-    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
-
-    assert_eq!(output.semantic.functions.len(), 0);
-    assert_eq!(output.semantic.classes.len(), 0);
-}
-
 #[cfg(feature = "lang-javascript")]
 #[test]
 fn test_javascript_parse_and_extract() {
@@ -605,20 +591,6 @@ class MyClass {
     assert!(class_names.contains(&"MyClass"));
 }
 
-#[cfg(feature = "lang-typescript")]
-#[test]
-fn test_typescript_edge_case_empty_file() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("empty.ts");
-
-    fs::write(&file_path, "").unwrap();
-
-    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
-
-    assert_eq!(output.semantic.functions.len(), 0);
-    assert_eq!(output.semantic.classes.len(), 0);
-}
-
 #[cfg(feature = "lang-go")]
 #[test]
 fn test_go_parse_and_extract() {
@@ -658,20 +630,6 @@ type MyInterface interface {
         .collect();
     assert!(class_names.contains(&"MyStruct"));
     assert!(class_names.contains(&"MyInterface"));
-}
-
-#[cfg(feature = "lang-go")]
-#[test]
-fn test_go_edge_case_empty_file() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("empty.go");
-
-    fs::write(&file_path, "").unwrap();
-
-    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
-
-    assert_eq!(output.semantic.functions.len(), 0);
-    assert_eq!(output.semantic.classes.len(), 0);
 }
 
 #[cfg(feature = "lang-java")]
@@ -714,20 +672,6 @@ enum MyEnum {
     assert!(class_names.contains(&"MyClass"));
     assert!(class_names.contains(&"MyInterface"));
     assert!(class_names.contains(&"MyEnum"));
-}
-
-#[cfg(feature = "lang-java")]
-#[test]
-fn test_java_edge_case_empty_file() {
-    let temp_dir = TempDir::new().unwrap();
-    let file_path = temp_dir.path().join("empty.java");
-
-    fs::write(&file_path, "").unwrap();
-
-    let output = analyze_file(file_path.to_str().unwrap(), None).unwrap();
-
-    assert_eq!(output.semantic.functions.len(), 0);
-    assert_eq!(output.semantic.classes.len(), 0);
 }
 
 // Cache tests

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -208,7 +208,10 @@ async fn call_tool_with_profile(profile: Option<&str>, tool_name: &str) -> serde
 
 #[tokio::test]
 async fn test_edit_profile_tool_count() {
-    let _guard = env_var_lock();
+    // Arrange: hold guard only during setup; drop before first .await
+    {
+        let _guard = env_var_lock();
+    }
     // Arrange: initialize with edit profile
     let resp = call_tools_list_with_profile(Some("edit")).await;
 
@@ -246,7 +249,10 @@ async fn test_edit_profile_tool_count() {
 
 #[tokio::test]
 async fn test_analyze_profile_tool_count() {
-    let _guard = env_var_lock();
+    // Arrange: hold guard only during setup; drop before first .await
+    {
+        let _guard = env_var_lock();
+    }
     // Arrange: initialize with analyze profile
     let resp = call_tools_list_with_profile(Some("analyze")).await;
 
@@ -292,10 +298,13 @@ async fn test_analyze_profile_tool_count() {
 
 #[tokio::test]
 async fn test_no_profile_tool_count() {
-    let _guard = env_var_lock();
-    // Arrange: initialize with no profile metadata; env var must be absent.
-    unsafe {
-        std::env::remove_var("APTU_CODER_PROFILE");
+    // Arrange: hold guard only during setup; drop before first .await
+    {
+        let _guard = env_var_lock();
+        // Arrange: initialize with no profile metadata; env var must be absent.
+        unsafe {
+            std::env::remove_var("APTU_CODER_PROFILE");
+        }
     }
     let resp = call_tools_list_with_profile(None).await;
 
@@ -313,10 +322,13 @@ async fn test_no_profile_tool_count() {
 
 #[tokio::test]
 async fn test_unknown_profile_tool_count() {
-    let _guard = env_var_lock();
-    // Arrange: initialize with unknown profile string; env var must be absent.
-    unsafe {
-        std::env::remove_var("APTU_CODER_PROFILE");
+    // Arrange: hold guard only during setup; drop before first .await
+    {
+        let _guard = env_var_lock();
+        // Arrange: initialize with unknown profile string; env var must be absent.
+        unsafe {
+            std::env::remove_var("APTU_CODER_PROFILE");
+        }
     }
     let resp = call_tools_list_with_profile(Some("unknown_profile")).await;
 
@@ -334,7 +346,10 @@ async fn test_unknown_profile_tool_count() {
 
 #[tokio::test]
 async fn test_disabled_tool_returns_invalid_params() {
-    let _guard = env_var_lock();
+    // Arrange: hold guard only during setup; drop before first .await
+    {
+        let _guard = env_var_lock();
+    }
     // Arrange: initialize with edit profile and try to call a disabled tool (analyze_directory)
     let resp = call_tool_with_profile(Some("edit"), "analyze_directory").await;
 
@@ -352,17 +367,18 @@ async fn test_disabled_tool_returns_invalid_params() {
 
 #[tokio::test]
 async fn test_profile_env_var_fallback() {
-    // Serialize against other env-var-mutating tests.
-    let _guard = env_var_lock();
-
-    // Arrange: set APTU_CODER_PROFILE env var to "edit", initialize with no _meta.
-    unsafe {
-        std::env::set_var("APTU_CODER_PROFILE", "edit");
+    // Serialize against other env-var-mutating tests; drop guard before first .await.
+    {
+        let _guard = env_var_lock();
+        // Arrange: set APTU_CODER_PROFILE env var to "edit", initialize with no _meta.
+        unsafe {
+            std::env::set_var("APTU_CODER_PROFILE", "edit");
+        }
     }
 
     let resp = call_tools_list_with_profile(None).await;
 
-    // Cleanup before any assertion so panics cannot leave the env var set.
+    // Cleanup after async call so the env var is present during initialize.
     unsafe {
         std::env::remove_var("APTU_CODER_PROFILE");
     }
@@ -391,18 +407,19 @@ async fn test_profile_env_var_fallback() {
 
 #[tokio::test]
 async fn test_profile_env_var_ignored_when_meta_present() {
-    // Serialize against other env-var-mutating tests.
-    let _guard = env_var_lock();
-
-    // Arrange: set APTU_CODER_PROFILE=edit but initialize with _meta "analyze".
-    // _meta must win.
-    unsafe {
-        std::env::set_var("APTU_CODER_PROFILE", "edit");
+    // Serialize against other env-var-mutating tests; drop guard before first .await.
+    {
+        let _guard = env_var_lock();
+        // Arrange: set APTU_CODER_PROFILE=edit but initialize with _meta "analyze".
+        // _meta must win.
+        unsafe {
+            std::env::set_var("APTU_CODER_PROFILE", "edit");
+        }
     }
 
     let resp = call_tools_list_with_profile(Some("analyze")).await;
 
-    // Cleanup before any assertion.
+    // Cleanup after async call so the env var is present during initialize.
     unsafe {
         std::env::remove_var("APTU_CODER_PROFILE");
     }


### PR DESCRIPTION
Closes #1021

## Changes

**F6 -- Remove 4 redundant per-language empty-file tests**

Deleted from `crates/aptu-coder-core/tests/integration_tests.rs`:
- `test_python_edge_case_empty_file`
- `test_typescript_edge_case_empty_file`
- `test_go_edge_case_empty_file`
- `test_java_edge_case_empty_file`

Each only asserted `functions.len() == 0` and `classes.len() == 0`. An empty file never reaches the per-language tree-sitter handler. `test_semantic_analysis_empty_file` (kept) covers the same early-return path with richer assertions.

**F8 -- Fix MutexGuard held across .await in profiles.rs**

Scoped `env_var_lock()` guard to a setup block before the first `.await` in all 7 async test functions. `std::sync::MutexGuard` is `!Send`; holding it across `.await` is semantically wrong. `serial_test` prevented deadlocks but the pattern should not remain.

`exec_command.rs` was audited and confirmed not to use `env_var_lock()` -- no changes needed there.

## Verification

- `cargo test`: 535 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
