### PR TITLE
docs: update stale INVALID_PARAMS references for analyze_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | Tool | Purpose | Languages |
 |------|---------|-----------|
 | `analyze_directory` | Directory tree with LOC, function, and class counts; respects `.gitignore` | all |
-| `analyze_file` | Functions, classes, and imports with signatures and line ranges; returns `INVALID_PARAMS` for unsupported extensions | all |
+| `analyze_file` | Functions, classes, and imports with signatures and line ranges; returns graceful fallback (line count, file head, no AST) for unsupported extensions | all |
 | `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`); returns `INVALID_PARAMS` for unsupported extensions | all |
 | `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |

--- a/crates/aptu-coder-core/README.md
+++ b/crates/aptu-coder-core/README.md
@@ -14,7 +14,7 @@ Core library for code structure analysis using tree-sitter.
 ## Features
 
 - **Directory analysis** - File tree with LOC, function, and class counts
-- **File analysis** - Functions, classes, and imports with signatures and line ranges; returns `INVALID_PARAMS` for unsupported extensions
+- **File analysis** - Functions, classes, and imports with signatures and line ranges; returns graceful fallback (line count, file head, no AST) for unsupported extensions
 - **Symbol call graphs** - Callers and callees across a directory with configurable depth
 - **Module index** - Lightweight function and import index (~75% smaller than full file analysis); returns `INVALID_PARAMS` for unsupported extensions
 - **Edit operations** - In-file edits: overwrite, exact-block replace

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,7 @@ When `git_ref` is set, `changed_files_from_git_ref()` runs `git diff` to get the
 
 ### analyze_file (File Details)
 
-1. Detect language from extension; return `INVALID_PARAMS` immediately if the extension is not in the supported set
+1. Detect language from extension; dispatch to graceful fallback for unsupported extensions (returns line count, file head, no AST)
 2. SemanticExtractor parses the file: functions with signatures, classes/structs with fields, imports, type references
 3. Format as structured sections
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,7 +158,7 @@ Added `--port N` flag. When set, aptu-coder binds to `127.0.0.1:N` and serves al
 
 Four PRs shipped together to make `exec_command` output safe for large contexts:
 
-- **#955**: `analyze_file` and `analyze_module` return `INVALID_PARAMS` for unsupported file extensions instead of a generic error; `inputSchema` pattern constraint added so MCP clients surface the restriction before calling.
+- **#955**: `analyze_file` and `analyze_module` return `INVALID_PARAMS` for unsupported file extensions instead of a generic error; `inputSchema` pattern constraint added so MCP clients surface the restriction before calling. (Superseded by #1061 and #1062, which replaced `analyze_file` with graceful fallback and regex extraction.)
 - **#957**: CI runners migrated to `ubuntu-24.04-arm` everywhere (ARM64).
 - **#961**: Byte-level output caps on `exec_command`: stdout 30k chars (tail-preserving), stderr 10k chars (tail-preserving), combined `output_text` 50k chars. Cap thresholds are data-driven from 27,981 observed calls (0.33% exceed 30k stdout). `output_truncated: Option<bool>` added to `MetricEvent` and the JSONL schema.
 - **#962**: Command-pattern output filter table: 7 built-in rules (git pull/fetch/push/log/status, cargo build/test) suppress per-file noise before output reaches the model. `git pull` additionally injects `--no-stat` before execution. Project-local rules via `.aptu/filters.toml`. `filter_applied` field in `structuredContent` identifies which rule fired. Filters apply on success only; raw output preserved on failure.

--- a/docs/audit/2026-06-unsupported-extension-handling.md
+++ b/docs/audit/2026-06-unsupported-extension-handling.md
@@ -236,8 +236,11 @@ Binary size delta must be documented in PR description. Existing language extrac
 | 1 | #1060 | Extension label in `analyze_directory`; two-line change | Zero |
 | 2 | #1061 | Graceful fallback in `analyze_file`; eliminates 28% error rate | Low |
 | 3 | #1062 | Regex extraction for Astro, CSS, YAML, JSON, TOML | Low |
+| 3 | #1072 | Observability: `tracing::warn` on Astro TypeScript extractor error | Zero |
 | 4 | #1063 | `tree-sitter-css` + `tree-sitter-yaml` grammars | Medium |
 | -- | #1064 | Tracking: deferred grammar candidates; no code | Zero |
 
 Order 1 items are independent and can be developed in parallel. Order 2 gates on Order 1
-(#1061 provides the fallback path #1062 extends). Order 4 gates on #969, #1061, and #1062.
+(#1061 provides the fallback path #1062 extends). Order 3 (#1072) gates on #1062. Order 4 gates on #969, #1061, and #1062.
+
+All items through order 3 (including #1072) are merged; the unsupported-extension-handling milestone is complete.


### PR DESCRIPTION
## Summary

Update five documentation files to reflect graceful fallback behaviour introduced by #1061 and #1062 for `analyze_file` on unsupported extensions.

## Changes

- **README.md**: `analyze_file` tool row now describes graceful fallback (line count, file head, no AST) instead of `INVALID_PARAMS`. `analyze_module` row unchanged (still returns `INVALID_PARAMS`).
- **crates/aptu-coder-core/README.md**: Same correction to the File analysis feature bullet. Module index bullet unchanged.
- **docs/ARCHITECTURE.md**: `analyze_file` flow step 1 updated to describe fallback dispatch. `analyze_module` step 1 unchanged.
- **docs/ROADMAP.md**: #955 entry annotated with superseding issues #1061 and #1062.
- **docs/audit/2026-06-unsupported-extension-handling.md**: #1072 added to Implementation Order table at order 3; closing note added marking the milestone complete.

## Acceptance criteria

- [x] `analyze_file` row in `README.md` describes graceful fallback, not `INVALID_PARAMS`
- [x] `analyze_module` row in `README.md` remains accurate (`INVALID_PARAMS` unchanged)
- [x] Same corrections applied to `crates/aptu-coder-core/README.md`
- [x] `docs/ARCHITECTURE.md` `analyze_file` flow step 1 describes fallback dispatch
- [x] `docs/ARCHITECTURE.md` `analyze_module` flow step 1 unchanged
- [x] `docs/ROADMAP.md` #955 entry annotated with superseding issues (#1061, #1062)
- [x] `docs/audit/2026-06-unsupported-extension-handling.md` Implementation Order table includes #1072; milestone marked complete
- [x] No source code changes; documentation only
- [x] `cargo test -p aptu-coder-core` passes

Closes #1075
