### PR TITLE
chore(release): bump version to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version to 0.17.1 for patch release.

Closes no issue -- version-only change to unlock the signed release tag and Homebrew formula update.

## Changes

- `Cargo.toml`: `0.17.0` -> `0.17.1`
- `Cargo.lock`: updated to match
