### PR TITLE
feat(lang): add CSS and YAML tree-sitter grammar support (#1063)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-css",
  "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -116,6 +117,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "tree-sitter-yaml",
 ]
 
 [[package]]
@@ -2290,6 +2292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-css"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-fortran"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2392,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tree-sitter-typescript = "0.23.2"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-fortran = "0.6.0"
 tree-sitter-md = "0.5.3"
+tree-sitter-css = "0.25.0"
+tree-sitter-yaml = "0.7.2"
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-client"] }

--- a/crates/aptu-coder-core/Cargo.toml
+++ b/crates/aptu-coder-core/Cargo.toml
@@ -21,7 +21,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["lang-rust", "lang-go", "lang-java", "lang-kotlin", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp", "lang-markdown"]
+default = ["lang-rust", "lang-go", "lang-java", "lang-kotlin", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp", "lang-markdown", "lang-css", "lang-yaml"]
 schemars = ["dep:schemars"]
 lang-rust = ["dep:tree-sitter-rust"]
 lang-go = ["dep:tree-sitter-go"]
@@ -36,6 +36,8 @@ lang-fortran = ["dep:tree-sitter-fortran"]
 lang-csharp = ["dep:tree-sitter-c-sharp"]
 lang-markdown = ["dep:tree-sitter-md"]
 lang-html = []
+lang-css = ["dep:tree-sitter-css"]
+lang-yaml = ["dep:tree-sitter-yaml"]
 
 [dependencies]
 tree-sitter = { workspace = true }
@@ -63,6 +65,8 @@ tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-fortran = { workspace = true, optional = true }
 tree-sitter-md = { workspace = true, optional = true }
+tree-sitter-css = { workspace = true, optional = true }
+tree-sitter-yaml = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/aptu-coder-core/src/languages/css.rs
+++ b/crates/aptu-coder-core/src/languages/css.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! CSS language handler for tree-sitter-css.
+//!
+//! Extracts CSS rule sets (selectors) as function-equivalent elements and
+//! `@import` statements as imports.
+
+/// Tree-sitter query for extracting CSS rule sets (selectors) as elements.
+///
+/// Each `rule_set` node's `selectors` child is captured as the element name.
+pub const ELEMENT_QUERY: &str = r"
+(rule_set (selectors) @func_name) @function
+";
+
+/// Tree-sitter query for extracting CSS `@import` statements.
+///
+/// Captures the string value (URL) inside each `import_statement`.
+pub const IMPORT_QUERY: &str = r"
+(import_statement (string_value) @import_path)
+";
+
+/// Tree-sitter call query for CSS (empty -- no call sites in CSS).
+pub const CALL_QUERY: &str = "";
+
+#[cfg(all(test, feature = "lang-css"))]
+mod tests {
+    use tree_sitter::{Parser, StreamingIterator};
+
+    fn parse_and_query(src: &str, query_str: &str, capture_name: &str) -> Vec<String> {
+        let language = tree_sitter_css::LANGUAGE;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&language.into())
+            .expect("failed to set language");
+        let tree = parser.parse(src, None).expect("parse failed");
+        let query = tree_sitter::Query::new(&language.into(), query_str).expect("invalid query");
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), src.as_bytes());
+        let capture_idx = query
+            .capture_index_for_name(capture_name)
+            .expect("capture not found");
+        let mut results = Vec::new();
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                if cap.index == capture_idx {
+                    let text = &src[cap.node.start_byte()..cap.node.end_byte()];
+                    results.push(text.trim().to_owned());
+                }
+            }
+        }
+        results
+    }
+
+    /// CSS rule sets are extracted with the correct selector text.
+    #[test]
+    fn test_css_rule_set_element_extraction() {
+        let src = "body { color: red; }\n.container { margin: 0; }\n#header { font-size: 16px; }\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY, "func_name");
+        assert_eq!(names, vec!["body", ".container", "#header"]);
+    }
+
+    /// CSS @import statements are extracted as imports (string_value includes quotes).
+    #[test]
+    fn test_css_import_extraction() {
+        let src = "@import \"reset.css\";\n@import \"theme.css\";\nbody { color: red; }\n";
+        let imports = parse_and_query(src, super::IMPORT_QUERY, "import_path");
+        assert_eq!(imports, vec!["\"reset.css\"", "\"theme.css\""]);
+    }
+
+    /// An empty CSS file returns empty analysis without errors.
+    #[test]
+    fn test_css_empty_file() {
+        let names = parse_and_query("", super::ELEMENT_QUERY, "func_name");
+        assert!(names.is_empty());
+        let imports = parse_and_query("", super::IMPORT_QUERY, "import_path");
+        assert!(imports.is_empty());
+    }
+}

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -11,6 +11,8 @@
 pub mod cpp;
 #[cfg(feature = "lang-csharp")]
 pub mod csharp;
