### PR TITLE
docs: document filters module, shared test harness, and module ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,11 @@ For richer analysis, use `python scripts/mcp-metrics.py --help`.
 
 ## API verification (critical)
 
-Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. **Read `crates/aptu-coder/src/lib.rs` before adding or modifying any tool** -- it is the authoritative reference for tool handler patterns.
+Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. **Read `crates/aptu-coder/src/lib.rs` before adding or modifying any tool** -- it is the authoritative reference for tool handler patterns. Path validation logic lives in `src/validation.rs`; shell detection in `src/shell.rs`; exec output filtering (built-in rules, project-local `.aptu/filters.toml`, `schema_version` enforcement) in `src/filters.rs`. Read the relevant module before touching those subsystems.
+
+## Integration tests
+
+Integration tests for the `aptu-coder` crate live in `crates/aptu-coder/tests/`. A shared MCP harness in `tests/common/mod.rs` provides `make_test_analyzer()` and `call_tool_raw(tool_name, params)` -- use these in new integration tests rather than duplicating the server setup. `call_tool_raw` spins up a real in-process MCP server over a duplex pipe, runs the full initialize/call/shutdown handshake, and returns the raw JSON response.
 
 ## rmcp footguns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,8 @@ This project follows a Rust adaptation of the [NASA/JPL Power of 10](https://en.
 
 - **Zero warnings:** `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test`, and `cargo deny check` must all pass
 - **Every unsafe block requires a SAFETY comment:** Enforced by `clippy::undocumented_unsafe_blocks = deny` in workspace lints
-- **No `.unwrap()` in production code:** Enforced by `clippy::unwrap_used = "deny"`. Test code is exempted via `#[cfg_attr(test, allow(clippy::unwrap_used))]` at each crate root.
+- **No `.unwrap()` in production code:** Enforced by `clippy::unwrap_used = "deny"`. Test code is exempted via `#[cfg_attr(test, allow(clippy::unwrap_used))]` at each crate root. Use `.expect("reason")` in tests instead of `.unwrap()`.
+- **Shared MCP test harness:** Integration tests for `aptu-coder` live in `crates/aptu-coder/tests/`. Use `make_test_analyzer()` and `call_tool_raw(tool_name, params)` from `tests/common/mod.rs` rather than duplicating server setup. Unit tests for `validation`, `shell`, and `filters` logic live as `#[cfg(test)]` modules in their respective source files.
 - **No unchecked indexing on untrusted data:** Use `.get()` with explicit error propagation instead of `[]`
 - **Loops over untrusted or externally-driven data must have an explicit bound or checked max-iteration guard**
 - **Minimize #[cfg] feature combinations:** Each supported combination must be covered by CI

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,30 +20,33 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 
 | Module | File | Responsibility |
 |--------|------|-----------------|
-| `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing, OTel providers, metrics channel; stdio transport by default, streamable HTTP when `--port N` is passed |
+| **`aptu-coder`** | | |
+| `filters` | `crates/aptu-coder/src/filters.rs` | `exec_command` output filtering: `build_builtin_filter_rules`, `load_filter_table` (built-in + project-local `.aptu/filters.toml`), `apply_filter`, `maybe_inject_no_stat`; `FilterTableConfig` validates `schema_version` on deserialization and falls back to built-in rules on mismatch or parse error |
 | `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command`; exec plumbing (`build_exec_command`, `run_exec_impl`, `handle_output_persist`) |
-| `validation` | `crates/aptu-coder/src/validation.rs` | Path resolution and boundary enforcement: `validate_path` (CWD-relative), `validate_path_in_dir` (working_dir-relative with traversal prevention), `io_error_to_path_error` |
-| `shell` | `crates/aptu-coder/src/shell.rs` | Login shell detection: `resolve_shell` checks `APTU_SHELL` env, then scans `PATH` for `bash`, falls back to `/bin/sh` (Unix) or `cmd` (Windows) |
 | `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients via `notifications/message` |
-| `otel` | `crates/aptu-coder/src/otel.rs` | OpenTelemetry provider initialization; `init_otel` (traces), `init_log_appender` (logs), `init_meter` (metrics); all gated on `OTEL_EXPORTER_OTLP_ENDPOINT`; noop when unset |
-| `schema_helpers` | `crates/aptu-coder-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
+| `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing, OTel providers, metrics channel; stdio transport by default, streamable HTTP when `--port N` is passed |
 | `metrics` | `crates/aptu-coder/src/metrics.rs` | Always-on JSONL metrics: daily-rotating files, `MetricEvent`, `MetricsSender`, `MetricsWriter`; includes `migrate_legacy_metrics_dir` for the `code-analyze-mcp` → `aptu-coder` XDG path migration |
