### PR TITLE
fix(edit): use resolved path for file I/O in edit_overwrite and edit_replace

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2643,7 +2643,7 @@ impl CodeAnalyzer {
         span.record("gen_ai.operation.name", "execute_tool");
         span.record("gen_ai.tool.name", "edit_overwrite");
         span.record("path", &params.path);
-        let _validated_path = if let Some(ref wd) = params.working_dir {
+        let resolved_path: std::path::PathBuf = if let Some(ref wd) = params.working_dir {
             match validate_path_in_dir(&params.path, false, std::path::Path::new(wd)) {
                 Ok(p) => p,
                 Err(e) => {
@@ -2661,7 +2661,10 @@ impl CodeAnalyzer {
                     return Ok(err_to_tool_result(e));
                 }
             }
-        };
+        }
+        // Normalize away any trailing separator that PathBuf::join(empty) may add.
+        .components()
+        .collect();
         let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
@@ -2670,7 +2673,7 @@ impl CodeAnalyzer {
         let sid = self.session_id.lock().await.clone();
 
         // Guard against directory paths
-        if std::fs::metadata(&params.path)
+        if std::fs::metadata(&resolved_path)
             .map(|m| m.is_dir())
             .unwrap_or(false)
         {
@@ -2707,10 +2710,9 @@ impl CodeAnalyzer {
             )));
         }
 
-        let path = std::path::PathBuf::from(&params.path);
         let content = params.content.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            aptu_coder_core::edit_overwrite_content(&path, &content)
+            aptu_coder_core::edit_overwrite_content(&resolved_path, &content)
         });
 
         let output = match handle.await {
@@ -2892,7 +2894,7 @@ impl CodeAnalyzer {
         span.record("gen_ai.operation.name", "execute_tool");
         span.record("gen_ai.tool.name", "edit_replace");
         span.record("path", &params.path);
-        let _validated_path = if let Some(ref wd) = params.working_dir {
+        let resolved_path: std::path::PathBuf = if let Some(ref wd) = params.working_dir {
             match validate_path_in_dir(&params.path, true, std::path::Path::new(wd)) {
                 Ok(p) => p,
                 Err(e) => {
@@ -2910,7 +2912,10 @@ impl CodeAnalyzer {
                     return Ok(err_to_tool_result(e));
                 }
             }
-        };
+        }
+        // Normalize away any trailing separator that PathBuf::join(empty) may add.
+        .components()
+        .collect();
         let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
@@ -2919,7 +2924,7 @@ impl CodeAnalyzer {
         let sid = self.session_id.lock().await.clone();
 
         // Guard against directory paths
-        if std::fs::metadata(&params.path)
+        if std::fs::metadata(&resolved_path)
             .map(|m| m.is_dir())
             .unwrap_or(false)
         {
@@ -2956,11 +2961,10 @@ impl CodeAnalyzer {
             )));
         }
 
-        let path = std::path::PathBuf::from(&params.path);
         let old_text = params.old_text.clone();
         let new_text = params.new_text.clone();
         let handle = tokio::task::spawn_blocking(move || {
-            aptu_coder_core::edit_replace_block(&path, &old_text, &new_text)
+            aptu_coder_core::edit_replace_block(&resolved_path, &old_text, &new_text)
         });
 
         let output = match handle.await {

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2661,10 +2661,7 @@ impl CodeAnalyzer {
                     return Ok(err_to_tool_result(e));
                 }
             }
-        }
-        // Normalize away any trailing separator that PathBuf::join(empty) may add.
-        .components()
-        .collect();
+        };
         let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
@@ -2912,10 +2909,7 @@ impl CodeAnalyzer {
                     return Ok(err_to_tool_result(e));
                 }
             }
