### PR TITLE
fix(exec_command): remove non-functional cache scaffolding and make metrics honest

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3114,15 +3114,7 @@ impl CodeAnalyzer {
         let command = params.command.clone();
         let timeout_secs = params.timeout_secs;
 
-        // Determine cache key and whether to use cache
-        let _cache_key = (
-            command.clone(),
-            working_dir_path
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_default(),
-        );
-        // Execute command (caching disabled; explicit opt-in via cache=true not implemented)
+        // Execute command (non-cacheable; exec_command is side-effecting and non-idempotent)
         let resolved_path_str = self.resolved_path.as_ref().as_deref();
         let output = run_exec_impl(
             command.clone(),
@@ -3229,7 +3221,7 @@ impl CodeAnalyzer {
                     error_type: Some("internal_error".to_string()),
                     session_id: sid.clone(),
                     seq: Some(seq),
-                    cache_hit: Some(false),
+                    cache_hit: None,
                     cache_write_failure: None,
                     cache_tier: None,
                     exit_code,
@@ -3257,7 +3249,7 @@ impl CodeAnalyzer {
             error_subtype: None,
             session_id: sid,
             seq: Some(seq),
-            cache_hit: Some(false),
+            cache_hit: None,
             cache_write_failure: None,
             cache_tier: None,
             exit_code,

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -654,24 +654,36 @@ async fn test_exec_cache_hit_on_sequential_repeat() {
     let sc1 = &resp1["result"]["structuredContent"];
     let stdout1 = sc1["stdout"].as_str().unwrap_or("").to_string();
 
-    // Second call should hit the cache (same command, no stdin)
+    // Second call executes independently (exec_command is non-cacheable)
     let resp2 = call_exec_command_raw(params2).await;
     let sc2 = &resp2["result"]["structuredContent"];
     let stdout2 = sc2["stdout"].as_str().unwrap_or("").to_string();
 
-    // Assert: both calls succeeded and returned the same output
+    // Assert: both calls succeeded with identical output (both ran the command)
     assert_eq!(sc1["exit_code"], 0, "first call should succeed: {sc1}");
     assert_eq!(sc2["exit_code"], 0, "second call should succeed: {sc2}");
-    assert_eq!(stdout1, stdout2, "cached output should match original");
+    assert_eq!(
+        stdout1, stdout2,
+        "both calls should produce the same output"
+    );
     assert!(
         stdout1.contains("cache_test_123"),
         "output should contain the echo string"
+    );
+    // Assert: cache_hit is absent (exec_command is non-cacheable)
+    assert!(
+        sc1["cache_hit"].is_null(),
+        "cache_hit must be absent for exec_command: {sc1}"
+    );
+    assert!(
+        sc2["cache_hit"].is_null(),
+        "cache_hit must be absent for exec_command: {sc2}"
     );
 }
 
 #[tokio::test]
 async fn test_exec_cache_skipped_with_stdin() {
-    // Arrange: run a command with stdin (should bypass cache)
+    // Arrange: run a command with stdin
     let cmd = "cat";
     let stdin_content = "test_stdin_data";
     let params = serde_json::json!({
@@ -692,6 +704,11 @@ async fn test_exec_cache_skipped_with_stdin() {
             .contains("test_stdin_data"),
         "stdout should contain the stdin content: {sc}"
     );
+    // Assert: cache_hit is absent (exec_command is non-cacheable regardless of stdin)
+    assert!(
+        sc["cache_hit"].is_null(),
+        "cache_hit must be absent for exec_command with stdin: {sc}"
+    );
 }
 
 #[tokio::test]
@@ -705,36 +722,23 @@ async fn test_exec_cache_not_populated_on_failure() {
     let resp1 = call_exec_command_raw(params1).await;
     let sc1 = &resp1["result"]["structuredContent"];
 
-    // Second call should re-execute (not cached because first failed)
+    // Second call re-executes independently
     let resp2 = call_exec_command_raw(params2).await;
     let sc2 = &resp2["result"]["structuredContent"];
 
-    // Assert: both calls failed (non-zero exit)
+    // Assert: both calls failed (non-zero exit) and cache_hit is absent
     assert_ne!(sc1["exit_code"], 0, "false command should fail: {sc1}");
     assert_ne!(
         sc2["exit_code"], 0,
         "false command should fail on second call too: {sc2}"
     );
-}
-
-#[tokio::test]
-async fn test_exec_cache_bypassed_with_false_param() {
-    // Arrange: run a command with cache: false parameter
-    let cmd = "echo bypass_cache";
-    let params = serde_json::json!({
-        "command": cmd,
-        "cache": false
-    });
-
-    // Act: call with cache disabled
-    let resp = call_exec_command_raw(params).await;
-    let sc = &resp["result"]["structuredContent"];
-
-    // Assert: command executed successfully
-    assert_eq!(sc["exit_code"], 0, "command should succeed: {sc}");
     assert!(
-        sc["stdout"].as_str().unwrap_or("").contains("bypass_cache"),
-        "output should contain the echo string: {sc}"
+        sc1["cache_hit"].is_null(),
+        "cache_hit must be absent for failing exec_command: {sc1}"
+    );
+    assert!(
+        sc2["cache_hit"].is_null(),
+        "cache_hit must be absent for failing exec_command: {sc2}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1039.

`exec_command` advertised cache behavior (`cache: Option<bool>` parameter documented as default-enabled) but caching was never implemented. The handler computed `_cache_key` then ignored it, always emitting `cache_hit: Some(false)`. Local metrics showed 56,589 cacheable calls and 0 hits.

## Changes

- **`crates/aptu-coder/src/lib.rs`**: Removed `cache: Option<bool>` field and its doc comment from `ExecCommandParams`. Deleted dead `_cache_key` computation and disabled-cache comment. Changed both `cache_hit: Some(false)` metric emissions (success path and error path) to `cache_hit: None`.
- **`crates/aptu-coder/tests/exec_command.rs`**: Rewrote three cache tests (`test_exec_cache_hit_on_sequential_repeat`, `test_exec_cache_skipped_with_stdin`, `test_exec_cache_not_populated_on_failure`) to assert `cache_hit` is absent. Deleted `test_exec_cache_bypassed_with_false_param` (parameter no longer exists).

## Rationale

`exec_command` runs arbitrary shell commands which are non-idempotent and side-effecting (`git clone`, `rm -rf`, etc.). Caching without runtime determinism validation would be unsafe. Approach B (remove scaffolding) was selected over Approach A (restore cache) because:

1. No runtime guard can prevent a caller from setting `cache=true` on a side-effecting command
2. The parameter was `Option<bool>` with `None or true = enabled (default)` -- a dangerous default
3. Removing unused scaffolding is strictly safer than enabling it

If a safe opt-in cache for deterministic read-only commands is needed in the future, it can be added as a dedicated feature with explicit allowlisting and determinism assertions.

## Testing

- 545 tests pass: `cargo test`
- No clippy warnings: `cargo clippy -- -D warnings`
- Formatted: `cargo fmt --check`
- No new dependencies
