### PR TITLE
chore: bump version to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version from `0.16.1` to `0.16.2` ahead of the patch release.

## Changes since v0.16.1

### Bug Fixes

- **`schema_version` validated after deserialization in `FilterTableConfig`** (#1029): Invalid or missing `schema_version` fields in `.aptu/filters.toml` are now caught immediately on load with a clear error rather than silently accepted.

### Refactors & Cleanup

- **Extract `validation`, `shell`, and unit tests from `lib.rs`** (#1030, closes #1024): `lib.rs` split into focused modules; shell detection, path validation, and their tests now live in dedicated files.
- **Remove unused dependencies and stale lint suppressions** (#1026, closes #1019, #1020): Dropped the `which` crate (replaced by stdlib PATH scan), removed phantom `allow` attributes.
- **Fix crate boundary leaks, visibility gaps, and duplicates** (#1035): Corrected `pub` surface area in `aptu-coder-core`; removed duplicate type definitions.

### Tests

- **Replace hollow placeholder tests with real integration tests** (#1032): Integration tests now spin up an in-process MCP server via the shared harness and exercise full tool call round-trips.
- **Remove redundant empty-file tests; fix `MutexGuard` held across await** (#1027, closes #1021): Eliminated duplicate coverage; fixed a latent deadlock hazard in async test setup.

### Documentation

- **Document filters module, shared test harness, and module ownership** (#1036)
- **Document interleaved filter fix and `schema_version` fallback in README** (#1033)
- **Add June 2026 dependency and code quality audit** (#1025)

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.16.1...v0.16.2
