### PR TITLE
refactor(exec_command): remove dead cache field from ExecCommandParams

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -56,10 +56,6 @@ pub struct ExecCommandParams {
     pub cpu_limit_secs: Option<u64>,
     /// UTF-8 content to pipe into the process stdin (max `STDIN_MAX_BYTES` = 1 MB). When None, stdin is closed (null).
     pub stdin: Option<String>,
-    /// Enable caching of command results. None or true = enabled (default); false = disabled.
-    /// Caching is skipped if stdin is provided, regardless of this setting.
-    #[serde(default)]
-    pub cache: Option<bool>,
 }
 
 impl ExecCommandParams {

--- a/docs/audit/2026-06-performance-token-efficiency.md
+++ b/docs/audit/2026-06-performance-token-efficiency.md
@@ -63,7 +63,7 @@ Observed cache impact:
 
 | ID | Severity | Type | Finding | Issue | Status |
 |---|---|---|---|---|---|
-| F1 | High | Bug | `exec_command` cache behavior is documented but inactive | [#1039](https://github.com/clouatre-labs/aptu-coder/issues/1039) | Open |
+| F1 | High | Bug | `exec_command` cache behavior is documented but inactive | [#1039](https://github.com/clouatre-labs/aptu-coder/issues/1039) | Closed |
 | F2 | High | Refactor | `analyze_module` does full file analysis instead of the existing module fast path | [#1046](https://github.com/clouatre-labs/aptu-coder/issues/1046) | Open |
 | F3 | High | Refactor | Shallow `analyze_directory` still performs an unbounded tree walk | [#1044](https://github.com/clouatre-labs/aptu-coder/issues/1044) | Open |
 | F4 | Medium | Refactor | Directory analysis reads eligible files twice | [#1041](https://github.com/clouatre-labs/aptu-coder/issues/1041) | Open |


### PR DESCRIPTION
## Summary

Remove the dead `cache: Option<bool>` field from `ExecCommandParams`. The field was documented as default-enabled but was never read by the handler. Commit 332244d (#1049) already removed the dead `_cache_key` computation and made metrics honest (`cache_hit: None`). This completes the cleanup by removing the struct field itself.

Also marks audit doc finding F1 as Closed.

## Changes

- `crates/aptu-coder/src/lib.rs`: remove 2-line doc-comment, `#[serde(default)]`, and `pub cache: Option<bool>` from `ExecCommandParams`
- `docs/audit/2026-06-performance-token-efficiency.md`: F1 row Status: Open -> Closed

## Testing

- `cargo test`: 557 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean

Closes #1054
