### PR TITLE
fix(analyze): use file extension as language label for unregistered types

### DIFF
--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -188,7 +188,12 @@ fn process_file_entry(entry: &WalkEntry, source: &str) -> FileInfo {
             Err(_) => (lang_str, 0, 0),
         }
     } else {
-        ("unknown".to_string(), 0, 0)
+        (
+            ext.map(|e| e.to_lowercase())
+                .unwrap_or_else(|| "unknown".to_string()),
+            0,
+            0,
+        )
     };
 
     let is_test = is_test_file(&entry.path);

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -210,7 +210,7 @@ fn test_analyze_unsupported_file_type() {
     assert_eq!(txt.line_count, 2);
     assert_eq!(txt.function_count, 0);
     assert_eq!(txt.class_count, 0);
-    assert_eq!(txt.language, "unknown");
+    assert_eq!(txt.language, "txt");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`process_file_entry` was writing `"unknown"` into `FileInfo.language` for any file whose extension is not in the registered language map, even when the extension itself was available. This caused the Languages summary in `analyze_directory` output to group all unrecognised file types (`.txt`, `.yaml`, `.toml`, etc.) under a single `"unknown"` bucket instead of their actual extension.

## Changes

- `crates/aptu-coder-core/src/analyze.rs`: In `process_file_entry`, the `else` branch now uses `ext.map(|e| e.to_lowercase()).unwrap_or_else(|| "unknown".to_string())` -- extension present but unregistered gets its lowercased name; extension absent falls back to `"unknown"`.
- `crates/aptu-coder-core/tests/integration_tests.rs`: Update `test_analyze_unsupported_file_type` assertion from `"unknown"` to `"txt"` to match the new behavior.

## Out of scope

`collect_file_analysis` lines 641-643 use a `language` local as a `SemanticExtractor` routing key (not stored in `FileInfo`). That site is intentionally unchanged.

Closes #1060
