### PR TITLE
docs(exec_command): prefer working_dir over cd in tool description

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3186,7 +3186,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; use timeout_secs to limit execution time. working_dir sets initial working directory; cd and absolute paths in command string bypass this restriction. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; use timeout_secs to limit execution time. Prefer working_dir over cd <path> && in command -- set working_dir and use relative paths; cd and absolute paths still work but are redundant when working_dir is set. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",


### PR DESCRIPTION
## Summary

The `exec_command` tool description documented `working_dir` without stating it is preferred over prepending `cd <path> &&` in the command string. Delegates consistently used the `cd` anti-pattern (55% of calls in production), causing redundant token cost on every invocation.

Replaces the escape-hatch disclosure sentence with a prescriptive preference statement. No behavior change; description only.

## Changes

- `crates/aptu-coder/src/lib.rs`: update `exec_command` tool description sentence

## Motivation

Analysis of session logs showed 1,400+ daily `exec_command` calls with `cd /abs/path &&` prefix and no `working_dir` set, and 40 calls with both set to the same value (strict redundancy). Root cause: the description said `cd bypasses this restriction` without saying not to use it. Per Anthropic's tool design guidance, implicit preferences must be made explicit in tool descriptions.
