### PR TITLE
feat(lang): add Markdown language support and HTML extension stubs (#969)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -2342,6 +2343,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tree-sitter-python = "0.25.0"
 tree-sitter-typescript = "0.23.2"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-fortran = "0.6.0"
+tree-sitter-md = "0.5.3"
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-client"] }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ All languages are enabled by default. Disable individual languages at compile ti
 | JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
 | C/C++ | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` | `lang-cpp` |
 | C# | `.cs` | `lang-csharp` |
+| Markdown | `.md`, `.mdx` | `lang-markdown` |
+| HTML | `.html`, `.htm` | `lang-html` (stub; no extraction) |
 
 ## Installation
 

--- a/crates/aptu-coder-core/Cargo.toml
+++ b/crates/aptu-coder-core/Cargo.toml
@@ -21,7 +21,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["lang-rust", "lang-go", "lang-java", "lang-kotlin", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"]
+default = ["lang-rust", "lang-go", "lang-java", "lang-kotlin", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp", "lang-markdown"]
 schemars = ["dep:schemars"]
 lang-rust = ["dep:tree-sitter-rust"]
 lang-go = ["dep:tree-sitter-go"]
@@ -34,6 +34,8 @@ lang-javascript = ["dep:tree-sitter-javascript"]
 lang-tsx = ["dep:tree-sitter-typescript"]
 lang-fortran = ["dep:tree-sitter-fortran"]
 lang-csharp = ["dep:tree-sitter-c-sharp"]
+lang-markdown = ["dep:tree-sitter-md"]
+lang-html = []
 
 [dependencies]
 tree-sitter = { workspace = true }
@@ -59,6 +61,7 @@ tree-sitter-python = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-fortran = { workspace = true, optional = true }
+tree-sitter-md = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/aptu-coder-core/src/lang.rs
+++ b/crates/aptu-coder-core/src/lang.rs
@@ -59,13 +59,22 @@ const EXTENSION_MAP: &[(&str, &str)] = &[
     ("ts", "typescript"),
     #[cfg(feature = "lang-tsx")]
     ("tsx", "tsx"),
+    #[cfg(feature = "lang-html")]
+    ("html", "html"),
+    #[cfg(feature = "lang-html")]
+    ("htm", "html"),
+    #[cfg(feature = "lang-markdown")]
+    ("md", "markdown"),
+    #[cfg(feature = "lang-markdown")]
+    ("mdx", "markdown"),
 ];
 
 /// Returns the language identifier for the given file extension, or `None` if unsupported.
 ///
 /// The lookup is case-insensitive. Supported extensions include `rs`, `py`, `go`, `java`,
 /// `ts`, `tsx`, `js`, `mjs`, `cjs`, `c`, `cc`, `cpp`, `cxx`, `h`, `hpp`, `hxx`, `cs`,
-/// and Fortran variants `f`, `f77`, `f90`, `f95`, `f03`, `f08`, `for`, `ftn`.
+/// Fortran variants `f`, `f77`, `f90`, `f95`, `f03`, `f08`, `for`, `ftn`,
+/// HTML variants `html`, `htm`, and Markdown variants `md`, `mdx`.
 #[must_use]
 pub fn language_for_extension(ext: &str) -> Option<&'static str> {
     EXTENSION_MAP
@@ -114,6 +123,10 @@ pub fn supported_languages() -> &'static [&'static str] {
         "cpp",
         #[cfg(feature = "lang-csharp")]
         "csharp",
+        #[cfg(feature = "lang-html")]
+        "html",
+        #[cfg(feature = "lang-markdown")]
+        "markdown",
     ]
 }
 

--- a/crates/aptu-coder-core/src/languages/html.rs
+++ b/crates/aptu-coder-core/src/languages/html.rs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! HTML language stub.
+//!
+//! HTML is recognised by extension (`html`, `htm`) but has no tree-sitter grammar
+//! dependency in this release. Extraction returns zero functions and imports.
+//! This module reserves the feature slot for a future `tree-sitter-html` upgrade.
+
+/// Tree-sitter element query for HTML (empty -- no grammar compiled in).
+pub const ELEMENT_QUERY: &str = "";
+
+/// Tree-sitter call query for HTML (empty -- no grammar compiled in).
+pub const CALL_QUERY: &str = "";

--- a/crates/aptu-coder-core/src/languages/markdown.rs
+++ b/crates/aptu-coder-core/src/languages/markdown.rs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! Markdown language handler for tree-sitter-md.
+//!
+//! Extracts ATX headings (`# Heading`) and setext headings (underlined with `===` or `---`)
+//! as function-equivalent elements. Fenced code block contents are not extracted.
+
+/// Tree-sitter query for extracting Markdown headings as elements.
+///
+/// Both ATX headings (`# Title`) and setext headings (text underlined with `=` or `-`)
+/// are captured via the `heading_content` field. The field syntax is required because
+/// `heading_content` is a field name on the heading nodes, not a standalone node type.
+pub const ELEMENT_QUERY: &str = r"
+(atx_heading heading_content: (_) @func_name) @function
+(setext_heading heading_content: (_) @func_name) @function
+";
+
+/// Tree-sitter call query for Markdown (empty -- no call sites in Markdown).
+pub const CALL_QUERY: &str = "";
+
+#[cfg(all(test, feature = "lang-markdown"))]
+mod tests {
+    use tree_sitter::{Parser, StreamingIterator};
+
+    fn parse_and_query(src: &str, query_str: &str) -> Vec<String> {
+        let language = tree_sitter_md::LANGUAGE;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&language.into())
+            .expect("failed to set language");
+        let tree = parser.parse(src, None).expect("parse failed");
+        let query = tree_sitter::Query::new(&language.into(), query_str).expect("invalid query");
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), src.as_bytes());
+        let func_name_idx = query
+            .capture_index_for_name("func_name")
+            .expect("no func_name capture");
+        let mut names = Vec::new();
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                if cap.index == func_name_idx {
+                    let text = &src[cap.node.start_byte()..cap.node.end_byte()];
+                    names.push(text.trim().to_owned());
+                }
+            }
+        }
+        names
+    }
+
+    /// ATX headings are extracted with the correct heading text.
+    #[test]
+    fn test_atx_headings_extracted() {
+        let src = "# Introduction\n\n## Installation\n\n### Details\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY);
+        assert_eq!(names, vec!["Introduction", "Installation", "Details"]);
+    }
+
+    /// Setext headings are extracted as functions.
+    #[test]
+    fn test_setext_heading_extracted() {
+        let src = "Overview\n========\n\nSetup\n-----\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY);
+        assert_eq!(names, vec!["Overview", "Setup"]);
+    }
+
+    /// A file with no headings returns zero functions and no error.
+    #[test]
+    fn test_no_headings_returns_empty() {
+        let src = "Just some prose.\n\nNo headings here.\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY);
+        assert!(names.is_empty());
+    }
+
+    /// A `#` inside a fenced code block is NOT extracted as a heading.
+    #[test]
+    fn test_code_fence_not_extracted() {
+        let src = "```python\n# not a heading\nprint('hello')\n```\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY);
+        assert!(names.is_empty());
+    }
+}

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -262,8 +262,9 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
         // `None` here, which causes `analyze_file` to emit an INVALID_PARAMS error with the
         // message "unsupported language: html". This is intentional: the extension is registered
         // so that the file-type is recognised and a clear error surfaces rather than silently
