### PR TITLE
chore: bump version to 0.16.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Patch release fixing `analyze_directory` to return the documented tree-view output by default. The tool was unconditionally overwriting the initial tree output with a flat paginated list whenever `summary` was unset, and the auto-summary threshold (50,000 chars) never fired in practice across 684 real calls. Agents were receiving a flat list despite the tool description claiming "Tree-view". No breaking changes to public tool APIs or structured output schemas.

## What's Changed

### Bug Fixes

- **Fix `analyze_directory` to return tree output by default; lower auto-summary threshold to 5K chars** (#1058, closes #1057): `SIZE_LIMIT` lowered from `50_000` to `5_000` chars (~150 files at depth=2). Handler conditional rewritten so `summary=None` with output ≤5000 chars returns `format_structure` (tree), `summary=None` with output >5000 chars returns `format_summary` (compact auto), `summary=Some(true)` returns `format_summary`, and `summary=Some(false)` returns `format_structure_paginated` (flat, cursor-paginated, now explicitly opt-in). Tool description updated to accurately reflect default behavior. Fixed `test_handle_overview_mode_verbose_no_summary_block` which was asserting the old buggy flat-list output. Added `test_analyze_directory_summary_false_forces_pagination` edge-case test.

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.16.3...v0.16.4
