### PR TITLE
fix(schema): replace non-standard uint/uint64 JSON Schema formats with draft-07 compliant integer

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -51,8 +51,16 @@ pub struct DefUseSite {
     /// File path (relative to the analysis root).
     pub file: String,
     /// Line number (1-indexed) in the file.
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
     pub line: usize,
     /// Column offset (0-indexed, byte offset from line start).
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
     pub column: usize,
     /// 3-line code context: lines N-1, N, N+1 from source.
     pub snippet: String,
@@ -842,6 +850,10 @@ pub struct EditOverwriteOutput {
     /// Path of the file that was written.
     pub path: String,
     /// Number of bytes written (UTF-8 byte length of content).
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
     pub bytes_written: usize,
 }
 
@@ -866,8 +878,16 @@ pub struct EditReplaceOutput {
     /// Path of the file that was edited.
     pub path: String,
     /// File size in bytes before the edit.
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
     pub bytes_before: usize,
     /// File size in bytes after the edit.
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
     pub bytes_after: usize,
 }
 
@@ -890,6 +910,10 @@ pub struct FilterRule {
     #[serde(default)]
     pub keep_lines_matching: Vec<String>,
     /// Maximum number of lines to keep in output.
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::option_integer_schema")
+    )]
     pub max_lines: Option<usize>,
     /// Replacement text if filtered output is empty (success-only).
     pub on_empty: Option<String>,

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -45,14 +45,17 @@ pub struct ExecCommandParams {
     /// Shell command to execute via sh -c (or $SHELL if set).
     pub command: String,
     /// Timeout in seconds before SIGKILL. None = no timeout (default).
+    #[schemars(schema_with = "aptu_coder_core::schema_helpers::option_integer_schema")]
     pub timeout_secs: Option<u64>,
     /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
     pub working_dir: Option<String>,
     /// Cap on virtual address space in megabytes (Linux only; silently accepted but not enforced on macOS).
     /// None = no limit (default).
+    #[schemars(schema_with = "aptu_coder_core::schema_helpers::option_integer_schema")]
     pub memory_limit_mb: Option<u64>,
     /// CPU time limit in seconds. Complements timeout_secs (wall-clock). SIGXCPU on soft-limit breach, SIGKILL on hard-limit breach.
     /// None = no limit (default).
+    #[schemars(schema_with = "aptu_coder_core::schema_helpers::option_integer_schema")]
     pub cpu_limit_secs: Option<u64>,
     /// UTF-8 content to pipe into the process stdin (max `STDIN_MAX_BYTES` = 1 MB). When None, stdin is closed (null).
     pub stdin: Option<String>,


### PR DESCRIPTION
## Summary

Fixes #1091.

Adds `#[schemars(schema_with)]` annotations to 9 unsigned integer fields across 5 structs in 2 files, replacing the non-standard `"uint"` and `"uint64"` JSON Schema formats (emitted by default for `usize` and `u64` by schemars 1.2.1) with draft-07 compliant format-free integer schemas (`{"type":"integer","minimum":0}`).

## Changes

crates/aptu-coder-core/src/types.rs
crates/aptu-coder/src/lib.rs

## Test plan

- [x] Tests pass (see 03-build.json test_results: 580 passed)
- [x] Linter clean (cargo clippy -- -D warnings: clean)
- [x] Security scan clean (no critical/high findings)

## Affected fields

**crates/aptu-coder-core/src/types.rs**
- `DefUseSite.line` (usize)
- `DefUseSite.column` (usize)
- `EditOverwriteOutput.bytes_written` (usize)
- `EditReplaceOutput.bytes_before` (usize)
- `EditReplaceOutput.bytes_after` (usize)
- `FilterRule.max_lines` (Option<usize>)

**crates/aptu-coder/src/lib.rs**
- `ExecCommandParams.timeout_secs` (Option<u64>)
- `ExecCommandParams.memory_limit_mb` (Option<u64>)
- `ExecCommandParams.cpu_limit_secs` (Option<u64>)

## Approach

Reuses the existing `integer_schema` and `option_integer_schema` helpers from `crates/aptu-coder-core/src/schema_helpers.rs`. No new helpers, no new dependencies, no runtime changes.

## Verification

After the fix, `tools/list` emits zero occurrences of `"uint"` or `"uint64"` format strings across all 7 tool schemas. Confirmed by piping a live `tools/list` request through the built binary and grepping for uint patterns.