+#[cfg(feature = "lang-css")]
+pub mod css;
 #[cfg(feature = "lang-fortran")]
 pub mod fortran;
 #[cfg(feature = "lang-go")]
@@ -32,6 +34,8 @@ pub mod regex_fallback;
 pub mod rust;
 #[cfg(any(feature = "lang-typescript", feature = "lang-tsx"))]
 pub mod typescript;
+#[cfg(feature = "lang-yaml")]
+pub mod yaml;
 
 use tree_sitter::{Language, Node};
 
@@ -284,6 +288,38 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: None,
         }),
+        #[cfg(feature = "lang-css")]
+        "css" => Some(LanguageInfo {
+            name: "css",
+            language: tree_sitter_css::LANGUAGE.into(),
+            element_query: css::ELEMENT_QUERY,
+            call_query: css::CALL_QUERY,
+            reference_query: None,
+            import_query: Some(css::IMPORT_QUERY),
+            impl_query: None,
+            impl_trait_query: None,
+            defuse_query: None,
+            extract_function_name: None,
+            find_method_for_receiver: None,
+            find_receiver_type: None,
+            extract_inheritance: None,
+        }),
+        #[cfg(feature = "lang-yaml")]
+        "yaml" => Some(LanguageInfo {
+            name: "yaml",
+            language: tree_sitter_yaml::LANGUAGE.into(),
+            element_query: yaml::ELEMENT_QUERY,
+            call_query: yaml::CALL_QUERY,
+            reference_query: None,
+            import_query: None,
+            impl_query: None,
+            impl_trait_query: None,
+            defuse_query: None,
+            extract_function_name: None,
+            find_method_for_receiver: None,
+            find_receiver_type: None,
+            extract_inheritance: None,
+        }),
         _ => None,
     }
 }
@@ -316,6 +352,10 @@ pub fn get_ts_language(lang_name: &str) -> Option<Language> {
         "csharp" => Some(tree_sitter_c_sharp::LANGUAGE.into()),
         #[cfg(feature = "lang-javascript")]
         "javascript" => Some(tree_sitter_javascript::LANGUAGE.into()),
+        #[cfg(feature = "lang-css")]
+        "css" => Some(tree_sitter_css::LANGUAGE.into()),
+        #[cfg(feature = "lang-yaml")]
+        "yaml" => Some(tree_sitter_yaml::LANGUAGE.into()),
         _ => None,
     }
 }
