### PR TITLE
fix(filters): validate schema_version in FilterTableConfig after deserialization

### DIFF
--- a/crates/aptu-coder/src/filters.rs
+++ b/crates/aptu-coder/src/filters.rs
@@ -11,7 +11,6 @@ use tracing::warn;
 /// TOML configuration for filter rules.
 #[derive(serde::Deserialize)]
 pub(crate) struct FilterTableConfig {
-    #[allow(dead_code)]
     schema_version: u32,
     filters: Vec<types::FilterRule>,
 }
@@ -234,6 +233,14 @@ pub(crate) fn load_filter_table(cwd: &Path) -> Vec<CompiledRule> {
     if let Ok(content) = fs::read_to_string(&filters_path) {
         match toml::from_str::<FilterTableConfig>(&content) {
             Ok(config) => {
+                if config.schema_version != 1 {
+                    warn!(
+                        schema_version = config.schema_version,
+                        path = %filters_path.display(),
+                        "unsupported filters.toml schema_version; only version 1 is supported; falling back to built-in rules"
+                    );
+                    return compiled_rules;
+                }
                 for rule in config.filters {
                     if let Ok(pattern) = Regex::new(&rule.match_command) {
                         let strip_patterns = rule

--- a/crates/aptu-coder/src/filters.rs
+++ b/crates/aptu-coder/src/filters.rs
@@ -11,6 +11,9 @@ use tracing::warn;
 /// TOML configuration for filter rules.
 #[derive(serde::Deserialize)]
 pub(crate) struct FilterTableConfig {
+    /// Config file format version. Only version 1 is supported; other values
+    /// log a warning and fall back to built-in rules. Bump this when the
+    /// schema changes in a breaking way so old readers fail loudly.
     schema_version: u32,
     filters: Vec<types::FilterRule>,
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -5764,6 +5764,54 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_schema_version_falls_back_gracefully() {
+        // Edge case: schema_version != 1 in .aptu/filters.toml should fall back to built-ins.
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "aptu-test-schema-version-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let aptu_dir = tmp.join(".aptu");
+        std::fs::create_dir_all(&aptu_dir).expect("should create .aptu dir");
+
+        // schema_version = 2 with a valid filter rule; should be rejected
+        let toml_content = "schema_version = 2\n[[filters]]\nmatch_command = \"^my-v2-tool\"\nkeep_lines_matching = []\n";
+        let mut f = std::fs::File::create(aptu_dir.join("filters.toml"))
+            .expect("should create filters.toml");
+        f.write_all(toml_content.as_bytes())
+            .expect("should write toml");
+        drop(f);
+
+        // Should not panic; should return built-in rules only (no project-local rule)
+        let rules = filters::load_filter_table(&tmp);
+
+        // Built-in rules must be present
+        let has_git_pull = rules
+            .iter()
+            .any(|r| r.pattern.is_match("git pull origin main"));
+        assert!(
+            has_git_pull,
+            "should have git pull built-in rule after schema_version=2 rejection"
+        );
+
+        // The project-local rule must NOT be present
+        let has_v2_rule = rules
+            .iter()
+            .any(|r| r.pattern.is_match("my-v2-tool --flag"));
+        assert!(
+            !has_v2_rule,
+            "schema_version=2 rule should not be loaded; only built-ins expected"
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn test_metric_chars_threshold_breach_fires() {
         // Happy path: chars_threshold_breach is true when output_chars > 30_000
         let output_chars: usize = 35_000;


### PR DESCRIPTION
## Summary

Validates `schema_version` in `FilterTableConfig` after TOML deserialization. Files with `schema_version != 1` in `.aptu/filters.toml` previously loaded silently; they now log a `warn!` and fall back to built-in rules, matching the existing graceful-fallback pattern for parse errors.

Removes `#[allow(dead_code)]` from the `schema_version` field.

## Changes

- `crates/aptu-coder/src/filters.rs`: remove `#[allow(dead_code)]`; add 7-line validation block immediately after `toml::from_str` succeeds
- `crates/aptu-coder/src/lib.rs`: add `test_invalid_schema_version_falls_back_gracefully`

## Behavior change

`schema_version != 1` is no longer silently accepted. Users with a non-1 value will see a `warn!` log and built-in rules will be used instead.

## Testing

- `cargo test`: 240 passed (2 pre-existing failures in `tests/profiles.rs::test_profile_env_var_fallback` unrelated to this change)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean

Closes #1023
