### PR TITLE
chore(release): bump version to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.4"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.16", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.17", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Minor release adding broad language coverage for Markdown, CSS, YAML, Astro, JSON, and TOML; graceful fallback behavior for any unregistered file extension; and a bug fix ensuring `edit_overwrite` and `edit_replace` always operate on the resolved `working_dir`-relative path rather than the raw input path. No breaking changes to public tool APIs or structured output schemas.

## What's Changed

### Features

- **Add Markdown language support and HTML extension stubs** (#1066, closes #969): Full tree-sitter-based extraction for Markdown (headings as functions, ATX and setext styles, fenced code blocks). HTML stubs registered for `.html`/`.htm` extensions with a documented blocker on `tree-sitter-html` upstream crate availability. Supported language list in tool descriptions sorted alphabetically.
- **Regex-based extraction for Astro, CSS, YAML, JSON, TOML** (#1069, closes #1062): New `regex_fallback` module provides lightweight extraction for formats where tree-sitter grammars are absent or impractical. Astro extracts component imports and script-block functions; CSS extracts rule selectors; YAML and JSON extract top-level keys; TOML extracts section headers. Backed by the `regex` crate; no grammar compilation at runtime.
- **Add CSS and YAML tree-sitter grammar support** (#1073, closes #1063): Promotes CSS and YAML from regex-only to full tree-sitter parse trees. CSS extracts rule selectors, at-rules, and custom properties; YAML extracts top-level mapping keys. Both integrate with the existing `LanguageInfo` registry and L2 disk cache.
- **`analyze_file`: graceful fallback for unsupported extensions** (#1068, closes #1061): When a file extension is not registered in the language map, `analyze_file` now returns a valid (non-error) response with `line_count`, empty semantic fields, and an informational note rather than an `INVALID_PARAMS` error. `analyze_module` follows the same path. Fallback behavior is intentionally undocumented in tool descriptions -- agents should target supported extensions; the fallback is a safety net, not a contract.

### Bug Fixes

- **`edit_overwrite` and `edit_replace`: use resolved path for file I/O** (#1079, closes #1078): Both edit tools now resolve the user-supplied path against `working_dir` before opening the file. Previously the raw (unresolved) path was passed to the I/O layer while only the validation step used the resolved path, causing edits to silently write to the wrong location when `working_dir` was set.
- **Use file extension as language label for unregistered types** (#1067, closes #1060): `analyze_directory` and `analyze_file` were emitting `"unknown"` as the language label for files with unregistered extensions. The label is now the file extension itself (e.g., `"mdx"`, `"vue"`), making directory summaries and per-file output self-descriptive.

### Observability

- **Emit `tracing::warn` on Astro TypeScript extractor error in regex fallback** (#1076): When the Astro script-block TypeScript extractor encounters a parse error it now logs a structured warning with the file path rather than silently swallowing the error. Surfaces extraction failures in server logs without returning an error to the caller.

### Documentation

- **Update stale `INVALID_PARAMS` references for `analyze_file`** (#1077): `README.md`, `crates/aptu-coder-core/README.md`, `ARCHITECTURE.md`, `ROADMAP.md`, and the unsupported-extension audit document updated to reflect that `analyze_file` no longer returns `INVALID_PARAMS` for unknown extensions.
- **Unsupported extension handling analysis and issue roadmap** (#1065): Audit document in `docs/audit/` covering the prior error behavior, blast radius, and the issue plan that drove this release cycle.

### Dependencies

- Bump `rmcp` to v1.12.4 (#1071)
- Lock file maintenance, non-major bumps (#1074)
- Bump `github-actions` to v2.81.10 (#1070)

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.16.4...v0.17.0
