### PR TITLE
test(aptu-coder): replace hollow placeholder tests with real integration tests

### DIFF
--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
+#![allow(dead_code)]
 
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex as TokioMutex;
 use tracing_subscriber::filter::LevelFilter;
 
-#[allow(dead_code)]
 pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
@@ -20,7 +20,6 @@ pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     )
 }
 
-#[allow(dead_code)]
 pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_json::Value {
     let analyzer = make_test_analyzer();
     let (client, server) = tokio::io::duplex(65536);

--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex as TokioMutex;
+use tracing_subscriber::filter::LevelFilter;
+
+#[allow(dead_code)]
+pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
+    let peer = Arc::new(TokioMutex::new(None));
+    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
+    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::logging::LogEvent>();
+    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
+    aptu_coder::CodeAnalyzer::new(
+        peer,
+        log_level_filter,
+        rx,
+        aptu_coder::metrics::MetricsSender(metrics_tx),
+    )
+}
+
+#[allow(dead_code)]
+pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_json::Value {
+    let analyzer = make_test_analyzer();
+    let (client, server) = tokio::io::duplex(65536);
+
+    // Spawn the analyzer server on the server half
+    let mut server_handle = tokio::spawn(async move {
+        let (server_rx, server_tx) = tokio::io::split(server);
+        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
+            let _ = service.waiting().await;
+        }
+    });
+
+    let (client_rx, mut client_tx) = tokio::io::split(client);
+    let mut reader = BufReader::new(client_rx).lines();
+
+    // Step 1: Send initialize request
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "0.1.0"}
+        }
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(init.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    // Step 2: Read initialize response (discard)
+    let _resp = reader.next_line().await.unwrap().unwrap();
+
+    // Step 3: Send initialized notification (no id)
+    let notif = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {}
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(notif.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    // Step 4: Send tools/call
+    let call = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": params
+        }
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(call.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    // Step 5: Race response loop against server handle to surface server panics
+    tokio::select! {
+        result = async {
+            loop {
+                let line = reader.next_line().await.unwrap().unwrap();
+                let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+                if v.get("id") == Some(&serde_json::json!(2)) {
+                    return v;
+                }
+            }
+        } => {
+            server_handle.abort();
+            result
+        }
+        outcome = &mut server_handle => {
+            match outcome {
+                Ok(_) => panic!("server task exited unexpectedly before tool response"),
+                Err(e) => panic!("server task panicked: {e}"),
+            }
+        }
+    }
+}

--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -48,11 +48,21 @@ pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_
     })
     .to_string()
         + "\n";
