### PR TITLE
feat(analyze_file): project SemanticAnalysis in structuredContent when fields is set

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -546,6 +546,57 @@ impl SemanticAnalysis {
             def_use_sites: Vec::new(),
         }
     }
+
+    /// Return a filtered copy of this `SemanticAnalysis` based on the requested field set.
+    ///
+    /// - `None` (or a slice containing `AnalyzeFileField::All`) returns a full clone.
+    /// - Otherwise each of `functions`, `classes`, and `imports` is populated only when the
+    ///   corresponding `AnalyzeFileField` variant is present in `fields`.
+    /// - All other fields (`references`, `call_frequency`, `calls`, `impl_traits`,
+    ///   `def_use_sites`) are always preserved unchanged.
+    #[must_use]
+    pub fn project(&self, fields: Option<&[AnalyzeFileField]>) -> Self {
+        let Some(fields) = fields else {
+            return self.clone();
+        };
+        if fields.iter().any(|f| matches!(f, AnalyzeFileField::All)) {
+            return self.clone();
+        }
+        let functions = if fields
+            .iter()
+            .any(|f| matches!(f, AnalyzeFileField::Functions))
+        {
+            self.functions.clone()
+        } else {
+            Vec::new()
+        };
+        let classes = if fields
+            .iter()
+            .any(|f| matches!(f, AnalyzeFileField::Classes))
+        {
+            self.classes.clone()
+        } else {
+            Vec::new()
+        };
+        let imports = if fields
+            .iter()
+            .any(|f| matches!(f, AnalyzeFileField::Imports))
+        {
+            self.imports.clone()
+        } else {
+            Vec::new()
+        };
+        Self {
+            functions,
+            classes,
+            imports,
+            references: self.references.clone(),
+            call_frequency: self.call_frequency.clone(),
+            calls: self.calls.clone(),
+            impl_traits: self.impl_traits.clone(),
+            def_use_sites: self.def_use_sites.clone(),
+        }
+    }
 }
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -559,37 +559,43 @@ impl SemanticAnalysis {
         let Some(fields) = fields else {
             return self.clone();
         };
-        if fields.iter().any(|f| matches!(f, AnalyzeFileField::All)) {
+
+        // Single pass: derive a presence bitmask so each variant is checked exactly once.
+        let mut want_all = false;
+        let mut want_functions = false;
+        let mut want_classes = false;
+        let mut want_imports = false;
+        for f in fields {
+            match f {
+                AnalyzeFileField::All => {
+                    want_all = true;
+                    break;
+                }
+                AnalyzeFileField::Functions => want_functions = true,
+                AnalyzeFileField::Classes => want_classes = true,
+                AnalyzeFileField::Imports => want_imports = true,
+            }
+        }
+        if want_all {
             return self.clone();
         }
-        let functions = if fields
-            .iter()
-            .any(|f| matches!(f, AnalyzeFileField::Functions))
-        {
-            self.functions.clone()
-        } else {
-            Vec::new()
-        };
-        let classes = if fields
-            .iter()
-            .any(|f| matches!(f, AnalyzeFileField::Classes))
-        {
-            self.classes.clone()
-        } else {
-            Vec::new()
-        };
-        let imports = if fields
-            .iter()
-            .any(|f| matches!(f, AnalyzeFileField::Imports))
-        {
-            self.imports.clone()
-        } else {
-            Vec::new()
-        };
+
         Self {
-            functions,
-            classes,
-            imports,
+            functions: if want_functions {
+                self.functions.clone()
+            } else {
+                Vec::new()
+            },
+            classes: if want_classes {
+                self.classes.clone()
+            } else {
+                Vec::new()
+            },
+            imports: if want_imports {
+                self.imports.clone()
+            } else {
+                Vec::new()
+            },
             references: self.references.clone(),
             call_frequency: self.call_frequency.clone(),
             calls: self.calls.clone(),

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1731,10 +1731,10 @@ impl CodeAnalyzer {
             final_text.push_str(cursor);
         }
 
-        // Build the response output, sharing SemanticAnalysis from the Arc to avoid cloning it.
+        // Build the response output, projecting SemanticAnalysis to only the requested sections.
         let response_output = analyze::FileAnalysisOutput::new(
             formatted,
-            arc_output.semantic.clone(),
+            arc_output.semantic.project(params.fields.as_deref()),
             line_count,
             next_cursor,
         );

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -211,3 +211,234 @@ async fn test_analyze_module_moduleonly_cache_tier_metrics() {
         "second call output must contain function 'hello'; got: {text2}"
     );
 }
+
+#[tokio::test]
+async fn test_fields_functions_only_structured() {
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    // Arrange: temp Rust file with functions, a class, and an import
+    let cwd = std::env::current_dir().unwrap();
+    let mut f = NamedTempFile::with_suffix_in(".rs", &cwd).unwrap();
+    writeln!(
+        f,
+        "use std::collections::HashMap;\npub struct Foo {{}}\nimpl Foo {{\n    pub fn bar(&self) {{}}\n}}\npub fn baz() {{}}\n"
+    )
+    .unwrap();
+
+    // Act: analyze_file with fields=[functions]
+    let resp = call_tool_raw(
+        "analyze_file",
+        serde_json::json!({
+            "path": f.path().to_str().unwrap(),
+            "ast_recursion_limit": null,
+            "page_size": null,
+            "fields": ["functions"]
+        }),
+    )
+    .await;
+
+    // Assert: no error
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success; got: {resp}"
+    );
+
+    // Inspect structuredContent.semantic
+    let sc = &resp["result"]["structuredContent"];
+    let functions = sc["semantic"]["functions"]
+        .as_array()
+        .expect("functions must be array");
+    let classes = sc["semantic"]["classes"]
+        .as_array()
+        .expect("classes must be array");
+    let imports = sc["semantic"]["imports"]
+        .as_array()
+        .expect("imports must be array");
+
+    assert!(
+        !functions.is_empty(),
+        "functions must be non-empty for fields=[functions]; got: {sc}"
+    );
+    assert!(
+        classes.is_empty(),
+        "classes must be empty for fields=[functions]; got: {sc}"
+    );
+    assert!(
+        imports.is_empty(),
+        "imports must be empty for fields=[functions]; got: {sc}"
+    );
+}
+
+#[tokio::test]
+async fn test_fields_classes_only_structured() {
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    // Arrange: temp Rust file with functions, a class, and an import
+    let cwd = std::env::current_dir().unwrap();
+    let mut f = NamedTempFile::with_suffix_in(".rs", &cwd).unwrap();
+    writeln!(
+        f,
+        "use std::collections::HashMap;\npub struct Foo {{}}\nimpl Foo {{\n    pub fn bar(&self) {{}}\n}}\npub fn baz() {{}}\n"
+    )
+    .unwrap();
+
+    // Act: analyze_file with fields=[classes]
+    let resp = call_tool_raw(
+        "analyze_file",
+        serde_json::json!({
+            "path": f.path().to_str().unwrap(),
+            "ast_recursion_limit": null,
+            "page_size": null,
+            "fields": ["classes"]
+        }),
+    )
+    .await;
+
+    // Assert: no error
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success; got: {resp}"
+    );
+
+    // Inspect structuredContent.semantic
+    let sc = &resp["result"]["structuredContent"];
+    let functions = sc["semantic"]["functions"]
+        .as_array()
+        .expect("functions must be array");
+    let classes = sc["semantic"]["classes"]
+        .as_array()
+        .expect("classes must be array");
+    let imports = sc["semantic"]["imports"]
+        .as_array()
+        .expect("imports must be array");
+
+    assert!(
+        functions.is_empty(),
+        "functions must be empty for fields=[classes]; got: {sc}"
+    );
+    assert!(
+        !classes.is_empty(),
+        "classes must be non-empty for fields=[classes]; got: {sc}"
+    );
+    assert!(
+        imports.is_empty(),
+        "imports must be empty for fields=[classes]; got: {sc}"
+    );
+}
+
+#[tokio::test]
+async fn test_fields_imports_only_structured() {
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    // Arrange: temp Rust file with functions, a class, and an import
+    let cwd = std::env::current_dir().unwrap();
+    let mut f = NamedTempFile::with_suffix_in(".rs", &cwd).unwrap();
+    writeln!(
+        f,
+        "use std::collections::HashMap;\npub struct Foo {{}}\nimpl Foo {{\n    pub fn bar(&self) {{}}\n}}\npub fn baz() {{}}\n"
+    )
+    .unwrap();
+
+    // Act: analyze_file with fields=[imports]
+    let resp = call_tool_raw(
+        "analyze_file",
+        serde_json::json!({
+            "path": f.path().to_str().unwrap(),
+            "ast_recursion_limit": null,
+            "page_size": null,
+            "fields": ["imports"]
+        }),
+    )
+    .await;
+
+    // Assert: no error
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success; got: {resp}"
+    );
+
+    // Inspect structuredContent.semantic
+    let sc = &resp["result"]["structuredContent"];
+    let functions = sc["semantic"]["functions"]
+        .as_array()
+        .expect("functions must be array");
+    let classes = sc["semantic"]["classes"]
+        .as_array()
+        .expect("classes must be array");
+    let imports = sc["semantic"]["imports"]
+        .as_array()
+        .expect("imports must be array");
+
+    assert!(
+        functions.is_empty(),
+        "functions must be empty for fields=[imports]; got: {sc}"
+    );
+    assert!(
+        classes.is_empty(),
+        "classes must be empty for fields=[imports]; got: {sc}"
+    );
+    assert!(
+        !imports.is_empty(),
+        "imports must be non-empty for fields=[imports]; got: {sc}"
+    );
+}
+
+#[tokio::test]
+async fn test_fields_none_structured_full() {
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    // Arrange: temp Rust file with functions, a class, and an import
+    let cwd = std::env::current_dir().unwrap();
+    let mut f = NamedTempFile::with_suffix_in(".rs", &cwd).unwrap();
+    writeln!(
+        f,
+        "use std::collections::HashMap;\npub struct Foo {{}}\nimpl Foo {{\n    pub fn bar(&self) {{}}\n}}\npub fn baz() {{}}\n"
+    )
+    .unwrap();
+
+    // Act: analyze_file with fields=None (no projection)
+    let resp = call_tool_raw(
+        "analyze_file",
+        serde_json::json!({
+            "path": f.path().to_str().unwrap(),
+            "ast_recursion_limit": null,
+            "page_size": null
+        }),
+    )
+    .await;
+
+    // Assert: no error
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success; got: {resp}"
+    );
+
+    // Inspect structuredContent.semantic -- all sections must be present (regression)
+    let sc = &resp["result"]["structuredContent"];
+    let functions = sc["semantic"]["functions"]
+        .as_array()
+        .expect("functions must be array");
+    let classes = sc["semantic"]["classes"]
+        .as_array()
+        .expect("classes must be array");
+    let imports = sc["semantic"]["imports"]
+        .as_array()
+        .expect("imports must be array");
+
+    assert!(
+        !functions.is_empty(),
+        "functions must be non-empty when fields=None; got: {sc}"
+    );
+    assert!(
+        !classes.is_empty(),
+        "classes must be non-empty when fields=None; got: {sc}"
+    );
+    assert!(
+        !imports.is_empty(),
+        "imports must be non-empty when fields=None; got: {sc}"
+    );
+}


