### PR TITLE
docs(readme): document interleaved filter fix and schema_version fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The 30k stdout cap is data-driven: analysis of 27,981 observed `exec_command` ca
 
 **exec_command output filters**
 
-A built-in filter table suppresses per-file noise from chatty CLI tools before output reaches the model. Filters apply on success only; raw output is always preserved on failure.
+A built-in filter table suppresses per-file noise from chatty CLI tools before output reaches the model. Filters apply to stdout, stderr, and interleaved output on success only; raw output is always preserved on failure.
 
 | Command | Behavior |
 |---------|----------|
@@ -221,7 +221,7 @@ A built-in filter table suppresses per-file noise from chatty CLI tools before o
 | `cargo build` | Strips `Compiling` / `Checking` / `Downloading` / `Fresh` lines; empty output replaced with `ok (build clean)` |
 | `cargo test` | Strips `Compiling` / `Checking` / `Fresh` lines |
 
-Project-local rules can be added in `.aptu/filters.toml`. Parse errors fall back to the built-in table (no crash). When a filter fires, `filter_applied` in `structuredContent` identifies which rule matched.
+Project-local rules can be added in `.aptu/filters.toml`. Parse errors and unrecognized schema_version values (version != 1) fall back to the built-in table with a logged warning; no crash occurs. When a filter fires, `filter_applied` in `structuredContent` identifies which rule matched.
 
 ## Non-Interactive Pipelines
 


### PR DESCRIPTION
## Summary

Update README.md with two factual corrections documenting recent fixes:

1. The exec_command filter intro now states filters apply to stdout, stderr, and interleaved output (from PR #1017)
2. The filter fallback sentence now covers schema_version != 1 as a warn+fallback trigger alongside parse errors (from PR #1029)

## Changes

- README.md: sentence-level edits in the exec_command filter section (lines 208 and 224)

## Test plan

- Markdown is documentation only; no automated tests apply
- Both edits are factual descriptions of existing behavior already deployed in merged PRs
- All links remain absolute; no structural changes to README