-        // skipping the file. Track https://github.com/tree-sitter/tree-sitter-html for the
-        // ^0.25 release.
+        // skipping the file.
+        // TODO: implement once tree-sitter-html ^0.25 ships.
+        //       Track releases: https://github.com/tree-sitter/tree-sitter-html/releases
         #[cfg(feature = "lang-html")]
         "html" => None,
         #[cfg(feature = "lang-markdown")]

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -256,6 +256,14 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(javascript::find_receiver_type),
             extract_inheritance: Some(javascript::extract_inheritance),
         }),
+        // HTML is a reserved feature stub. `tree-sitter-html` 0.23.x is incompatible with the
+        // tree-sitter 0.26 API used by this crate; full HTML support is blocked on the
+        // tree-sitter-html ^0.25 release. Until then, analysis of `.html`/`.htm` files returns
+        // `None` here, which causes `analyze_file` to emit an INVALID_PARAMS error with the
+        // message "unsupported language: html". This is intentional: the extension is registered
+        // so that the file-type is recognised and a clear error surfaces rather than silently
+        // skipping the file. Track https://github.com/tree-sitter/tree-sitter-html for the
+        // ^0.25 release.
         #[cfg(feature = "lang-html")]
         "html" => None,
         #[cfg(feature = "lang-markdown")]

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -15,12 +15,16 @@ pub mod csharp;
 pub mod fortran;
 #[cfg(feature = "lang-go")]
 pub mod go;
