### PR TITLE
refactor(core): eliminate double reads and record exec filters

### DIFF
--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -150,6 +150,7 @@ impl FileAnalysisOutput {
     }
 }
 /// Reason a file was skipped during eligibility check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SkipReason {
     Oversized,
     Unreadable,

--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -149,16 +149,24 @@ impl FileAnalysisOutput {
         }
     }
 }
-/// Check if a file is eligible for analysis based on size and language support.
-fn check_file_eligibility(entry: &WalkEntry) -> bool {
+/// Reason a file was skipped during eligibility check.
+enum SkipReason {
+    Oversized,
+    Unreadable,
+}
+
+/// Check if a file is eligible for analysis based on size and readability.
+///
+/// Returns `Ok(content)` when the file should be analyzed, `Err(reason)` to skip it.
+fn check_file_eligibility(entry: &WalkEntry) -> Result<String, SkipReason> {
     // Check file size before reading
     if entry.path.metadata().map(|m| m.len()).unwrap_or(0) > MAX_FILE_SIZE_BYTES {
         tracing::debug!("skipping large file: {}", entry.path.display());
-        return false;
+        return Err(SkipReason::Oversized);
     }
 
     // Try to read file content; skip binary or unreadable files
-    std::fs::read_to_string(&entry.path).is_ok()
+    std::fs::read_to_string(&entry.path).map_err(|_| SkipReason::Unreadable)
 }
 
 /// Process a single file entry and extract its analysis data.
@@ -205,16 +213,13 @@ fn analyze_single_file(
         return None;
     }
 
-    // Check file eligibility
-    if !check_file_eligibility(entry) {
-        progress.fetch_add(1, Ordering::Relaxed);
-        return None;
-    }
-
-    // Read file content (already checked in check_file_eligibility)
-    let Ok(source) = std::fs::read_to_string(&entry.path) else {
-        progress.fetch_add(1, Ordering::Relaxed);
-        return None;
+    // Check file eligibility; progress accounting happens on all exit paths below
+    let source = match check_file_eligibility(entry) {
+        Ok(content) => content,
+        Err(_) => {
+            progress.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
     };
 
     let file_info = process_file_entry(entry, &source);

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3257,6 +3257,7 @@ impl CodeAnalyzer {
             output_truncated: Some(output_truncated),
             chars_threshold_breach: text.len() > 30_000,
             file_ext: None,
+            filter_applied: output.filter_applied.clone(),
         });
         Ok(result)
     }
@@ -5735,6 +5736,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: output_chars > 30_000,
             file_ext: None,
+            filter_applied: None,
         };
         assert!(
             event.chars_threshold_breach,
@@ -5766,6 +5768,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: output_chars > 30_000,
             file_ext: None,
+            filter_applied: None,
         };
         assert!(
             !event.chars_threshold_breach,

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -57,6 +57,10 @@ pub struct MetricEvent {
     /// Only populated for `analyze_file` and `analyze_module`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file_ext: Option<&'static str>,
+    /// Name of the filter rule that matched and transformed exec_command output.
+    /// `None` when no filter fired or for non-`exec_command` tools.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter_applied: Option<String>,
 }
 
 /// Sender half of the metrics channel; cloned and passed to tools for event emission.
@@ -574,6 +578,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         tx.send(make_event()).unwrap();
         tx.send(make_event()).unwrap();
@@ -632,6 +637,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("analyze_directory"));
@@ -663,6 +669,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""result":"error""#));
@@ -694,6 +701,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""error_subtype":"not_found""#));
@@ -721,6 +729,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""error_subtype":"ambiguous""#));
@@ -748,6 +757,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         };
         let serialized = serde_json::to_string(&event).unwrap();
         let json_str = r#"{"ts":1700000000000,"tool":"analyze_file","duration_ms":100,"output_chars":500,"param_path_depth":2,"max_depth":3,"result":"ok","error_type":null,"session_id":"1742468880123-42","seq":5}"#;
@@ -821,6 +831,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         })
         .unwrap();
         tx.send(MetricEvent {
@@ -843,6 +854,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         })
         .unwrap();
         drop(tx);
@@ -930,6 +942,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         })
         .unwrap();
         drop(tx);
@@ -992,6 +1005,7 @@ mod tests {
             output_truncated: None,
             chars_threshold_breach: false,
             file_ext: None,
+            filter_applied: None,
         })
         .unwrap();
         drop(tx);

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -44,7 +44,7 @@ Each line in the JSONL file is one JSON object:
 | `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable |
 | `timed_out` | `bool` | `true` if the call timed out; `false` otherwise |
 | `output_truncated` | `bool \| null` | `true` if any truncation occurred (line cap, per-stream byte cap, or combined cap); `false` if the command completed without truncation; `null` for all non-`exec_command` tools and for `exec_command` calls emitted by older server versions |
-| `filter_applied` | `string \| null` | Name of the filter rule that matched and transformed the output (e.g., `"git pull"`, `"cargo build"`); `null` when no filter fired or for non-`exec_command` tools. Present in `structuredContent` only; not recorded in JSONL. |
+| `filter_applied` | `string \| null` | Name of the filter rule that matched and transformed the output (e.g., `"git pull"`, `"cargo build"`); `null` when no filter fired or for non-`exec_command` tools. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
 | `chars_threshold_breach` | `bool` | `true` when `output_chars > 30,000`; fires for the top ~0.33% of `exec_command` calls (p99.7 of 27,981 observed calls). Early-warning signal for responses approaching the per-stream byte-cap threshold (MAX_STDOUT_BYTES = 30,000). Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`); defaults to `false` on parse for backward compatibility. |
 
 ### Example record
@@ -63,6 +63,7 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 | `seq` | early | `null` |
 | `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
 | `chars_threshold_breach` | current | `false` (omitted from JSONL when false; safe to query with `// false`) |
+| `filter_applied` | current | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
 
 The five jq one-liners in `AGENTS.md` do not reference `output_truncated` and are unaffected. To query truncation events across all retained JSONL files:
 


### PR DESCRIPTION
Three independent refactors to improve core analysis and metrics infrastructure.

## Changes

### #1041 - Eliminate double filesystem read in directory analysis

Refactored `check_file_eligibility` to return `Result<String, SkipReason>` with the pre-loaded file content, eliminating a redundant `read_to_string` call per eligible file. The function now checks metadata size first, then reads and returns `Ok(content)` or `Err(reason)`. Updated `analyze_single_file` to consume the pre-loaded string directly and call `progress.fetch_add` exactly once on all exit paths. Added `#[derive(Debug, Clone, Copy, PartialEq, Eq)]` to `SkipReason` per inline review suggestion.

### #1042 - Record exec_command filter application in JSONL metrics

Added `filter_applied: Option<String>` to `MetricEvent` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, matching the existing pattern for optional fields (`cache_hit`, `exit_code`, `output_truncated`). Populated from `ShellOutput.filter_applied` in both the success and error branches of the exec_command metric emission path. Updated `docs/OBSERVABILITY.md` schema table to document the field and removed the stale note claiming it is absent from JSONL.

### #1043 - Tool description audit

Reviewed all MCP tool description strings in `lib.rs`. Descriptions already contain only routing guidance and lightweight/heavy distinctions with no duplicated prose already enforced by JSON schema. No changes required.

## Test plan

- `cargo test`: 545 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean

Closes #1041
Closes #1042
Closes #1043