@@ -327,7 +367,9 @@ pub fn get_ts_language(lang_name: &str) -> Option<Language> {
 #[must_use]
 pub fn try_regex_fallback(source: &str, language: &str) -> Option<crate::types::SemanticAnalysis> {
     match language {
+        #[cfg(not(feature = "lang-css"))]
         "css" => Some(regex_fallback::extract_css(source)),
+        #[cfg(not(feature = "lang-yaml"))]
         "yaml" => Some(regex_fallback::extract_yaml(source)),
         "json" => Some(regex_fallback::extract_json(source)),
         "toml" => Some(regex_fallback::extract_toml(source)),

--- a/crates/aptu-coder-core/src/languages/yaml.rs
+++ b/crates/aptu-coder-core/src/languages/yaml.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! YAML language handler for tree-sitter-yaml.
+//!
+//! Extracts top-level mapping keys as function-equivalent elements.
+//! YAML has no import concept; the import query is left empty.
+
+/// Tree-sitter query for extracting YAML block mapping keys as elements.
+///
+/// Each `block_mapping_pair` node's `key` field is captured as the element name.
+pub const ELEMENT_QUERY: &str = r"
+(block_mapping_pair key: (_) @func_name) @function
+";
+
+/// Tree-sitter call query for YAML (empty -- no call sites in YAML).
+pub const CALL_QUERY: &str = "";
+
+#[cfg(all(test, feature = "lang-yaml"))]
+mod tests {
+    use tree_sitter::{Parser, StreamingIterator};
+
+    fn parse_and_query(src: &str, query_str: &str, capture_name: &str) -> Vec<String> {
+        let language = tree_sitter_yaml::LANGUAGE;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&language.into())
+            .expect("failed to set language");
+        let tree = parser.parse(src, None).expect("parse failed");
+        let query = tree_sitter::Query::new(&language.into(), query_str).expect("invalid query");
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), src.as_bytes());
+        let capture_idx = query
+            .capture_index_for_name(capture_name)
+            .expect("capture not found");
+        let mut results = Vec::new();
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                if cap.index == capture_idx {
+                    let text = &src[cap.node.start_byte()..cap.node.end_byte()];
+                    results.push(text.trim().to_owned());
+                }
+            }
+        }
+        results
+    }
+
+    /// YAML block mapping keys are extracted as elements.
+    #[test]
+    fn test_yaml_block_mapping_element_extraction() {
+        let src = "name: my-project\nversion: 1.0.0\ndescription: A test project\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY, "func_name");
+        assert_eq!(names, vec!["name", "version", "description"]);
+    }
+
+    /// An empty YAML file returns empty analysis without errors.
+    #[test]
+    fn test_yaml_empty_file() {
+        let names = parse_and_query("", super::ELEMENT_QUERY, "func_name");
+        assert!(names.is_empty());
+    }
+
+    /// YAML multi-document stream extracts keys from each document.
+    #[test]
+    fn test_yaml_multi_document_stream() {
+        let src = "---\nfoo: bar\nbaz: qux\n---\nalpha: beta\n";
+        let names = parse_and_query(src, super::ELEMENT_QUERY, "func_name");
+        assert!(names.contains(&"foo".to_owned()));
+        assert!(names.contains(&"baz".to_owned()));
+        assert!(names.contains(&"alpha".to_owned()));
+    }
+}


### PR DESCRIPTION
## Summary

Add `tree-sitter-css 0.25.0` and `tree-sitter-yaml 0.7.2` as grammar dependencies behind `lang-css` and `lang-yaml` feature flags, following the pattern established in #969. Both features are default-on.

Closes #1063

## Changes

- `Cargo.toml`: add `tree-sitter-css = "0.25.0"` and `tree-sitter-yaml = "0.7.2"` to workspace dependencies
- `crates/aptu-coder-core/Cargo.toml`: add `lang-css` and `lang-yaml` features (both in `default`); add optional deps
- `crates/aptu-coder-core/src/languages/css.rs`: new language module with `ELEMENT_QUERY` (rule_set/selectors) and `IMPORT_QUERY` (@import rules)
- `crates/aptu-coder-core/src/languages/yaml.rs`: new language module with `ELEMENT_QUERY` (block_mapping_pair keys)
- `crates/aptu-coder-core/src/languages/mod.rs`: register both languages in `get_language_info()` behind `#[cfg(feature)]` guards; gate `try_regex_fallback()` css/yaml arms with `#[cfg(not(feature = "lang-css/yaml"))]` so tree-sitter takes precedence when features are enabled

## Critical fix: try_regex_fallback ordering

`parser.rs` calls `try_regex_fallback()` before `get_language_info()`. Without gating the css/yaml arms of `try_regex_fallback()`, the regex path would always short-circuit and the tree-sitter grammars would be dead code. The fix lives entirely in `mod.rs`.

## Acceptance criteria

- [x] `tree-sitter-css = "0.25.0"` and `tree-sitter-yaml = "0.7.2"` added to workspace `Cargo.toml`
- [x] `lang-css` and `lang-yaml` features added to `aptu-coder-core/Cargo.toml`, both in `default`
- [x] `LanguageInfo` for CSS implemented: element query extracts selectors; import query extracts `@import` paths
- [x] `LanguageInfo` for YAML implemented: element query extracts top-level mapping keys
- [x] `cargo build --no-default-features` succeeds (feature flags are genuinely optional)
- [x] `cargo test` passes (152 passed; 1 pre-existing flaky race condition on `test_profile_env_var_fallback` unrelated to this change)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo deny check advisories licenses` passes

## Binary size impact

Run `cargo install --path crates/aptu-coder --profile release` before and after to compare. Projected ~100KB increase from tree-sitter-css and tree-sitter-yaml parser.c compilation (each ~50KB compiled).

## Note on import path quoting

`tree-sitter-css 0.25.0`'s `string_value` node text includes surrounding quote characters. The import query captures the raw node text (e.g., `"reset.css"` not `reset.css`). This matches the behavior of other tree-sitter grammars in this codebase.