+#[cfg(feature = "lang-html")]
+pub mod html;
 #[cfg(feature = "lang-java")]
 pub mod java;
 #[cfg(feature = "lang-javascript")]
 pub mod javascript;
 #[cfg(feature = "lang-kotlin")]
 pub mod kotlin;
+#[cfg(feature = "lang-markdown")]
+pub mod markdown;
 #[cfg(feature = "lang-python")]
 pub mod python;
 #[cfg(feature = "lang-rust")]
@@ -251,6 +255,24 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_method_for_receiver: Some(javascript::find_method_for_receiver),
             find_receiver_type: Some(javascript::find_receiver_type),
             extract_inheritance: Some(javascript::extract_inheritance),
+        }),
+        #[cfg(feature = "lang-html")]
+        "html" => None,
+        #[cfg(feature = "lang-markdown")]
+        "markdown" => Some(LanguageInfo {
+            name: "markdown",
+            language: tree_sitter_md::LANGUAGE.into(),
+            element_query: markdown::ELEMENT_QUERY,
+            call_query: markdown::CALL_QUERY,
+            reference_query: None,
+            import_query: None,
+            impl_query: None,
+            impl_trait_query: None,
+            defuse_query: None,
+            extract_function_name: None,
+            find_method_for_receiver: None,
+            find_receiver_type: None,
+            extract_inheritance: None,
         }),
         _ => None,
     }

--- a/crates/aptu-coder-core/src/schema_helpers.rs
+++ b/crates/aptu-coder-core/src/schema_helpers.rs
@@ -49,7 +49,7 @@ pub fn option_ast_limit_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
 /// `AnalyzeFileParams` and `AnalyzeModuleParams`. Covers every extension in
 /// `lang.rs` `EXTENSION_MAP`. Centralised here so adding a language requires
 /// one change, not two.
-pub const SUPPORTED_FILE_EXT_PATTERN: &str = r"(?i)\.(rs|py|go|ts|tsx|js|mjs|cjs|java|kt|kts|cs|cpp|cc|cxx|c|h|hpp|hxx|f|f77|f90|f95|f03|f08|for|ftn)$";
+pub const SUPPORTED_FILE_EXT_PATTERN: &str = r"(?i)\.(rs|py|go|ts|tsx|js|mjs|cjs|java|kt|kts|cs|cpp|cc|cxx|c|h|hpp|hxx|f|f77|f90|f95|f03|f08|for|ftn|html|htm|md|mdx)$";
 
 /// Returns a string schema with a `pattern` constraint covering all supported
 /// source file extensions. Used as `schema_with` on `path` fields.

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1495,7 +1495,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_file",
         title = "Analyze File",