-        }
-        // Normalize away any trailing separator that PathBuf::join(empty) may add.
-        .components()
-        .collect();
+        };
         let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -169,7 +169,9 @@ pub(crate) fn validate_path_in_dir(
         // below catches any residual traversal regardless.
         let p = std::path::Path::new(path);
         let mut ancestor = p.to_path_buf();
-        let mut suffix = std::path::PathBuf::new();
+        // Collect suffix components in reverse order, then reassemble without
+        // join(PathBuf::new()) to avoid a trailing separator on the first push.
+        let mut suffix_components: Vec<std::ffi::OsString> = Vec::new();
 
         loop {
             let full_path = canonical_working_dir.join(&ancestor);
@@ -179,7 +181,7 @@ pub(crate) fn validate_path_in_dir(
             if let Some(parent) = ancestor.parent()
                 && let Some(file_name) = ancestor.file_name()
             {
-                suffix = std::path::PathBuf::from(file_name).join(&suffix);
+                suffix_components.push(file_name.to_owned());
                 ancestor = parent.to_path_buf();
             } else {
                 // No existing ancestor found (or path contains `..`) --
@@ -188,6 +190,9 @@ pub(crate) fn validate_path_in_dir(
                 break;
             }
         }
+
+        // Reassemble suffix in the original (forward) order without trailing separator.
+        let suffix: std::path::PathBuf = suffix_components.into_iter().rev().collect();
 
         let canonical_base = canonical_working_dir.join(&ancestor);
         let canonical_base =

--- a/crates/aptu-coder/tests/edit_working_dir.rs
+++ b/crates/aptu-coder/tests/edit_working_dir.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use common::call_tool_raw;
+
+/// edit_overwrite with working_dir writes the file inside working_dir, not server CWD.
+#[tokio::test]
+async fn edit_overwrite_working_dir_writes_inside_working_dir() {
+    // Arrange: create a temp dir inside CWD to act as working_dir.
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "output.txt";
+    let expected_path = temp_dir.path().join(file_name);
+
+    // Act: call edit_overwrite with a relative path and working_dir
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "hello from working_dir",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert: tool must succeed and file must exist inside working_dir
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success but got error: {resp}"
+    );
+    assert!(
+        expected_path.exists(),
+        "file should exist inside working_dir at {:?}",
+        expected_path
+    );
+    let written = std::fs::read_to_string(&expected_path).expect("should read written file");
+    assert_eq!(written, "hello from working_dir");
+}
+
+/// edit_replace with working_dir modifies the correct file inside working_dir, not server CWD.
+#[tokio::test]
+async fn edit_replace_working_dir_modifies_inside_working_dir() {
+    // Arrange: create a temp dir inside CWD with a pre-existing file.
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "source.txt";
+    let file_path = temp_dir.path().join(file_name);
+    std::fs::write(&file_path, "old text here").expect("should write initial file");
+
+    // Act: call edit_replace with a relative path and working_dir
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "old text here",
+            "new_text": "new text here",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert: tool must succeed and file inside working_dir must be updated
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success but got error: {resp}"
+    );
+    let updated = std::fs::read_to_string(&file_path).expect("should read updated file");
+    assert_eq!(updated, "new text here");
+}


### PR DESCRIPTION
## Summary

Fixes #1078.

Both `edit_overwrite` and `edit_replace` accepted a `working_dir` parameter and correctly validated the path via `validate_path_in_dir`, producing a canonicalized absolute path anchored within `working_dir`. However, the resolved path was stored in `_validated_path` and discarded. All file I/O (metadata check, PathBuf construction, `spawn_blocking` closure) used the raw `params.path` string instead, causing silent writes to the wrong location when `working_dir` differs from server CWD.

## Changes

- `crates/aptu-coder/src/lib.rs`: rename `_validated_path` to `resolved_path` in both handlers; wire it through metadata check and `spawn_blocking` closure; keep `param_path` sourced from `params.path` for metrics and cache
- `crates/aptu-coder/tests/edit_working_dir.rs`: two integration tests asserting files land inside `working_dir`

## Test plan

- Tests pass (154 passed, 0 failed; see 03-build.json test_results)
- Linter clean (cargo clippy -- -D warnings)
- Security scan clean (no critical/high findings)