-    client_tx.write_all(init.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
+    client_tx
+        .write_all(init.as_bytes())
+        .await
+        .expect("failed to write initialize request");
+    client_tx
+        .flush()
+        .await
+        .expect("failed to flush initialize request");
 
     // Step 2: Read initialize response (discard)
-    let _resp = reader.next_line().await.unwrap().unwrap();
+    let _resp = reader
+        .next_line()
+        .await
+        .expect("IO error reading initialize response")
+        .expect("server closed before sending initialize response");
 
     // Step 3: Send initialized notification (no id)
     let notif = serde_json::json!({
@@ -62,8 +72,14 @@ pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_
     })
     .to_string()
         + "\n";
-    client_tx.write_all(notif.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
+    client_tx
+        .write_all(notif.as_bytes())
+        .await
+        .expect("failed to write initialized notification");
+    client_tx
+        .flush()
+        .await
+        .expect("failed to flush initialized notification");
 
     // Step 4: Send tools/call
     let call = serde_json::json!({
@@ -77,15 +93,26 @@ pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_
     })
     .to_string()
         + "\n";
-    client_tx.write_all(call.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
+    client_tx
+        .write_all(call.as_bytes())
+        .await
+        .expect("failed to write tools/call request");
+    client_tx
+        .flush()
+        .await
+        .expect("failed to flush tools/call request");
 
     // Step 5: Race response loop against server handle to surface server panics
     tokio::select! {
         result = async {
             loop {
-                let line = reader.next_line().await.unwrap().unwrap();
-                let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+                let line = reader
+                    .next_line()
+                    .await
+                    .expect("IO error reading tool response")
+                    .expect("server closed before sending tool response");
+                let v: serde_json::Value =
+                    serde_json::from_str(&line).expect("tool response is not valid JSON");
                 if v.get("id") == Some(&serde_json::json!(2)) {
                     return v;
                 }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -247,24 +247,22 @@ async fn exec_command_timeout() {
 
 #[tokio::test]
 async fn exec_command_working_dir_rejection() {
-    // Arrange: pass a working_dir that points outside the server's CWD
-    // This test verifies that the handler rejects paths outside the allowed directory
-    // We'll use a path like "/tmp" or "../../etc" which should be rejected
+    // Arrange: working_dir=/tmp is outside the server's CWD
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo hi",
+        "working_dir": "/tmp"
+    }))
+    .await;
 
-    // Note: This test is a placeholder that documents the expected behavior.
-    // The actual handler validation happens in the exec_command tool handler in lib.rs,
-    // which calls validate_path() and checks if the directory exists and is within bounds.
-    // A full integration test would require setting up the MCP server context.
-
-    // For now, we verify that attempting to use an absolute path like /tmp
-    // would be rejected by the validate_path function.
-    let invalid_path = "/tmp";
-
-    // The validate_path function should reject this because it's outside the server's CWD
-    // This is tested implicitly by the handler's validation logic.
+    // Assert: handler must reject with isError=true and mention 'outside'
     assert!(
-        invalid_path.starts_with("/"),
-        "absolute paths should be rejected by validate_path"
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for working_dir outside CWD: {resp}"
+    );
+    let content_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        content_text.contains("outside"),
+        "error message should contain 'outside': {content_text}"
     );
 }
 

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1,105 +1,12 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::Mutex as TokioMutex;
-use tracing_subscriber::filter::LevelFilter;
+mod common;
 
-fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
-    let peer = Arc::new(TokioMutex::new(None));
-    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::logging::LogEvent>();
-    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
-    aptu_coder::CodeAnalyzer::new(
-        peer,
-        log_level_filter,
-        rx,
-        aptu_coder::metrics::MetricsSender(metrics_tx),
-    )
-}
+use common::call_tool_raw;
 
 async fn call_exec_command_raw(params: serde_json::Value) -> serde_json::Value {
-    let analyzer = make_test_analyzer();
-    let (client, server) = tokio::io::duplex(65536);
-
-    // Spawn the analyzer server on the server half
-    let mut server_handle = tokio::spawn(async move {
-        let (server_rx, server_tx) = tokio::io::split(server);
-        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
-            let _ = service.waiting().await;
-        }
-    });
-
-    let (client_rx, mut client_tx) = tokio::io::split(client);
-    let mut reader = BufReader::new(client_rx).lines();
-
-    // Step 1: Send initialize request
-    let init = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": "2025-11-25",
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1.0"}
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(init.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    // Step 2: Read initialize response (discard)
-    let _resp = reader.next_line().await.unwrap().unwrap();
-
-    // Step 3: Send initialized notification (no id)
-    let notif = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/initialized",
-        "params": {}
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(notif.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    // Step 4: Send tools/call
-    let call = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {
-            "name": "exec_command",
-            "arguments": params
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(call.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    // Step 5: Race response loop against server handle to surface server panics
-    tokio::select! {
-        result = async {
-            loop {
-                let line = reader.next_line().await.unwrap().unwrap();
-                let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-                if v.get("id") == Some(&serde_json::json!(2)) {
-                    return v;
-                }
-            }
-        } => {
-            server_handle.abort();
-            result
-        }
-        outcome = &mut server_handle => {
-            match outcome {
-                Ok(_) => panic!("server task exited unexpectedly before tool response"),
-                Err(e) => panic!("server task panicked: {e}"),
-            }
-        }
-    }
+    call_tool_raw("exec_command", params).await
 }
 
 #[tokio::test]

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -1,101 +1,12 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
 use aptu_coder::logging::LogEvent;
+use common::call_tool_raw;
 use rmcp::model::{CallToolResult, Content, LoggingLevel, Meta};
-use std::sync::{Arc, Mutex};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::Mutex as TokioMutex;
-use tracing_subscriber::filter::LevelFilter;
 
-fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
-    let peer = Arc::new(TokioMutex::new(None));
-    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<LogEvent>();
-    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
-    aptu_coder::CodeAnalyzer::new(
-        peer,
-        log_level_filter,
-        rx,
-        aptu_coder::metrics::MetricsSender(metrics_tx),
-    )
-}
-
-async fn call_analyze_directory_raw(params: serde_json::Value) -> serde_json::Value {
-    let analyzer = make_test_analyzer();
-    let (client, server) = tokio::io::duplex(65536);
-
-    let mut server_handle = tokio::spawn(async move {
-        let (server_rx, server_tx) = tokio::io::split(server);
-        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
-            let _ = service.waiting().await;
-        }
-    });
-
-    let (client_rx, mut client_tx) = tokio::io::split(client);
-    let mut reader = BufReader::new(client_rx).lines();
-
-    let init = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": "2025-11-25",
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1.0"}
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(init.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    let _resp = reader.next_line().await.unwrap().unwrap();
-
-    let notif = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/initialized",
-        "params": {}
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(notif.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    let call = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {
-            "name": "analyze_directory",
-            "arguments": params
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx.write_all(call.as_bytes()).await.unwrap();
-    client_tx.flush().await.unwrap();
-
-    tokio::select! {
-        result = async {
-            loop {
-                let line = reader.next_line().await.unwrap().unwrap();
-                let v: serde_json::Value = serde_json::from_str(&line).unwrap();
-                if v.get("id") == Some(&serde_json::json!(2)) {
-                    return v;
-                }
-            }
-        } => {
-            server_handle.abort();
-            result
-        }
-        outcome = &mut server_handle => {
-            match outcome {
-                Ok(_) => panic!("server task exited unexpectedly before tool response"),
-                Err(e) => panic!("server task panicked: {e}"),
-            }
-        }
-    }
-}
 #[tokio::test]
 async fn test_batch_draining_with_multiple_events() {
     use serde_json::json;
@@ -147,11 +58,14 @@ fn test_call_tool_result_cache_hint_metadata() {
 #[tokio::test]
 async fn test_path_outside_cwd_rejected() {
     // Arrange: path=/etc/passwd is outside the server's CWD
-    let resp = call_analyze_directory_raw(serde_json::json!({
-        "path": "/etc/passwd",
-        "max_depth": 0,
-        "page_size": 10
-    }))
+    let resp = call_tool_raw(
+        "analyze_directory",
+        serde_json::json!({
+            "path": "/etc/passwd",
+            "max_depth": 0,
+            "page_size": 10
+        }),
+    )
     .await;
 
     // Assert: handler must reject with isError=true and mention 'outside'

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -2,6 +2,100 @@
 // SPDX-License-Identifier: Apache-2.0
 use aptu_coder::logging::LogEvent;
 use rmcp::model::{CallToolResult, Content, LoggingLevel, Meta};
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex as TokioMutex;
+use tracing_subscriber::filter::LevelFilter;
+
+fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
+    let peer = Arc::new(TokioMutex::new(None));
+    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
+    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<LogEvent>();
+    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
+    aptu_coder::CodeAnalyzer::new(
+        peer,
+        log_level_filter,
+        rx,
+        aptu_coder::metrics::MetricsSender(metrics_tx),
+    )
+}
+
+async fn call_analyze_directory_raw(params: serde_json::Value) -> serde_json::Value {
+    let analyzer = make_test_analyzer();
+    let (client, server) = tokio::io::duplex(65536);
+
+    let mut server_handle = tokio::spawn(async move {
+        let (server_rx, server_tx) = tokio::io::split(server);
+        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
+            let _ = service.waiting().await;
+        }
+    });
+
+    let (client_rx, mut client_tx) = tokio::io::split(client);
+    let mut reader = BufReader::new(client_rx).lines();
+
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "0.1.0"}
+        }
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(init.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    let _resp = reader.next_line().await.unwrap().unwrap();
+
+    let notif = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {}
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(notif.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    let call = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "analyze_directory",
+            "arguments": params
+        }
+    })
+    .to_string()
+        + "\n";
+    client_tx.write_all(call.as_bytes()).await.unwrap();
+    client_tx.flush().await.unwrap();
+
+    tokio::select! {
+        result = async {
+            loop {
+                let line = reader.next_line().await.unwrap().unwrap();
+                let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+                if v.get("id") == Some(&serde_json::json!(2)) {
+                    return v;
+                }
+            }
+        } => {
+            server_handle.abort();
+            result
+        }
+        outcome = &mut server_handle => {
+            match outcome {
+                Ok(_) => panic!("server task exited unexpectedly before tool response"),
+                Err(e) => panic!("server task panicked: {e}"),
+            }
+        }
+    }
+}
 #[tokio::test]
 async fn test_batch_draining_with_multiple_events() {
     use serde_json::json;
@@ -50,25 +144,24 @@ fn test_call_tool_result_cache_hint_metadata() {
     );
 }
 
-#[test]
-fn test_path_outside_cwd_rejected() {
-    // S4: Verify that paths outside the current working directory are rejected.
-    // The validate_path function is called by all tool handlers at entry.
-    // This regression test ensures that absolute paths outside CWD are properly rejected.
-    let path = "/etc/passwd";
+#[tokio::test]
+async fn test_path_outside_cwd_rejected() {
+    // Arrange: path=/etc/passwd is outside the server's CWD
+    let resp = call_analyze_directory_raw(serde_json::json!({
+        "path": "/etc/passwd",
+        "max_depth": 0,
+        "page_size": 10
+    }))
+    .await;
 
-    // Verify the path is actually outside CWD (safety check)
-    let cwd = std::env::current_dir().expect("should get cwd");
+    // Assert: handler must reject with isError=true and mention 'outside'
     assert!(
-        !std::path::Path::new(path).starts_with(&cwd),
-        "Test setup error: /etc/passwd should be outside CWD"
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for path outside CWD: {resp}"
     );
-
-    // The validate_path function (tested in lib.rs unit tests) rejects this path.
-    // This test verifies the error message is accurate.
-    let error_msg = "path is outside the allowed root";
+    let content_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
     assert!(
-        error_msg.contains("outside"),
-        "Error message should mention 'outside': {error_msg}"
+        content_text.contains("outside"),
+        "error message should contain 'outside': {content_text}"
     );
 }


### PR DESCRIPTION
## Summary

Replaced two hollow placeholder tests with real MCP integration tests that verify path validation behavior through the full MCP protocol stack. Extracted the duplicated test harness into a shared `tests/common/mod.rs` module to eliminate copy-paste drift.

## Changes

- `crates/aptu-coder/tests/common/mod.rs` (new): shared harness exposing `make_test_analyzer()` and `call_tool_raw(tool_name, params)`, ported from the existing `call_exec_command_raw` pattern and parameterized on tool name.
- `crates/aptu-coder/tests/exec_command.rs`: removed inline `make_test_analyzer` and `call_exec_command_raw` helpers; thin `call_exec_command_raw` wrapper now delegates to `call_tool_raw`. Replaced `exec_command_working_dir_rejection` placeholder with a real integration test calling `exec_command` with `working_dir=/tmp` and asserting `isError=true` with `"outside"` in the error message.
- `crates/aptu-coder/tests/integration_tests.rs`: removed inline harness copy added in the first commit; `test_path_outside_cwd_rejected` now uses `call_tool_raw("analyze_directory", ...)` via `mod common`. Test asserts `isError=true` with `"outside"` in the error message for `path=/etc/passwd`.

## Test plan

- [x] Tests pass (31 relevant tests; pre-existing failures in `profiles.rs` are unrelated)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Formatter clean (`cargo fmt --check`)
- [x] No production code modified

Closes #1031