### PR DESCRIPTION
## Summary

Project `SemanticAnalysis` in `structuredContent` when `fields=[...]` is specified on `analyze_file`, so that structured payloads are reduced to match the text projection.

## Changes

- `crates/aptu-coder-core/src/types.rs`: Add `SemanticAnalysis::project(fields: Option<&[AnalyzeFileField]>) -> Self` method. Returns `self.clone()` when `fields` is `None` or contains `All`; otherwise zeroes `functions`, `classes`, and `imports` arrays for unselected variants. All other fields (`references`, `calls`, `impl_traits`, `def_use_sites`, `call_frequency`) are always preserved.
- `crates/aptu-coder/src/lib.rs`: Replace `arc_output.semantic.clone()` with `arc_output.semantic.project(params.fields.as_deref())` before `FileAnalysisOutput::new()`.
- `crates/aptu-coder/tests/integration_tests.rs`: Add 4 integration tests that inspect `structuredContent.semantic` arrays for each projection variant and the `fields=None` regression.

## Acceptance Criteria

- [x] `fields=["functions"]` reduces classes and imports to `[]` in `structuredContent`
- [x] Existing clients receive schema-conformant structured output (empty arrays are valid per schema)
- [x] Full structured output remains available when no projection is requested
- [x] Text output behavior unchanged
- [x] All tests pass: `cargo test`
- [x] No clippy warnings: `cargo clippy -- -D warnings`
- [x] Code formatted: `cargo fmt --check`
- [x] No `unwrap()`, `expect()`, or `println!` in library code
- [x] Commit GPG signed and DCO signed-off

Closes #1045
