### PR TITLE
chore(release): bump version to 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bumps workspace version from `0.17.1` to `0.17.2`.

Closes #1089