-        description = "Functions, types, classes, and imports from a single source file. Returns functions (name, signature, line range), classes (methods, fields, inheritance), imports; paginate with cursor/page_size. Use fields=[\"functions\",\"classes\",\"imports\"] to limit output sections. Fails if directory path supplied; use analyze_directory instead. Fails if summary=true and cursor. git_ref not supported for single-file analysis. Use analyze_module for lightweight function/import index (~75% smaller). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
+        description = "Functions, types, classes, and imports from a single source file. Returns functions (name, signature, line range), classes (methods, fields, inheritance), imports; paginate with cursor/page_size. Use fields=[\"functions\",\"classes\",\"imports\"] to limit output sections. Fails if directory path supplied; use analyze_directory instead. Fails if summary=true and cursor. git_ref not supported for single-file analysis. Use analyze_module for lightweight function/import index (~75% smaller). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, HTML, Markdown. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
         output_schema = schema_for_type::<analyze::FileAnalysisOutput>(),
         annotations(
             title = "Analyze File",
@@ -2260,7 +2260,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_module",
         title = "Analyze Module",
-        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#. Example queries: What functions are defined in src/analyze.rs?",
+        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, HTML, Markdown. Example queries: What functions are defined in src/analyze.rs?",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",
@@ -5027,8 +5027,8 @@ mod tests {
         // Arrange: unsupported extension; both analyze_file and analyze_module
         // route through handle_file_details_mode so one test covers both.
         let temp_dir = tempfile::TempDir::new().expect("should create temp dir");
-        let unsupported_file = temp_dir.path().join("notes.md");
-        std::fs::write(&unsupported_file, "# notes").expect("should write file");
+        let unsupported_file = temp_dir.path().join("notes.txt");
+        std::fs::write(&unsupported_file, "some notes").expect("should write file");
 
         let analyzer = make_analyzer();
         let mut params = AnalyzeFileParams::default();

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1495,7 +1495,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_file",
         title = "Analyze File",
-        description = "Functions, types, classes, and imports from a single source file. Returns functions (name, signature, line range), classes (methods, fields, inheritance), imports; paginate with cursor/page_size. Use fields=[\"functions\",\"classes\",\"imports\"] to limit output sections. Fails if directory path supplied; use analyze_directory instead. Fails if summary=true and cursor. git_ref not supported for single-file analysis. Use analyze_module for lightweight function/import index (~75% smaller). Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, HTML, Markdown. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
+        description = "Functions, types, classes, and imports from a single source file. Returns functions (name, signature, line range), classes (methods, fields, inheritance), imports; paginate with cursor/page_size. Use fields=[\"functions\",\"classes\",\"imports\"] to limit output sections. Fails if directory path supplied; use analyze_directory instead. Fails if summary=true and cursor. git_ref not supported for single-file analysis. Use analyze_module for lightweight function/import index (~75% smaller). Supported: C/C++, C#, Fortran, Go, HTML, Java, JavaScript, Markdown, Python, Rust, TypeScript, TSX. Example queries: What functions are defined in src/lib.rs?; Show me the classes and their methods in src/analyzer.py.",
         output_schema = schema_for_type::<analyze::FileAnalysisOutput>(),
         annotations(
             title = "Analyze File",
@@ -2260,7 +2260,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_module",
         title = "Analyze Module",
-        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Rust, Go, Java, Python, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, HTML, Markdown. Example queries: What functions are defined in src/analyze.rs?",
+        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: C/C++, C#, Fortran, Go, HTML, Java, JavaScript, Markdown, Python, Rust, TypeScript, TSX. Example queries: What functions are defined in src/analyze.rs?",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",


### PR DESCRIPTION
## Summary

Adds Markdown language support and HTML extension stubs to aptu-coder, resolving #969.

Markdown (full): `analyze_file` and `analyze_module` now recognize `.md` and `.mdx` files. Headings (ATX and setext) are extracted as navigational anchors ("functions"), enabling document structure browsing.

HTML (stub): `.html` and `.htm` extensions are registered in the extension map and `SUPPORTED_FILE_EXT_PATTERN`. No grammar is wired (deferred until `tree-sitter-html` 0.25+ is released); the `lang-html` feature compiles cleanly but returns no parse results.

## Changes

- `Cargo.toml`: adds `tree-sitter-md = "0.5.3"` to workspace dependencies
- `crates/aptu-coder-core/Cargo.toml`: adds `lang-markdown` (with `dep:tree-sitter-md`) and `lang-html` features; `lang-markdown` added to default features
- `crates/aptu-coder-core/src/schema_helpers.rs`: extends `SUPPORTED_FILE_EXT_PATTERN` with `html|htm|md|mdx`
- `crates/aptu-coder-core/src/lang.rs`: adds extension map entries for `html`, `htm`, `md`, `mdx` behind feature gates; adds `html` and `markdown` to `supported_languages()`
- `crates/aptu-coder-core/src/languages/mod.rs`: adds `pub mod markdown` and `pub mod html` declarations; adds match arms in `get_language_info()`
- `crates/aptu-coder-core/src/languages/markdown.rs`: new file -- `ELEMENT_QUERY` (ATX + setext heading capture), `CALL_QUERY` (empty), 4 unit tests
- `crates/aptu-coder-core/src/languages/html.rs`: new file -- empty query stubs, documented as reserved pending upstream parser
- `crates/aptu-coder/src/lib.rs`: appends `HTML, Markdown` to `Supported:` lists in `analyze_file` and `analyze_module` descriptions; updates path parameter pattern
- `README.md`: adds Markdown and HTML rows to language support table

## Test Plan

- [x] Tests pass (562 passed, 0 failed in 03-build.json)
- [x] Linter clean
- [x] All markdown.rs unit tests pass with lang-markdown feature enabled

## Notes

- `tree-sitter-md` uses `heading_content` as a field name (not a node type); query uses field syntax `heading_content: (_) @func_name`
- Workspace `Cargo.toml` cannot mark dependencies as `optional = true`; optional flag lives only in the per-crate `Cargo.toml`

Closes #969