+| `otel` | `crates/aptu-coder/src/otel.rs` | OpenTelemetry provider initialization; `init_otel` (traces), `init_log_appender` (logs), `init_meter` (metrics); all gated on `OTEL_EXPORTER_OTLP_ENDPOINT`; noop when unset |
+| `shell` | `crates/aptu-coder/src/shell.rs` | Login shell detection: `resolve_shell` checks `APTU_SHELL` env, then scans `PATH` for `bash`, falls back to `/bin/sh` (Unix) or `cmd` (Windows) |
+| `validation` | `crates/aptu-coder/src/validation.rs` | Path resolution and boundary enforcement: `validate_path` (CWD-relative), `validate_path_in_dir` (working_dir-relative with traversal prevention), `io_error_to_path_error` |
+| **`aptu-coder-core`** | | |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
-| `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
-| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all seven tools |
-| `traversal` | `crates/aptu-coder-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
-| `types` | `crates/aptu-coder-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
-| `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
-| `languages/mod` | `crates/aptu-coder-core/src/languages/mod.rs` | LanguageInfo registry and handler function types |
-| `languages/rust` | `crates/aptu-coder-core/src/languages/rust.rs` | Rust-specific queries and semantic handlers |
-| `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
-| `languages/fortran` | `crates/aptu-coder-core/src/languages/fortran.rs` | Fortran-specific queries and semantic handlers; supports module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`); registers `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` |
 | `cache` | `crates/aptu-coder-core/src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
-| `test_detection` | `crates/aptu-coder-core/src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |
-| `pagination` | `crates/aptu-coder-core/src/pagination.rs` | Cursor-based pagination with CursorData and PaginationMode (Default, Callers, Callees) |
+| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all seven tools |
 | `graph` | `crates/aptu-coder-core/src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
+| `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
+| `languages/fortran` | `crates/aptu-coder-core/src/languages/fortran.rs` | Fortran-specific queries and semantic handlers; supports module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`); registers `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` |
+| `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
+| `languages/mod` | `crates/aptu-coder-core/src/languages/mod.rs` | LanguageInfo registry and handler function types |
+| `languages/rust` | `crates/aptu-coder-core/src/languages/rust.rs` | Rust-specific queries and semantic handlers |
+| `pagination` | `crates/aptu-coder-core/src/pagination.rs` | Cursor-based pagination with CursorData and PaginationMode (Default, Callers, Callees) |
+| `parser` | `crates/aptu-coder-core/src/parser.rs` | Tree-sitter parsing; ElementExtractor and SemanticExtractor |
+| `schema_helpers` | `crates/aptu-coder-core/src/schema_helpers.rs` | Core JSON Schema helpers for integer and page_size field validation |
+| `test_detection` | `crates/aptu-coder-core/src/test_detection.rs` | Test file detection by path heuristics (directory and filename patterns) |
+| `traversal` | `crates/aptu-coder-core/src/traversal.rs` | Directory walking with .gitignore support via ignore crate |
+| `types` | `crates/aptu-coder-core/src/types.rs` | Shared data structures (`AnalyzeDirectoryParams`, `AnalyzeFileParams`, `AnalyzeModuleParams`, `AnalyzeSymbolParams`, `AnalysisResult`, etc.) |
 
 ## Data Flow
 


### PR DESCRIPTION
## Summary

Documentation catch-up for work merged today (post-v0.16.1): module extraction refactor (#1030), filters schema_version fix (#1029), shared MCP test harness (#1032).

## Changes

- **`docs/ARCHITECTURE.md`**: Add `filters` module row to the module map (`build_builtin_filter_rules`, `load_filter_table`, `apply_filter`, `maybe_inject_no_stat`; `FilterTableConfig` schema_version validation and fallback behaviour).
- **`AGENTS.md`**: Extend the API verification section to point agents at `validation.rs`, `shell.rs`, and `filters.rs` as authoritative for those subsystems. Add "Integration tests" section documenting `tests/common/mod.rs`, `make_test_analyzer()`, and `call_tool_raw()`.
- **`CONTRIBUTING.md`**: Note `.expect("reason")` as the test idiom; add shared MCP harness pattern and location of unit tests for `validation`, `shell`, and `filters`.

## Verification

- [ ] No code changes; docs only
- [ ] `cargo fmt --check` not applicable
- [ ] Content matches current source (`filters.rs`, `shell.rs`, `validation.rs`, `tests/common/mod.rs`)

Closes #1036
