### PR TITLE
chore(deps): replace which crate with stdlib PATH scan in detect_shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "which",
 ]
 
 [[package]]
@@ -2582,15 +2581,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -35,7 +35,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
 nix = { version = "0.31", features = ["resource"] }
-which = "8"
 regex = { workspace = true }
 toml = { workspace = true }
 opentelemetry = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -480,7 +480,17 @@ fn resolve_shell() -> String {
     }
     #[cfg(unix)]
     {
-        if which::which("bash").is_ok() {
+        if std::env::var("PATH").is_ok_and(|p| {
+            std::env::split_paths(&p).any(|dir| {
+                use std::os::unix::fs::PermissionsExt as _;
+                let candidate = dir.join("bash");
+                candidate.is_file()
+                    && candidate
+                        .metadata()
+                        .map(|m| m.permissions().mode() & 0o111 != 0)
+                        .unwrap_or(false)
+            })
+        }) {
             return "bash".to_string();
         }
         "/bin/sh".to_string()


### PR DESCRIPTION
Closes #1022

## Summary

Replace `which::which("bash").is_ok()` in `resolve_shell()` with a stdlib PATH scan, then remove `which = "8"` from `crates/aptu-coder/Cargo.toml`.

The `which` crate was pulled in as a direct dependency for a single call site. The replacement uses stdlib only:

```rust
std::env::var("PATH").is_ok_and(|p| {
    std::env::split_paths(&p).any(|dir| {
        use std::os::unix::fs::PermissionsExt as _;
        let candidate = dir.join("bash");
        candidate.is_file()
            && candidate
                .metadata()
                .map(|m| m.permissions().mode() & 0o111 != 0)
                .unwrap_or(false)
    })
})
```

`split_paths` is used instead of `split(':')` for correct cross-platform PATH parsing. An executable permission check (`mode() & 0o111 != 0`) is added so a non-executable file named `bash` on PATH does not produce a false positive, matching the behaviour of the `which` crate.

Shell detection order preserved:
1. `APTU_SHELL` env var (highest priority, unaffected)
2. `bash` found and executable on `PATH` (this change)
3. `/bin/sh` fallback

The non-unix branch (`#[cfg(not(unix))]`) returns `"cmd"` directly and is unaffected.

## Changes

- `crates/aptu-coder/src/lib.rs` -- replace `which::which` with stdlib PATH scan + exec bit check
- `crates/aptu-coder/Cargo.toml` -- remove `which = "8"` dependency
- `Cargo.lock` -- updated

## Test plan

- [x] Tests pass (`cargo test`: 549 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Security scan clean (no critical/high findings)
