### PR TITLE
chore(core): fix crate boundary leaks, visibility gaps, and duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "regex",
  "rmcp",
  "rustls",
+ "schemars",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -12,6 +12,7 @@ use lru::LruCache;
 use rayon::prelude::*;
 use serde::{Serialize, de::DeserializeOwned};
 use std::num::NonZeroUsize;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -436,9 +437,12 @@ impl DiskCache {
                 total_write_failures: std::sync::atomic::AtomicU64::new(0),
             };
         }
+        #[cfg(unix)]
         if let Err(e) = std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)) {
             warn!(path = %base.display(), error = %e, "disk cache: failed to set directory permissions to 0700");
         }
+        #[cfg(not(unix))]
+        let _ = &base; // permissions not supported on this platform
         Self {
             base,
             disabled: false,
@@ -597,6 +601,7 @@ mod disk_cache_tests {
         assert_eq!(result, Some(value));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_disk_cache_permissions() {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/aptu-coder-core/src/graph.rs
+++ b/crates/aptu-coder-core/src/graph.rs
@@ -498,7 +498,7 @@ impl CallGraph {
     }
 
     #[instrument(skip(self))]
-    pub(crate) fn find_incoming_chains(
+    pub fn find_incoming_chains(
         &self,
         symbol: &str,
         follow_depth: u32,
@@ -507,7 +507,7 @@ impl CallGraph {
     }
 
     #[instrument(skip(self))]
-    pub(crate) fn find_outgoing_chains(
+    pub fn find_outgoing_chains(
         &self,
         symbol: &str,
         follow_depth: u32,

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod types;
 #[cfg(feature = "schemars")]
 pub mod schema_helpers;
 
-pub(crate) const EXCLUDED_DIRS: &[&str] = &[
+pub const EXCLUDED_DIRS: &[&str] = &[
     "node_modules",
     "vendor",
     ".git",
@@ -67,16 +67,18 @@ pub use analyze::{
 };
 pub use config::AnalysisConfig;
 pub use edit::{EditError, edit_overwrite_content, edit_replace_block};
+pub use graph::{GraphError, InternalCallChain};
 pub use lang::{language_for_extension, supported_languages};
+pub use pagination::{CursorData, PaginationError};
 pub use parser::ParserError;
+pub use traversal::{TraversalError, WalkEntry};
 pub use types::{
     AnalysisMode, AnalysisResult, AnalyzeDirectoryParams, AnalyzeFileField, AnalyzeFileParams,
     AnalyzeModuleParams, AnalyzeSymbolParams, CallChain, CallEdge, CallInfo, ClassInfo, DefUseKind,
     DefUseSite, EditOverwriteOutput, EditOverwriteParams, EditReplaceOutput, EditReplaceParams,
-    ErrorMeta, ExecCommandParams, FileInfo, FocusedAnalysisData, FunctionInfo, ImplTraitInfo,
-    ImportInfo, ModuleFunctionInfo, ModuleImportInfo, ModuleInfo, OutputControlParams,
-    PaginationParams, ReferenceInfo, ReferenceType, STDIN_MAX_BYTES, SemanticAnalysis, ShellOutput,
-    SymbolMatchMode,
+    FileInfo, FilterRule, FocusedAnalysisData, FunctionInfo, ImplTraitInfo, ImportInfo,
+    ModuleFunctionInfo, ModuleImportInfo, ModuleInfo, OutputControlParams, PaginationParams,
+    ReferenceInfo, ReferenceType, SemanticAnalysis, SymbolMatchMode,
 };
 
 /// Captures from a custom tree-sitter query.

--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -1525,7 +1525,7 @@ pub fn extract_impl_traits(source: &str, path: &Path) -> Vec<ImplTraitInfo> {
 /// Execute a custom tree-sitter query against source code.
 ///
 /// This is the internal implementation of the public `execute_query` function.
-pub fn execute_query_impl(
+pub(crate) fn execute_query_impl(
     language: &str,
     source: &str,
     query_str: &str,

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -7,9 +7,6 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::PathBuf;
 
-/// Maximum byte length for stdin content passed to exec_command.
-pub const STDIN_MAX_BYTES: usize = 1_048_576;
-
 /// A single edge in the call graph with impl-trait metadata.
 /// `neighbor_name` holds the caller name in `callers` maps and the callee name in `callees` maps.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -767,55 +764,6 @@ mod tests {
     }
 }
 
-/// Structured error metadata for MCP error responses.
-/// Serializes to camelCase JSON for inclusion in `ErrorData.data`.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ErrorMeta {
-    pub error_category: &'static str,
-    pub is_retryable: bool,
-    pub suggested_action: &'static str,
-}
-
-#[cfg(test)]
-mod error_meta_tests {
-    use super::*;
-
-    #[test]
-    fn test_error_meta_serialization_camel_case() {
-        let meta = ErrorMeta {
-            error_category: "validation",
-            is_retryable: false,
-            suggested_action: "fix input",
-        };
-        let v = serde_json::to_value(&meta).unwrap();
-        assert_eq!(v["errorCategory"], "validation");
-        assert_eq!(v["isRetryable"], false);
-        assert_eq!(v["suggestedAction"], "fix input");
-    }
-
-    #[test]
-    fn test_error_meta_validation_not_retryable() {
-        let meta = ErrorMeta {
-            error_category: "validation",
-            is_retryable: false,
-            suggested_action: "use summary=true",
-        };
-        assert!(!meta.is_retryable);
-    }
-
-    #[test]
-    fn test_error_meta_transient_retryable() {
-        let meta = ErrorMeta {
-            error_category: "transient",
-            is_retryable: true,
-            suggested_action: "retry the request",
-        };
-        assert!(meta.is_retryable);
-    }
-}
-
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -864,42 +812,6 @@ pub struct EditReplaceOutput {
     pub bytes_after: usize,
 }
 
-#[non_exhaustive]
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct ExecCommandParams {
-    /// Shell command to execute via sh -c (or $SHELL if set).
-    pub command: String,
-    /// Timeout in seconds before SIGKILL. None = no timeout (default).
-    pub timeout_secs: Option<u64>,
-    /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
-    pub working_dir: Option<String>,
-    /// Cap on virtual address space in megabytes (Linux only; silently accepted but not enforced on macOS).
-    /// None = no limit (default).
-    pub memory_limit_mb: Option<u64>,
-    /// CPU time limit in seconds. Complements timeout_secs (wall-clock). SIGXCPU on soft-limit breach, SIGKILL on hard-limit breach.
-    /// None = no limit (default).
-    pub cpu_limit_secs: Option<u64>,
-    /// UTF-8 content to pipe into the process stdin (max `STDIN_MAX_BYTES` = 1 MB). When None, stdin is closed (null).
-    pub stdin: Option<String>,
-    /// Enable caching of command results. None or true = enabled (default); false = disabled.
-    /// Caching is skipped if stdin is provided, regardless of this setting.
-    #[serde(default)]
-    pub cache: Option<bool>,
-}
-
-impl ExecCommandParams {
-    /// Creates a new ExecCommandParams with the given command.
-    pub fn new(command: String, timeout_secs: Option<u64>, working_dir: Option<String>) -> Self {
-        Self {
-            command,
-            timeout_secs,
-            working_dir,
-            ..Default::default()
-        }
-    }
-}
-
 /// Filter rule for command output post-processing.
 /// Matches command prefixes and applies transformations (strip/keep/cap lines).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -922,61 +834,4 @@ pub struct FilterRule {
     pub max_lines: Option<usize>,
     /// Replacement text if filtered output is empty (success-only).
     pub on_empty: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct ShellOutput {
-    /// Standard output from the command.
-    pub stdout: String,
-    /// Standard error from the command.
-    pub stderr: String,
-    /// Stdout and stderr interleaved in arrival order.
-    pub interleaved: String,
-    /// Exit code; null if killed by timeout.
-    pub exit_code: Option<i32>,
-    /// True if the command was killed due to timeout.
-    pub timed_out: bool,
-    /// True if the post-exit drain timed out (backgrounded process kept pipes open).
-    /// When true, any available output is still included; use the overflow file path
-    /// from the truncation notice Content block to recover the full output.
-    pub output_truncated: bool,
-    /// Set when the post-exit drain timed out because a background process held the
-    /// pipes open. Distinct from `output_truncated` (size cap) -- this indicates a
-    /// drain timeout rather than a size overflow.
-    pub output_collection_error: Option<String>,
-    /// Path to the slot file containing full stdout (if output was persisted).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stdout_path: Option<String>,
-    /// Path to the slot file containing full stderr (if output was persisted).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stderr_path: Option<String>,
-    /// Description of the filter applied to stdout (if any).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub filter_applied: Option<String>,
-}
-
-impl ShellOutput {
-    /// Creates a new ShellOutput with the given parameters.
-    pub fn new(
-        stdout: String,
-        stderr: String,
-        interleaved: String,
-        exit_code: Option<i32>,
-        timed_out: bool,
-        output_truncated: bool,
-    ) -> Self {
-        Self {
-            stdout,
-            stderr,
-            interleaved,
-            exit_code,
-            timed_out,
-            output_truncated,
-            output_collection_error: None,
-            stdout_path: None,
-            stderr_path: None,
-            filter_applied: None,
-        }
-    }
 }

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -42,6 +42,7 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-appender-tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+schemars = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -32,22 +32,103 @@ pub mod otel;
 mod shell;
 mod validation;
 
-pub use aptu_coder_core::analyze;
-use aptu_coder_core::types::STDIN_MAX_BYTES;
+use aptu_coder_core::analyze;
 use aptu_coder_core::{cache, completion, graph, traversal, types};
 use shell::resolve_shell;
 use validation::{validate_path, validate_path_in_dir};
 
-pub(crate) const EXCLUDED_DIRS: &[&str] = &[
-    "node_modules",
-    "vendor",
-    ".git",
-    "__pycache__",
-    "target",
-    "dist",
-    "build",
-    ".venv",
-];
+pub const STDIN_MAX_BYTES: usize = 1_048_576;
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct ExecCommandParams {
+    /// Shell command to execute via sh -c (or $SHELL if set).
+    pub command: String,
+    /// Timeout in seconds before SIGKILL. None = no timeout (default).
+    pub timeout_secs: Option<u64>,
+    /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
+    pub working_dir: Option<String>,
+    /// Cap on virtual address space in megabytes (Linux only; silently accepted but not enforced on macOS).
+    /// None = no limit (default).
+    pub memory_limit_mb: Option<u64>,
+    /// CPU time limit in seconds. Complements timeout_secs (wall-clock). SIGXCPU on soft-limit breach, SIGKILL on hard-limit breach.
+    /// None = no limit (default).
+    pub cpu_limit_secs: Option<u64>,
+    /// UTF-8 content to pipe into the process stdin (max `STDIN_MAX_BYTES` = 1 MB). When None, stdin is closed (null).
+    pub stdin: Option<String>,
+    /// Enable caching of command results. None or true = enabled (default); false = disabled.
+    /// Caching is skipped if stdin is provided, regardless of this setting.
+    #[serde(default)]
+    pub cache: Option<bool>,
+}
+
+impl ExecCommandParams {
+    /// Creates a new ExecCommandParams with the given command.
+    pub fn new(command: String, timeout_secs: Option<u64>, working_dir: Option<String>) -> Self {
+        Self {
+            command,
+            timeout_secs,
+            working_dir,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct ShellOutput {
+    /// Standard output from the command.
+    pub stdout: String,
+    /// Standard error from the command.
+    pub stderr: String,
+    /// Stdout and stderr interleaved in arrival order.
+    pub interleaved: String,
+    /// Exit code; null if killed by timeout.
+    pub exit_code: Option<i32>,
+    /// True if the command was killed due to timeout.
+    pub timed_out: bool,
+    /// True if the post-exit drain timed out (backgrounded process kept pipes open).
+    /// When true, any available output is still included; use the overflow file path
+    /// from the truncation notice Content block to recover the full output.
+    pub output_truncated: bool,
+    /// Set when the post-exit drain timed out because a background process held the
+    /// pipes open. Distinct from `output_truncated` (size cap) -- this indicates a
+    /// drain timeout rather than a size overflow.
+    pub output_collection_error: Option<String>,
+    /// Path to the slot file containing full stdout (if output was persisted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout_path: Option<String>,
+    /// Path to the slot file containing full stderr (if output was persisted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr_path: Option<String>,
+    /// Description of the filter applied to stdout (if any).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_applied: Option<String>,
+}
+
+impl ShellOutput {
+    /// Creates a new ShellOutput with the given parameters.
+    pub fn new(
+        stdout: String,
+        stderr: String,
+        interleaved: String,
+        exit_code: Option<i32>,
+        timed_out: bool,
+        output_truncated: bool,
+    ) -> Self {
+        Self {
+            stdout,
+            stderr,
+            interleaved,
+            exit_code,
+            timed_out,
+            output_truncated,
+            output_collection_error: None,
+            stdout_path: None,
+            stderr_path: None,
+            filter_applied: None,
+        }
+    }
+}
 
 use aptu_coder_core::cache::{AnalysisCache, CacheTier};
 use aptu_coder_core::formatter::{
@@ -185,17 +266,26 @@ impl<'a> opentelemetry::propagation::Extractor for ExtractMap<'a> {
     }
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ErrorMeta {
+    error_category: &'static str,
+    is_retryable: bool,
+    suggested_action: &'static str,
+}
+
 #[must_use]
 fn error_meta(
     category: &'static str,
     is_retryable: bool,
     suggested_action: &'static str,
 ) -> serde_json::Value {
-    serde_json::json!({
-        "errorCategory": category,
-        "isRetryable": is_retryable,
-        "suggestedAction": suggested_action,
+    serde_json::to_value(ErrorMeta {
+        error_category: category,
+        is_retryable,
+        suggested_action,
     })
+    .unwrap_or_default()
 }
 
 #[must_use]
@@ -2937,7 +3027,7 @@ impl CodeAnalyzer {
         name = "exec_command",
         title = "Exec Command",
         description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; use timeout_secs to limit execution time. working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
-        output_schema = schema_for_type::<types::ShellOutput>(),
+        output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",
             read_only_hint = false,
@@ -2949,7 +3039,7 @@ impl CodeAnalyzer {
     #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, command = tracing::field::Empty, exit_code = tracing::field::Empty, timed_out = tracing::field::Empty, output_truncated = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty))]
     pub async fn exec_command(
         &self,
-        params: Parameters<types::ExecCommandParams>,
+        params: Parameters<ExecCommandParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let t_start = std::time::Instant::now();
@@ -3338,7 +3428,7 @@ async fn run_exec_impl(
     seq: u32,
     resolved_path: Option<&str>,
     filter_table: &Arc<Vec<CompiledRule>>,
-) -> types::ShellOutput {
+) -> ShellOutput {
     // Inject --no-stat for git pull if not already present
     let command = maybe_inject_no_stat(&command);
 
@@ -3354,7 +3444,7 @@ async fn run_exec_impl(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            return types::ShellOutput::new(
+            return ShellOutput::new(
                 String::new(),
                 format!("failed to spawn command: {e}"),
                 format!("failed to spawn command: {e}"),
@@ -3420,7 +3510,7 @@ async fn run_exec_impl(
         handle_output_persist(stdout_str, stderr_str, slot);
     output_truncated = output_truncated || stdout_path.is_some() || byte_truncated;
 
-    let mut output = types::ShellOutput::new(
+    let mut output = ShellOutput::new(
         stdout,
         stderr,
         interleaved_str,
@@ -3602,7 +3692,7 @@ impl ServerHandler for CodeAnalyzer {
     }
 
     fn get_info(&self) -> InitializeResult {
-        let excluded = crate::EXCLUDED_DIRS.join(", ");
+        let excluded = aptu_coder_core::EXCLUDED_DIRS.join(", ");
         let instructions = format!(
             "Recommended workflow:\n\
             1. Start with analyze_directory(path=<repo_root>, max_depth=2, summary=true) to identify source package (largest by file count; exclude {excluded}).\n\
@@ -5103,7 +5193,7 @@ mod tests {
 
         // Sub-case 1: non-zero exit code (exit_code != Some(0))
         // The guard condition fails, so filter_applied must remain None and stdout unchanged
-        let mut output = types::ShellOutput::new(
+        let mut output = ShellOutput::new(
             stdout.to_string(),
             "".to_string(),
             "".to_string(),
@@ -5133,7 +5223,7 @@ mod tests {
 
         // Sub-case 2: zero exit code (exit_code == Some(0))
         // The guard condition passes, so filter_applied is set and stdout is filtered
-        let mut output2 = types::ShellOutput::new(
+        let mut output2 = ShellOutput::new(
             stdout.to_string(),
             "".to_string(),
             "".to_string(),
@@ -5233,7 +5323,7 @@ mod tests {
         );
 
         // Simulate the guard and field assignment from run_exec_impl
-        let mut output = types::ShellOutput::new(
+        let mut output = ShellOutput::new(
             filtered,
             "".to_string(),
             "".to_string(),

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -599,7 +599,7 @@ fn test_handler_output_collection_error() {
     // The field is populated when a post-exit drain timeout fires; that path
     // is difficult to trigger deterministically in an integration test, so we
     // verify the struct-level contract here.
-    use aptu_coder_core::types::ShellOutput;
+    use aptu_coder::ShellOutput;
     let mut output = ShellOutput::new(
         "out".into(),
         "err".into(),


### PR DESCRIPTION
Closes #1034

## Summary

Mechanical cleanup of the `aptu-coder-core` / `aptu-coder` crate boundary per issue #1034. No behavioral changes, no MCP wire-protocol changes.

## Batches implemented

**Batch 1 -- exec-command types moved to server (F1, F11)**
`ExecCommandParams`, `ShellOutput`, and `STDIN_MAX_BYTES` removed from `aptu-coder-core/src/types.rs` and defined locally in the server crate. All `types::ShellOutput` / `types::ExecCommandParams` references in `aptu-coder/src/lib.rs` updated to bare names. Test import in `crates/aptu-coder/tests/exec_command.rs` updated. Downstream consumers of `aptu-coder-core` no longer inherit exec types with no backing implementation.

**Batch 2 -- ErrorMeta consolidated (F2, F10)**
`ErrorMeta` struct and its three self-tests removed from `aptu-coder-core/src/types.rs`. A private typed `ErrorMeta` struct (same fields, same `#[serde(rename_all = "camelCase")]`) added to `aptu-coder/src/lib.rs`. The existing `fn error_meta(...)` helper body now delegates to this struct; all 54 call sites required zero changes. JSON wire shape is identical.

**Batch 3 -- CallGraph visibility and pub(crate) restrictions (F3, F4)**
`find_incoming_chains` and `find_outgoing_chains` changed from `pub(crate)` to `pub` in `graph.rs`; downstream library consumers can now perform BFS traversal. `execute_query_impl` in `parser.rs` changed from `pub` to `pub(crate)` (no external callers, public `execute_query()` wrapper unchanged). `determine_mode` left `pub` (used in core integration tests; not called from server).

**Batch 4 -- re-exports, EXCLUDED_DIRS dedup, pub use analyze (F6, F8, F9)**
`EXCLUDED_DIRS` changed from `pub(crate)` to `pub` in core `lib.rs`; server's duplicate constant removed and its single reference updated to `aptu_coder_core::EXCLUDED_DIRS`. Missing root re-exports added to core `lib.rs`: `GraphError`, `InternalCallChain`, `WalkEntry`, `TraversalError`, `PaginationError`, `CursorData`. `pub use aptu_coder_core::analyze` in server changed to private `use`.

**Batch 5 -- std::os::unix portability guard (F7)**
`#[cfg(unix)]` added to the top-level `use std::os::unix::fs::PermissionsExt` import and to the `set_permissions` call site in `cache.rs`. `test_disk_cache_permissions` wrapped with `#[cfg(unix)]`.

## Out of scope
- `tokio-util` feature-flag (F5): deferred, tracked in #1034.
- `lib.rs` monolith refactor: tracked separately per issue.

## Testing
- `cargo test`: 557 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo deny check advisories licenses`: clean
