### PR TITLE
docs: guard JSONL queries against CWD and announce path in MCP instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ Daily-rotated JSONL files live at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.
 
 Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool).
 
-Five validated jq one-liners:
+**Query rule:** always `cd` to the metrics directory before running jq glob patterns. Never pass brace-expanded filenames (`metrics-2026-06-1{0,1,2}.jsonl`) from a different working directory -- globs expand against CWD and silently produce no matches when the files are not there.
+
+Five validated jq one-liners (run from `~/.local/share/aptu-coder/`):
 
 1. Tool call volume: `jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
 2. Avg duration by tool: `jq -r '[.tool, .duration_ms] | @tsv' metrics-*.jsonl | awk -F'\t' '{c[$1]++;s[$1]+=$2} END{for(t in c) printf "%s\t%dms avg\n",t,s[t]/c[t]}' | sort -t$'\t' -k2 -rn`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,7 @@ Daily-rotated JSONL files live at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.
 
 Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool).
 
-**Query rule:** always `cd` to the metrics directory before running jq glob patterns. Never pass brace-expanded filenames (`metrics-2026-06-1{0,1,2}.jsonl`) from a different working directory -- globs expand against CWD and silently produce no matches when the files are not there.
-
-Five validated jq one-liners (run from `~/.local/share/aptu-coder/`):
+Five validated jq one-liners (run from `~/.local/share/aptu-coder/`). Always `cd` there first -- globs expand against CWD and silently match nothing from a different directory.
 
 1. Tool call volume: `jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
 2. Avg duration by tool: `jq -r '[.tool, .duration_ms] | @tsv' metrics-*.jsonl | awk -F'\t' '{c[$1]++;s[$1]+=$2} END{for(t in c) printf "%s\t%dms avg\n",t,s[t]/c[t]}' | sort -t$'\t' -k2 -rn`

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3910,7 +3910,7 @@ impl ServerHandler for CodeAnalyzer {
             3. For key files, prefer analyze_module for function/import index; use analyze_file for signatures and types.\n\
             4. Use analyze_symbol to trace call graphs.\n\
             Prefer summary=true on 1000+ files. Set max_depth=2; increase if packages too large. Paginate with cursor/page_size. For subagents: DISABLE_PROMPT_CACHING=1.\n\
-            JSONL metrics: always-on, written to $HOME/.local/share/aptu-coder/metrics-YYYY-MM-DD.jsonl (or $XDG_DATA_HOME/aptu-coder/ if set). To query: cd ${{HOME}}/.local/share/aptu-coder && jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn. Always cd to the metrics directory before running jq glob patterns -- never pass brace-expanded filenames from a different working directory."
+            JSONL metrics: always-on at $HOME/.local/share/aptu-coder/metrics-YYYY-MM-DD.jsonl ($XDG_DATA_HOME/aptu-coder/ if set). Query from that directory: cd to it before running jq glob patterns."
         );
         let capabilities = ServerCapabilities::builder()
             .enable_logging()

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3909,7 +3909,8 @@ impl ServerHandler for CodeAnalyzer {
             2. Re-run analyze_directory(path=<source_package>, max_depth=2, summary=true) for module map. Include test directories (tests/, *_test.go, test_*.py, test_*.rs, *.spec.ts, *.spec.js).\n\
             3. For key files, prefer analyze_module for function/import index; use analyze_file for signatures and types.\n\
             4. Use analyze_symbol to trace call graphs.\n\
-            Prefer summary=true on 1000+ files. Set max_depth=2; increase if packages too large. Paginate with cursor/page_size. For subagents: DISABLE_PROMPT_CACHING=1."
+            Prefer summary=true on 1000+ files. Set max_depth=2; increase if packages too large. Paginate with cursor/page_size. For subagents: DISABLE_PROMPT_CACHING=1.\n\
+            JSONL metrics: always-on, written to $HOME/.local/share/aptu-coder/metrics-YYYY-MM-DD.jsonl (or $XDG_DATA_HOME/aptu-coder/ if set). To query: cd ${{HOME}}/.local/share/aptu-coder && jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn. Always cd to the metrics directory before running jq glob patterns -- never pass brace-expanded filenames from a different working directory."
         );
         let capabilities = ServerCapabilities::builder()
             .enable_logging()

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3910,7 +3910,7 @@ impl ServerHandler for CodeAnalyzer {
             3. For key files, prefer analyze_module for function/import index; use analyze_file for signatures and types.\n\
             4. Use analyze_symbol to trace call graphs.\n\
             Prefer summary=true on 1000+ files. Set max_depth=2; increase if packages too large. Paginate with cursor/page_size. For subagents: DISABLE_PROMPT_CACHING=1.\n\
-            JSONL metrics: always-on at $HOME/.local/share/aptu-coder/metrics-YYYY-MM-DD.jsonl ($XDG_DATA_HOME/aptu-coder/ if set). Query from that directory: cd to it before running jq glob patterns."
+            JSONL metrics at $HOME/.local/share/aptu-coder/ (or $XDG_DATA_HOME/aptu-coder/). Always cd there before jq glob queries."
         );
         let capabilities = ServerCapabilities::builder()
             .enable_logging()

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -68,7 +68,7 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 The five jq one-liners in `AGENTS.md` do not reference `output_truncated` and are unaffected. To query truncation events across all retained JSONL files:
 
 ```bash
-jq -r 'select(.output_truncated==true) | [.tool, .output_chars, (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn
+cd ~/.local/share/aptu-coder && jq -r 'select(.output_truncated==true) | [.tool, .output_chars, (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn
 ```
 
 ## Daily Rotation and 30-Day Retention


### PR DESCRIPTION
## Problem

JSONL metrics queries silently return wrong results when run from the wrong working directory. Brace-expanded filenames like `metrics-2026-06-1{0,1,2}.jsonl` expand against CWD; when the shell is not inside `~/.local/share/aptu-coder/`, the glob matches nothing and jq processes zero files without error. This produced a false "only 1 call recorded" reading during a model-switch analysis, when the actual volume was 31,501 calls across the same period.

MCP clients also had no way to know where JSONL files land without reading AGENTS.md or OBSERVABILITY.md.

## Changes

- `AGENTS.md`: fold `cd`-first rule into the one-liners header line
- `docs/OBSERVABILITY.md`: prefix the truncation snippet with `cd ~/.local/share/aptu-coder &&`
- `lib.rs` `get_info`: append JSONL location and `cd`-first rule to MCP server instructions

## Testing

No logic change. Existing tests unaffected.
