### PR TITLE
fix(validation): apply Vec-collect fix to validate_path require_exists=false branch

### DIFF
--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -3,6 +3,7 @@
 //! Path validation helpers used by the edit_overwrite and edit_replace tool handlers.
 
 use rmcp::model::ErrorData;
+use tracing::warn;
 
 use crate::error_meta;
 
@@ -85,8 +86,14 @@ pub(crate) fn validate_path(
         // Reassemble suffix in the original (forward) order without trailing separator.
         let suffix: std::path::PathBuf = suffix_components.into_iter().rev().collect();
 
-        let canonical_base =
-            std::fs::canonicalize(&ancestor).unwrap_or_else(|_| allowed_root.clone());
+        let canonical_base = std::fs::canonicalize(&ancestor).unwrap_or_else(|e| {
+            warn!(
+                path = %ancestor.display(),
+                error = %e,
+                "canonicalize of existing ancestor failed (race condition); falling back to allowed_root"
+            );
+            allowed_root.clone()
+        });
         canonical_base.join(&suffix)
     };
 

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -45,10 +45,16 @@ pub(crate) fn validate_path(
             )
         })?
     } else {
-        // For non-existent files (edit_overwrite), walk up the path until we find an existing ancestor
+        // For non-existent files (edit_overwrite), walk up the path until we find an existing ancestor.
+        // `..` components are safe here: file_name() returns None for `..`, so the
+        // loop hits the else branch and resets ancestor to allowed_root, anchoring
+        // the resolved path inside allowed_root.  The starts_with check below catches
+        // any residual traversal regardless.
         let p = std::path::Path::new(path);
         let mut ancestor = p.to_path_buf();
-        let mut suffix = std::path::PathBuf::new();
+        // Collect suffix components in reverse order, then reassemble without
+        // join(PathBuf::new()) to avoid a trailing separator on the first push.
+        let mut suffix_components: Vec<std::ffi::OsString> = Vec::new();
 
         loop {
             if ancestor.exists() {
@@ -57,7 +63,7 @@ pub(crate) fn validate_path(
             if let Some(parent) = ancestor.parent()
                 && let Some(file_name) = ancestor.file_name()
             {
-                suffix = std::path::PathBuf::from(file_name).join(&suffix);
+                suffix_components.push(file_name.to_owned());
                 ancestor = parent.to_path_buf();
             } else {
                 // No existing ancestor found — use allowed_root as anchor
@@ -65,6 +71,9 @@ pub(crate) fn validate_path(
                 break;
             }
         }
+
+        // Reassemble suffix in the original (forward) order without trailing separator.
+        let suffix: std::path::PathBuf = suffix_components.into_iter().rev().collect();
 
         let canonical_base =
             std::fs::canonicalize(&ancestor).unwrap_or_else(|_| allowed_root.clone());
@@ -220,4 +229,38 @@ pub(crate) fn validate_path_in_dir(
     }
 
     Ok(canonical_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_path_no_trailing_slash() {
+        // Arrange: a multi-component path for a non-existent file
+        let input = "subdir/new_file.txt";
+
+        // Act: validate with require_exists=false
+        let result = validate_path(input, false);
+
+        // Assert: resolved path must not have a trailing slash
+        // The old bug (PathBuf::from(file_name).join(&suffix) with an empty
+        // PathBuf as the initial suffix) injected a trailing separator,
+        // producing ".../subdir/new_file.txt/" instead of
+        // ".../subdir/new_file.txt".
+        if let Ok(resolved) = result {
+            let path_str = resolved.to_string_lossy();
+            // PathBuf::to_string_lossy surrogates the trailing separator as "",
+            // but the canonical representation still carries it.  Check both.
+            assert!(
+                !path_str.ends_with('/'),
+                "resolved path must not end with trailing slash: {path_str}"
+            );
+            assert_eq!(
+                resolved.extension(),
+                Some(std::ffi::OsStr::new("txt")),
+                "file extension should be txt, path has trailing separator"
+            );
+        }
+    }
 }

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -14,7 +14,7 @@ pub(crate) fn validate_path(
     require_exists: bool,
 ) -> Result<std::path::PathBuf, ErrorData> {
     // Canonicalize the allowed root (CWD) to resolve symlinks
-    let allowed_root = std::fs::canonicalize(std::env::current_dir().map_err(|_| {
+    let cwd = std::env::current_dir().map_err(|_| {
         ErrorData::new(
             rmcp::model::ErrorCode::INVALID_PARAMS,
             "path is outside the allowed root".to_string(),
@@ -24,8 +24,18 @@ pub(crate) fn validate_path(
                 "ensure the working directory is accessible",
             )),
         )
-    })?)
-    .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+    })?;
+    let allowed_root = std::fs::canonicalize(&cwd).map_err(|_| {
+        ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_PARAMS,
+            "path is outside the allowed root".to_string(),
+            Some(error_meta(
+                "validation",
+                false,
+                "ensure the working directory is accessible",
+            )),
+        )
+    })?;
 
     let canonical_path = if require_exists {
         std::fs::canonicalize(path).map_err(|e| {

--- a/crates/aptu-coder/tests/edit_working_dir.rs
+++ b/crates/aptu-coder/tests/edit_working_dir.rs
@@ -43,6 +43,47 @@ async fn edit_overwrite_working_dir_writes_inside_working_dir() {
     assert_eq!(written, "hello from working_dir");
 }
 
+/// edit_overwrite without working_dir creates a new file relative to server CWD.
+#[tokio::test]
+async fn edit_overwrite_new_file_no_working_dir() {
+    // Arrange: create a temp dir inside CWD for the target file.
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let file_name = "new_output.txt";
+    let expected_path = temp_dir.path().join(file_name);
+    // Build the relative path from CWD to the temp dir file.
+    let temp_stem = temp_dir
+        .path()
+        .file_name()
+        .expect("temp dir has file name")
+        .to_str()
+        .expect("temp dir name is valid UTF-8");
+    let relative_path = format!("{temp_stem}/{file_name}");
+
+    // Act: call edit_overwrite without working_dir
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": relative_path,
+            "content": "hello no working_dir"
+        }),
+    )
+    .await;
+
+    // Assert: tool must succeed and file must exist and contain correct content
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success but got error: {resp}"
+    );
+    assert!(
+        expected_path.exists(),
+        "file should exist at {:?}",
+        expected_path
+    );
+    let written = std::fs::read_to_string(&expected_path).expect("should read written file");
+    assert_eq!(written, "hello no working_dir");
+}
+
 /// edit_replace with working_dir modifies the correct file inside working_dir, not server CWD.
 #[tokio::test]
 async fn edit_replace_working_dir_modifies_inside_working_dir() {


### PR DESCRIPTION
## Summary

Fixes the `edit_overwrite internal_error` regression introduced in 0.17.0 (#1079) where writing new files without `working_dir` produced a trailing-slash path that `rename(2)` rejected with `ENOENT`/`ENOTDIR`.

## Root Cause

The `require_exists=false` branch of `validate_path` in `validation.rs` used `PathBuf::from(file_name).join(&suffix)` with an initially empty suffix `PathBuf`. `join` on an empty `PathBuf` injects a trailing separator, producing paths like `subdir/new_file.txt/` instead of `subdir/new_file.txt`. The same bug was fixed in `validate_path_in_dir` by #1079 but was not applied to `validate_path`.

`edit_replace` was unaffected (takes the `require_exists=true` / `canonicalize` branch). `edit_overwrite` with `working_dir` was unaffected (`validate_path_in_dir` already patched).

## Changes

- **`crates/aptu-coder/src/validation.rs`** (`79e695a`): replace the buggy suffix loop in `validate_path` `require_exists=false` branch with `Vec<OsString>` collect + `.into_iter().rev().collect()` -- identical to the pattern in `validate_path_in_dir` (lines 174-195). Preserves the `PathBuf::starts_with` security check and all other validation logic.
- **`crates/aptu-coder/src/validation.rs`** (`9c62419`): propagate `canonicalize(current_dir())` error instead of falling back silently to a non-canonical path via `unwrap_or_else`.
- **`crates/aptu-coder/src/validation.rs`** (`8639cda`): emit `tracing::warn!` with path and error when the `canonicalize(&ancestor)` fallback fires (race condition between `exists()` check and canonicalization), instead of swallowing the error silently.
- **`crates/aptu-coder/tests/edit_working_dir.rs`**: add integration test `edit_overwrite_new_file_no_working_dir` and unit test `validate_path_no_trailing_slash`.

## Test Results

- 87 tests passed (includes 2 new tests)
- 1 pre-existing failure in `test_profile_env_var_fallback` (unrelated to this change)
- Lint clean, format clean

Closes #1089
