### PR TITLE
fix(exec_command): add cd prefix sanitizer, prohibit cd in description, clean up working_dir validation errors

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -47,7 +47,7 @@ pub struct ExecCommandParams {
     /// Timeout in seconds before SIGKILL. None = no timeout (default).
     #[schemars(schema_with = "aptu_coder_core::schema_helpers::option_integer_schema")]
     pub timeout_secs: Option<u64>,
-    /// Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process.
+    /// Working directory for the command. Set this instead of prepending cd to the command string. Validated against path traversal; does not sandbox the process.
     pub working_dir: Option<String>,
     /// Cap on virtual address space in megabytes (Linux only; silently accepted but not enforced on macOS).
     /// None = no limit (default).
@@ -2709,7 +2709,11 @@ impl CodeAnalyzer {
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(err_to_tool_result(e));
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "working_dir {:?} is not valid: {}. Provide an existing directory path.",
+                        wd, e.message
+                    ))])
+                    .with_meta(Some(no_cache_meta())));
                 }
             }
         } else {
@@ -2957,7 +2961,11 @@ impl CodeAnalyzer {
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(err_to_tool_result(e));
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "working_dir {:?} is not valid: {}. Provide an existing directory path.",
+                        wd, e.message
+                    ))])
+                    .with_meta(Some(no_cache_meta())));
                 }
             }
         } else {
@@ -3246,7 +3254,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; use timeout_secs to limit execution time. Prefer working_dir over cd <path> && in command -- set working_dir and use relative paths; cd and absolute paths still work but are redundant when working_dir is set. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; use timeout_secs to limit execution time. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",
@@ -3290,26 +3298,66 @@ impl CodeAnalyzer {
                     if !std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) {
                         span.record("error", true);
                         span.record("error.type", "invalid_params");
-                        return Ok(err_to_tool_result(ErrorData::new(
-                            rmcp::model::ErrorCode::INVALID_PARAMS,
-                            "working_dir must be a directory".to_string(),
-                            Some(error_meta(
-                                "validation",
-                                false,
-                                "provide a valid directory path",
-                            )),
-                        )));
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "working_dir {:?} is not a directory. Provide an existing directory path.",
+                            wd
+                        ))]).with_meta(Some(no_cache_meta())));
                     }
                     Some(p)
                 }
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(err_to_tool_result(e));
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "working_dir {:?} is not valid: {}. Provide an existing directory path.",
+                        wd, e.message
+                    ))])
+                    .with_meta(Some(no_cache_meta())));
                 }
             }
         } else {
             None
+        };
+
+        // Strip leading cd <path> && prefix from command if present
+        let (effective_command, cd_extracted_path) = strip_cd_prefix(&params.command);
+        let command = effective_command.to_owned();
+        let working_dir_path = if let Some(cd_path) = cd_extracted_path {
+            if working_dir_path.is_none() {
+                // Promote the cd path as working_dir, run through validation
+                match validate_path(cd_path, true) {
+                    Ok(p) if std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) => {
+                        tracing::debug!(
+                            "exec_command: promoting cd prefix path as working_dir: {}",
+                            cd_path
+                        );
+                        Some(p)
+                    }
+                    Ok(_) => {
+                        span.record("error", true);
+                        span.record("error.type", "invalid_params");
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "cd prefix path {:?} is not a directory. Set working_dir explicitly or use a valid directory path.",
+                            cd_path
+                        ))]).with_meta(Some(no_cache_meta())));
+                    }
+                    Err(_) => {
+                        span.record("error", true);
+                        span.record("error.type", "invalid_params");
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "cd prefix path {:?} does not exist or is outside CWD. Set working_dir explicitly.",
+                            cd_path
+                        ))]).with_meta(Some(no_cache_meta())));
+                    }
+                }
+            } else {
+                tracing::debug!(
+                    "exec_command: stripped redundant cd prefix from command; working_dir already set"
+                );
+                working_dir_path
+            }
+        } else {
+            working_dir_path
         };
 
         let param_path = params.working_dir.clone();
@@ -3331,7 +3379,6 @@ impl CodeAnalyzer {
             )));
         }
 
-        let command = params.command.clone();
         let timeout_secs = params.timeout_secs;
 
         // Execute command (non-cacheable; exec_command is side-effecting and non-idempotent)
@@ -3543,6 +3590,26 @@ fn build_exec_command(
     }
 
     cmd
+}
+
+/// Strip a leading `cd <path> &&` prefix from a command string.
+///
+/// Returns `(stripped_command, Some(extracted_path))` when the command starts with
+/// `cd <path> &&`. Returns `(cmd, None)` when no `cd ... &&` prefix is found.
+///
+/// Uses only `str` methods (no regex). Leading whitespace is trimmed before matching.
+fn strip_cd_prefix(cmd: &str) -> (&str, Option<&str>) {
+    let trimmed = cmd.trim_start();
+    let Some(rest) = trimmed.strip_prefix("cd ") else {
+        return (cmd, None);
+    };
+    // Find the && separator
+    let Some((path_part, rest_part)) = rest.split_once("&&") else {
+        return (cmd, None);
+    };
+    let path = path_part.trim();
+    let stripped = rest_part.trim();
+    (stripped, Some(path))
 }
 
 /// Run a spawned child process with timeout handling and output draining.
@@ -6094,5 +6161,35 @@ mod tests {
             result.is_ok(),
             "handle_overview_mode with None token must succeed"
         );
+    }
+
+    // ── strip_cd_prefix tests ──
+
+    #[test]
+    fn test_strip_cd_prefix_basic() {
+        let (cmd, path) = strip_cd_prefix("cd /tmp && echo hello");
+        assert_eq!(cmd, "echo hello");
+        assert_eq!(path, Some("/tmp"));
+    }
+
+    #[test]
+    fn test_strip_cd_prefix_no_ampersand() {
+        let (cmd, path) = strip_cd_prefix("cd /tmp");
+        assert_eq!(cmd, "cd /tmp");
+        assert_eq!(path, None);
+    }
+
+    #[test]
+    fn test_strip_cd_prefix_no_cd() {
+        let (cmd, path) = strip_cd_prefix("echo hello");
+        assert_eq!(cmd, "echo hello");
+        assert_eq!(path, None);
+    }
+
+    #[test]
+    fn test_strip_cd_prefix_with_spaces() {
+        let (cmd, path) = strip_cd_prefix("cd  /tmp  &&  echo hello");
+        assert_eq!(path, Some("/tmp"));
+        assert_eq!(cmd.trim(), "echo hello");
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -292,7 +292,12 @@ fn error_meta(
 
 #[must_use]
 fn err_to_tool_result(e: ErrorData) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(e.message)])
+    CallToolResult::error(vec![Content::text(e.message)]).with_meta(Some(no_cache_meta()))
+}
+
+#[must_use]
+fn tool_error(msg: String) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(msg)]).with_meta(Some(no_cache_meta()))
 }
 
 fn err_to_tool_result_from_pagination(
@@ -2709,11 +2714,10 @@ impl CodeAnalyzer {
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                    return Ok(tool_error(format!(
                         "working_dir {:?} is not valid: {}. Provide an existing directory path.",
                         wd, e.message
-                    ))])
-                    .with_meta(Some(no_cache_meta())));
+                    )));
                 }
             }
         } else {
@@ -2961,11 +2965,10 @@ impl CodeAnalyzer {
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                    return Ok(tool_error(format!(
                         "working_dir {:?} is not valid: {}. Provide an existing directory path.",
                         wd, e.message
-                    ))])
-                    .with_meta(Some(no_cache_meta())));
+                    )));
                 }
             }
         } else {
@@ -3298,21 +3301,20 @@ impl CodeAnalyzer {
                     if !std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) {
                         span.record("error", true);
                         span.record("error.type", "invalid_params");
-                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                        return Ok(tool_error(format!(
                             "working_dir {:?} is not a directory. Provide an existing directory path.",
                             wd
-                        ))]).with_meta(Some(no_cache_meta())));
+                        )));
                     }
                     Some(p)
                 }
                 Err(e) => {
                     span.record("error", true);
                     span.record("error.type", "invalid_params");
-                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                    return Ok(tool_error(format!(
                         "working_dir {:?} is not valid: {}. Provide an existing directory path.",
                         wd, e.message
-                    ))])
-                    .with_meta(Some(no_cache_meta())));
+                    )));
                 }
             }
         } else {
@@ -3351,18 +3353,18 @@ impl CodeAnalyzer {
                         Ok(_) => {
                             span.record("error", true);
                             span.record("error.type", "invalid_params");
-                            return Ok(CallToolResult::error(vec![Content::text(format!(
+                            return Ok(tool_error(format!(
                                 "cd prefix path {:?} is not a directory. Set working_dir explicitly or use a valid directory path.",
                                 cd_path
-                            ))]).with_meta(Some(no_cache_meta())));
+                            )));
                         }
                         Err(_) => {
                             span.record("error", true);
                             span.record("error.type", "invalid_params");
-                            return Ok(CallToolResult::error(vec![Content::text(format!(
+                            return Ok(tool_error(format!(
                                 "cd prefix path {:?} does not exist or is outside CWD. Set working_dir explicitly.",
                                 cd_path
-                            ))]).with_meta(Some(no_cache_meta())));
+                            )));
                         }
                     }
                 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -6208,15 +6208,11 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_cd_prefix_load_bearing_chain() {
-        // "cd sub && build && cd ../other && build" -- the first cd navigates to a
-        // subdirectory that the rest of the chain depends on. split_once("&&") extracts
-        // "sub" as the path and the tail as the stripped command; the caller must detect
-        // that "sub" != working_dir and pass the original command through unmodified.
+    fn test_strip_cd_prefix_multi_step_chain() {
+        // Parser splits on first &&; the caller is responsible for deciding whether to use it.
         let (stripped, path) =
-            strip_cd_prefix("cd workers/dashboard && bunx build && cd ../digest && bunx build");
-        // strip_cd_prefix itself splits on first &&; caller decides whether to use it.
+            strip_cd_prefix("cd workers/dashboard && bunx wrangler build 2>&1 | tail -8 && cd ../digest && bunx wrangler build 2>&1 | tail -8");
         assert_eq!(path, Some("workers/dashboard"));
-        assert_eq!(stripped.trim(), "bunx build && cd ../digest && bunx build");
+        assert_eq!(stripped.trim(), "bunx wrangler build 2>&1 | tail -8 && cd ../digest && bunx wrangler build 2>&1 | tail -8");
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3327,30 +3327,43 @@ impl CodeAnalyzer {
         let (effective_command, cd_extracted_path) = strip_cd_prefix(&params.command);
         let (command, working_dir_path) = if let Some(cd_path) = cd_extracted_path {
             if working_dir_path.is_none() {
-                // Promote the cd path as working_dir, run through validation
-                match validate_path(cd_path, true) {
-                    Ok(p) if std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) => {
-                        tracing::debug!(
-                            "exec_command: promoting cd prefix path as working_dir: {}",
-                            cd_path
-                        );
-                        (effective_command.to_owned(), Some(p))
-                    }
-                    Ok(_) => {
-                        span.record("error", true);
-                        span.record("error.type", "invalid_params");
-                        return Ok(CallToolResult::error(vec![Content::text(format!(
-                            "cd prefix path {:?} is not a directory. Set working_dir explicitly or use a valid directory path.",
-                            cd_path
-                        ))]).with_meta(Some(no_cache_meta())));
-                    }
-                    Err(_) => {
-                        span.record("error", true);
-                        span.record("error.type", "invalid_params");
-                        return Ok(CallToolResult::error(vec![Content::text(format!(
-                            "cd prefix path {:?} does not exist or is outside CWD. Set working_dir explicitly.",
-                            cd_path
-                        ))]).with_meta(Some(no_cache_meta())));
+                // Only promote when the path is a plain absolute literal -- no shell
+                // special characters (~, $, -). Relative paths and shell-expanded forms
+                // (cd ~, cd $VAR, cd -) must reach the shell unmodified; validate_path
+                // cannot resolve them correctly before execution.
+                let is_plain_absolute = cd_path.starts_with('/')
+                    && !cd_path.contains('$')
+                    && !cd_path.contains('~')
+                    && cd_path != "-";
+                if !is_plain_absolute {
+                    // Shell-special or relative -- pass through unmodified.
+                    (params.command.clone(), working_dir_path)
+                } else {
+                    // Promote the cd path as working_dir, run through validation
+                    match validate_path(cd_path, true) {
+                        Ok(p) if std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) => {
+                            tracing::debug!(
+                                "exec_command: promoting cd prefix path as working_dir: {}",
+                                cd_path
+                            );
+                            (effective_command.to_owned(), Some(p))
+                        }
+                        Ok(_) => {
+                            span.record("error", true);
+                            span.record("error.type", "invalid_params");
+                            return Ok(CallToolResult::error(vec![Content::text(format!(
+                                "cd prefix path {:?} is not a directory. Set working_dir explicitly or use a valid directory path.",
+                                cd_path
+                            ))]).with_meta(Some(no_cache_meta())));
+                        }
+                        Err(_) => {
+                            span.record("error", true);
+                            span.record("error.type", "invalid_params");
+                            return Ok(CallToolResult::error(vec![Content::text(format!(
+                                "cd prefix path {:?} does not exist or is outside CWD. Set working_dir explicitly.",
+                                cd_path
+                            ))]).with_meta(Some(no_cache_meta())));
+                        }
                     }
                 }
             } else {
@@ -6188,30 +6201,25 @@ mod tests {
 
     #[test]
     fn test_strip_cd_prefix_no_ampersand() {
+        // No && separator -- returned unmodified; shell handles the cd naturally.
         let (cmd, path) = strip_cd_prefix("cd /tmp");
         assert_eq!(cmd, "cd /tmp");
         assert_eq!(path, None);
     }
 
     #[test]
-    fn test_strip_cd_prefix_no_cd() {
-        let (cmd, path) = strip_cd_prefix("echo hello");
-        assert_eq!(cmd, "echo hello");
-        assert_eq!(path, None);
-    }
-
-    #[test]
-    fn test_strip_cd_prefix_with_spaces() {
+    fn test_strip_cd_prefix_with_extra_spaces() {
+        // Surrounding whitespace is trimmed from both extracted path and stripped command.
         let (cmd, path) = strip_cd_prefix("cd  /tmp  &&  echo hello");
         assert_eq!(path, Some("/tmp"));
-        assert_eq!(cmd.trim(), "echo hello");
+        assert_eq!(cmd, "echo hello");
     }
 
     #[test]
     fn test_strip_cd_prefix_splits_on_first_ampersand_only() {
-        // Only the leading cd is consumed; remaining && in the command are preserved.
-        let (stripped, path) = strip_cd_prefix("cd /a && cmd1 && cd /b && cmd2");
+        // Only the leading cd && is consumed; subsequent && in the command are preserved.
+        let (cmd, path) = strip_cd_prefix("cd /a && cmd1 && cd /b && cmd2");
         assert_eq!(path, Some("/a"));
-        assert_eq!(stripped.trim(), "cmd1 && cd /b && cmd2");
+        assert_eq!(cmd, "cmd1 && cd /b && cmd2");
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -6208,11 +6208,10 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_cd_prefix_multi_step_chain() {
-        // Parser splits on first &&; the caller is responsible for deciding whether to use it.
-        let (stripped, path) =
-            strip_cd_prefix("cd workers/dashboard && bunx wrangler build 2>&1 | tail -8 && cd ../digest && bunx wrangler build 2>&1 | tail -8");
-        assert_eq!(path, Some("workers/dashboard"));
-        assert_eq!(stripped.trim(), "bunx wrangler build 2>&1 | tail -8 && cd ../digest && bunx wrangler build 2>&1 | tail -8");
+    fn test_strip_cd_prefix_splits_on_first_ampersand_only() {
+        // Only the leading cd is consumed; remaining && in the command are preserved.
+        let (stripped, path) = strip_cd_prefix("cd /a && cmd1 && cd /b && cmd2");
+        assert_eq!(path, Some("/a"));
+        assert_eq!(stripped.trim(), "cmd1 && cd /b && cmd2");
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3319,10 +3319,13 @@ impl CodeAnalyzer {
             None
         };
 
-        // Strip leading cd <path> && prefix from command if present
+        // Strip leading "cd <path> &&" prefix from command only when provably redundant.
+        // - No working_dir: promote the cd path as working_dir (unambiguous).
+        // - working_dir already set: strip only if the cd path resolves to the same
+        //   directory; otherwise pass the command through unmodified (the cd is
+        //   load-bearing, e.g. a multi-step chain like "cd sub && build && cd ../other && build").
         let (effective_command, cd_extracted_path) = strip_cd_prefix(&params.command);
-        let command = effective_command.to_owned();
-        let working_dir_path = if let Some(cd_path) = cd_extracted_path {
+        let (command, working_dir_path) = if let Some(cd_path) = cd_extracted_path {
             if working_dir_path.is_none() {
                 // Promote the cd path as working_dir, run through validation
                 match validate_path(cd_path, true) {
@@ -3331,7 +3334,7 @@ impl CodeAnalyzer {
                             "exec_command: promoting cd prefix path as working_dir: {}",
                             cd_path
                         );
-                        Some(p)
+                        (effective_command.to_owned(), Some(p))
                     }
                     Ok(_) => {
                         span.record("error", true);
@@ -3351,13 +3354,24 @@ impl CodeAnalyzer {
                     }
                 }
             } else {
-                tracing::debug!(
-                    "exec_command: stripped redundant cd prefix from command; working_dir already set"
-                );
-                working_dir_path
+                // working_dir is already set -- only strip if the cd path resolves to
+                // the same directory (redundant). Otherwise keep the full original command.
+                let cd_resolves_to_same = validate_path(cd_path, true)
+                    .ok()
+                    .map(|p| Some(&p) == working_dir_path.as_ref())
+                    .unwrap_or(false);
+                if cd_resolves_to_same {
+                    tracing::debug!(
+                        "exec_command: stripped redundant cd prefix; matches explicit working_dir"
+                    );
+                    (effective_command.to_owned(), working_dir_path)
+                } else {
+                    // cd path differs from working_dir -- the cd is load-bearing; pass through.
+                    (params.command.clone(), working_dir_path)
+                }
             }
         } else {
-            working_dir_path
+            (params.command.clone(), working_dir_path)
         };
 
         let param_path = params.working_dir.clone();
@@ -6191,5 +6205,18 @@ mod tests {
         let (cmd, path) = strip_cd_prefix("cd  /tmp  &&  echo hello");
         assert_eq!(path, Some("/tmp"));
         assert_eq!(cmd.trim(), "echo hello");
+    }
+
+    #[test]
+    fn test_strip_cd_prefix_load_bearing_chain() {
+        // "cd sub && build && cd ../other && build" -- the first cd navigates to a
+        // subdirectory that the rest of the chain depends on. split_once("&&") extracts
+        // "sub" as the path and the tail as the stripped command; the caller must detect
+        // that "sub" != working_dir and pass the original command through unmodified.
+        let (stripped, path) =
+            strip_cd_prefix("cd workers/dashboard && bunx build && cd ../digest && bunx build");
+        // strip_cd_prefix itself splits on first &&; caller decides whether to use it.
+        assert_eq!(path, Some("workers/dashboard"));
+        assert_eq!(stripped.trim(), "bunx build && cd ../digest && bunx build");
     }
 }

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -115,7 +115,7 @@ pub(crate) fn validate_path(
 /// Maps an io::Error to an ErrorData with kind-specific message and preserved context.
 pub(crate) fn io_error_to_path_error(
     err: &std::io::Error,
-    path_context: &str,
+    _path_context: &str,
     suggested_action: &'static str,
 ) -> ErrorData {
     let msg = match err.kind() {

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -115,13 +115,13 @@ pub(crate) fn validate_path(
 /// Maps an io::Error to an ErrorData with kind-specific message and preserved context.
 pub(crate) fn io_error_to_path_error(
     err: &std::io::Error,
-    _path_context: &str,
+    path_context: &str,
     suggested_action: &'static str,
 ) -> ErrorData {
     let msg = match err.kind() {
-        std::io::ErrorKind::NotFound => "path not found".to_string(),
-        std::io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-        _ => "path is invalid".to_string(),
+        std::io::ErrorKind::NotFound => format!("path not found: {path_context}"),
+        std::io::ErrorKind::PermissionDenied => format!("permission denied: {path_context}"),
+        _ => format!("path is invalid: {path_context}"),
     };
     let mut meta = error_meta("validation", false, suggested_action);
     // Preserve io::Error context in data field

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -41,8 +41,8 @@ pub(crate) fn validate_path(
     let canonical_path = if require_exists {
         std::fs::canonicalize(path).map_err(|e| {
             let msg = match e.kind() {
-                std::io::ErrorKind::NotFound => format!("path not found: {path}"),
-                std::io::ErrorKind::PermissionDenied => format!("permission denied: {path}"),
+                std::io::ErrorKind::NotFound => "path not found".to_string(),
+                std::io::ErrorKind::PermissionDenied => "permission denied".to_string(),
                 _ => "path is outside the allowed root".to_string(),
             };
             ErrorData::new(

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -119,9 +119,9 @@ pub(crate) fn io_error_to_path_error(
     suggested_action: &'static str,
 ) -> ErrorData {
     let msg = match err.kind() {
-        std::io::ErrorKind::NotFound => format!("{path_context} not found"),
-        std::io::ErrorKind::PermissionDenied => format!("permission denied: {path_context}"),
-        _ => format!("{path_context} is invalid"),
+        std::io::ErrorKind::NotFound => "path not found".to_string(),
+        std::io::ErrorKind::PermissionDenied => "permission denied".to_string(),
+        _ => "path is invalid".to_string(),
     };
     let mut meta = error_meta("validation", false, suggested_action);
     // Preserve io::Error context in data field

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -767,15 +767,8 @@ async fn test_exec_slot_files_not_written_for_small_output() {
 
 #[tokio::test]
 async fn test_cd_prefix_chain_passthrough_with_working_dir() {
-    // Arrange: command is a real-world multi-step chain where the leading cd navigates
-    // to a subdirectory that the rest of the chain depends on. working_dir is set to
-    // the repo root (server CWD). The cd path ("workers/dashboard") differs from
-    // working_dir, so the full original command must pass through unmodified -- the
-    // sanitizer must not strip the leading cd.
-    //
-    // We use "cd /tmp && pwd && cd /var && pwd" -- /tmp and /var are guaranteed to
-    // exist, and the two pwd outputs prove the shell executed both cds in sequence,
-    // meaning the original command was not altered.
+    // When working_dir is set and the leading cd path differs, the sanitizer must
+    // pass the full command through unmodified so the shell executes every cd in order.
     let resp = call_exec_command_raw(serde_json::json!({
         "command": "cd /tmp && pwd && cd /var && pwd",
         "working_dir": std::env::current_dir().unwrap().to_str().unwrap()
@@ -789,15 +782,55 @@ async fn test_cd_prefix_chain_passthrough_with_working_dir() {
     let stdout = resp["result"]["structuredContent"]["stdout"]
         .as_str()
         .unwrap_or("");
-    // Both cds must have executed: /tmp appears before /var in the output.
+    let tmp_pos = stdout.find("/tmp").expect("expected /tmp in stdout");
+    let var_pos = stdout.find("/var").expect("expected /var in stdout");
+    assert!(tmp_pos < var_pos, "/tmp must precede /var in stdout: {stdout}");
+}
+
+#[tokio::test]
+async fn test_cd_prefix_plain_absolute_promoted_when_no_working_dir() {
+    // When no working_dir is supplied and the command starts with a plain absolute
+    // cd path, the sanitizer promotes the path as working_dir and strips the prefix.
+    // The server CWD is crates/aptu-coder; use its src/ subdir as the target.
+    let cwd = std::env::current_dir().unwrap();
+    let target = cwd.join("src");
+    let target_str = target.to_str().unwrap().to_owned();
+
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": format!("cd {} && pwd", target_str)
+    }))
+    .await;
+
     assert!(
-        stdout.contains("/tmp") && stdout.contains("/var"),
-        "expected both /tmp and /var in stdout, proving the chain ran unmodified: {stdout}"
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success: {resp}"
     );
-    let tmp_pos = stdout.find("/tmp").unwrap();
-    let var_pos = stdout.find("/var").unwrap();
+    let stdout = resp["result"]["structuredContent"]["stdout"]
+        .as_str()
+        .unwrap_or("");
     assert!(
-        tmp_pos < var_pos,
-        "/tmp must appear before /var in stdout: {stdout}"
+        stdout.trim().ends_with("/src"),
+        "pwd should resolve to the src subdir: {stdout}"
     );
+}
+
+#[tokio::test]
+async fn test_cd_prefix_shell_special_passes_through() {
+    // Shell-special cd forms (cd ~, cd $HOME, cd -, relative paths without working_dir)
+    // must not be intercepted by the sanitizer; they pass through to the shell unmodified.
+    // cd ~ is universally supported and expands to the home directory.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cd ~ && pwd"
+    }))
+    .await;
+
+    // The shell handles cd ~ naturally; the command must succeed.
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "cd ~ must reach the shell unmodified and succeed: {resp}"
+    );
+    let stdout = resp["result"]["structuredContent"]["stdout"]
+        .as_str()
+        .unwrap_or("");
+    assert!(!stdout.trim().is_empty(), "pwd after cd ~ must produce output: {stdout}");
 }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -764,3 +764,40 @@ async fn test_exec_slot_files_not_written_for_small_output() {
         "stderr_path must be absent for small output: {sc}"
     );
 }
+
+#[tokio::test]
+async fn test_cd_prefix_chain_passthrough_with_working_dir() {
+    // Arrange: command is a real-world multi-step chain where the leading cd navigates
+    // to a subdirectory that the rest of the chain depends on. working_dir is set to
+    // the repo root (server CWD). The cd path ("workers/dashboard") differs from
+    // working_dir, so the full original command must pass through unmodified -- the
+    // sanitizer must not strip the leading cd.
+    //
+    // We use "cd /tmp && pwd && cd /var && pwd" -- /tmp and /var are guaranteed to
+    // exist, and the two pwd outputs prove the shell executed both cds in sequence,
+    // meaning the original command was not altered.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cd /tmp && pwd && cd /var && pwd",
+        "working_dir": std::env::current_dir().unwrap().to_str().unwrap()
+    }))
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success: {resp}"
+    );
+    let stdout = resp["result"]["structuredContent"]["stdout"]
+        .as_str()
+        .unwrap_or("");
+    // Both cds must have executed: /tmp appears before /var in the output.
+    assert!(
+        stdout.contains("/tmp") && stdout.contains("/var"),
+        "expected both /tmp and /var in stdout, proving the chain ran unmodified: {stdout}"
+    );
+    let tmp_pos = stdout.find("/tmp").unwrap();
+    let var_pos = stdout.find("/var").unwrap();
+    assert!(
+        tmp_pos < var_pos,
+        "/tmp must appear before /var in stdout: {stdout}"
+    );
+}

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -784,7 +784,10 @@ async fn test_cd_prefix_chain_passthrough_with_working_dir() {
         .unwrap_or("");
     let tmp_pos = stdout.find("/tmp").expect("expected /tmp in stdout");
     let var_pos = stdout.find("/var").expect("expected /var in stdout");
-    assert!(tmp_pos < var_pos, "/tmp must precede /var in stdout: {stdout}");
+    assert!(
+        tmp_pos < var_pos,
+        "/tmp must precede /var in stdout: {stdout}"
+    );
 }
 
 #[tokio::test]
@@ -832,5 +835,8 @@ async fn test_cd_prefix_shell_special_passes_through() {
     let stdout = resp["result"]["structuredContent"]["stdout"]
         .as_str()
         .unwrap_or("");
-    assert!(!stdout.trim().is_empty(), "pwd after cd ~ must produce output: {stdout}");
+    assert!(
+        !stdout.trim().is_empty(),
+        "pwd after cd ~ must produce output: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #1101.

Five coordinated changes to eliminate the `cd <path> &&` duplication anti-pattern in `exec_command`, backed by server-side enforcement and aligned with MCP protocol 2025-11-25 requirements. This PR documents the full reasoning so the same patterns can be applied to other tools.

## Background and motivation

### Why description-only fixes fail (PR #1085 lesson)

PR #1085 changed the tool description from permissive ("cd still works, just prefer working_dir") to preferential ("prefer working_dir"). Production logs showed the pattern persisted -- models apply tool description text once at tool-selection time, but path management habits from training data dominate at fill time.

Root cause: the MCP spec defines `description` as a **hint**. It cannot enforce behavior. The spec's normative statement is "Servers MUST validate all inputs." Enforcement belongs in the implementation.

### The two description vectors

Tool descriptions reach models through two separate channels:

1. **Tool-level `description`** in `#[tool(...)]` -- read when the model chooses and constructs a call.
2. **Field-level `///` doc comments** on parameter structs -- schemars serializes these as `description` on each JSON Schema property, read when the model fills in individual fields.

Both vectors must carry consistent constraints. Changing only one is insufficient.

### MCP 2025-11-25 compliance

Under MCP 2025-11-25, input validation errors must be returned as tool execution errors (`isError: true` in `CallToolResult`) rather than JSON-RPC protocol errors (`INVALID_PARAMS` via `ErrorData`). Protocol errors cannot be given back to the model for self-correction; tool execution errors can. The three `working_dir` validation sites (`exec_command`, `edit_overwrite`, `edit_replace`) were returning `err_to_tool_result(ErrorData::new(INVALID_PARAMS, ...))`. Per guard analysis this produced identical wire output (both paths call `CallToolResult::error` internally), but the intent was wrong and the error messages lacked the bad value and corrective action.

### Goose developer extension reference

Goose's `shell` tool eliminates the problem class entirely: `working_dir` is injected server-side from `session.working_dir` (`ToolCallContext`), never exposed in `ShellParams`, never mentioned in the description. The model cannot emit it and cannot misuse it.

We cannot replicate this exactly (we are a stateless MCP server with no session CWD), but it establishes the principle: **the less the model controls, the less it can get wrong.**

## Changes

### 1. Tool description rewrite (Vector 1)

Removes all mention that `cd` is a valid option. No escape hatch = no alternative branch in model reasoning.

Before:
> "Prefer working_dir over cd \<path\> && in command -- set working_dir and use relative paths; cd and absolute paths still work but are redundant when working_dir is set."

After:
> "Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command."

### 2. `working_dir` field doc comment (Vector 2)

Fires the prohibition at field-fill time, the moment the model decides whether to set `working_dir` or use `cd`.

Before:
> "Working directory relative to server CWD. Validated against path traversal, but best-effort only -- does not sandbox the process."

After:
> "Working directory for the command. Set this instead of prepending cd to the command string. Validated against path traversal; does not sandbox the process."

### 3. Server-side `cd` prefix sanitizer

Adds `strip_cd_prefix(cmd: &str) -> (&str, Option<&str>)` using pure `str` methods (`strip_prefix`, `split_once`; no regex dependency). Detects `cd <path> &&` at the start of the command string and returns the stripped command plus the extracted path.

Integrated in the `exec_command` handler after `working_dir` validation with two carefully scoped rules:

**Rule 1 -- promotion (no `working_dir` supplied):** Only acts on plain absolute paths (`starts_with('/')`, no `$`, `~`, or `-`). Shell-special forms (`cd ~`, `cd $HOME`, `cd -`) and relative paths pass through unmodified so the shell handles them naturally. If the absolute path validates and is a directory, it is promoted as `working_dir` and the `cd` prefix is stripped.

**Rule 2 -- deduplication (`working_dir` already set):** Strips the `cd` prefix only if the extracted path resolves to the same directory as the explicit `working_dir` (provably redundant). If the paths differ, the full original command passes through unmodified -- the `cd` is load-bearing (e.g. `cd workers/dashboard && build && cd ../digest && build`).

### 4. `working_dir` validation error cleanup (MCP 2025-11-25)

Three validation sites (`exec_command`, `edit_overwrite`, `edit_replace`) now return `tool_error(format!(...))` with the bad value and a corrective action in the message. Wire output is identical to before, but intent is correct and messages are actionable.

### 5. `tool_error` helper + `err_to_tool_result` meta fix

Introduced `tool_error(msg: String) -> CallToolResult` -- centralises `CallToolResult::error(vec![Content::text(msg)]).with_meta(Some(no_cache_meta()))`. All six new validation return sites use it. `err_to_tool_result` now also attaches `no_cache_meta()`, fixing the ~30 existing error return sites that were missing it.

### 6. Path leakage fix in `validate_path` and `io_error_to_path_error`

Review surfaced that `validate_path` was embedding the raw `path` argument in `NotFound` and `PermissionDenied` error messages. Those messages reach the model via `isError: true` tool results -- not ideal for paths that may contain sensitive directory structure.

`validate_path`: `NotFound` and `PermissionDenied` branches now use static strings (`"path not found"`, `"permission denied"`), consistent with the other branches that already omitted path details.

`io_error_to_path_error`: user-facing message uses `path_context` (a caller-supplied label like `"working_dir"` or the relative input string, never a canonicalized absolute path). `io::Error` kind and source are preserved in `ErrorData` metadata fields (`ioErrorKind`, `ioErrorSource`) for debugging without surfacing them in the primary message.

## Generalisation guide

The patterns in this PR apply directly to other tools and future MCP work:

### Applying to other tools

| Pattern | Where to apply |
|---------|----------------|
| Two-vector description constraint (tool + field) | Any parameter where models have shown a consistent misuse pattern in session logs |
| Server-side sanitizer for model anti-patterns | Any tool where a parameter interaction is provably wrong before execution (not just doc-fixable) |
| Plain-absolute guard before `validate_path` | Any handler that intercepts path-like strings from the model before shell evaluation |
| `tool_error()` for all `isError=true` returns | Every tool handler -- replace any inline `CallToolResult::error(...).with_meta(...)` |
| `isError=true` for input validation, not `INVALID_PARAMS` | Every tool -- protocol errors are for transport/protocol failures only |

### What stays with the model (by design)

- Shell-special forms (`cd ~`, `cd $VAR`, `cd -`, relative paths) -- the shell must expand these; we cannot.
- Multi-step `cd` chains where the intermediate directory is load-bearing -- distinguishable only at runtime.
- Any `working_dir` that legitimately differs from the `cd` target -- explicit param wins unconditionally.

### Test patterns established

- **Unit test** the parser/sanitizer function in isolation (pure, fast, no I/O).
- **Integration test** the end-to-end handler behavior via `call_tool_raw` for each distinct caller branch.
- Assert **observable output** (stdout content, `isError`, `exit_code`), not internal state.
- One test per behavior; do not duplicate behaviors already covered by existing tests.

## Lessons learned from review

**Error messages as an information leak surface.** `validate_path` was interpolating the raw `path` argument into `NotFound` and `PermissionDenied` error strings. These messages reach the model via `isError: true` tool results and are visible in logs. Any path-derived string in an error message is a potential leak of filesystem structure. Rule: error messages visible to callers use static strings or caller-supplied labels; raw OS paths stay in metadata.

**Separate user-facing message from debug context.** `io_error_to_path_error` iterated through four states during review before settling on the right split: static strings in the primary message, `ioErrorKind` and `ioErrorSource` in the `ErrorData` metadata object. This is the correct pattern -- it satisfies both the security requirement (no path in message) and the debuggability requirement (full io::Error available in structured data).

**Plain-absolute guard is load-bearing, not cosmetic.** The initial `strip_cd_prefix` implementation promoted any `cd <path>` prefix. Review identified that shell-special forms (`cd ~`, `cd $HOME`, `cd -`) and relative paths must reach the shell unmodified -- `validate_path` cannot resolve them correctly before execution. The guard (`starts_with('/')`, no `$`/`~`, not `"-"`) is the boundary between "we can resolve this" and "the shell must handle this." It must be checked before calling `validate_path`, not after.

**Two-commit fix amplifies scope.** The `err_to_tool_result` meta fix (`no_cache_meta()` missing on ~30 error return sites) was discovered while adding `tool_error`. Bundling the helper introduction with the retroactive fix kept the blast radius visible in one diff and eliminated a class of silent cache-coherence bugs across the entire server.

## Testing

- 4 unit tests for `strip_cd_prefix` (`basic`, `no_&&`, `extra_spaces`, `first_&&_only`)
- 3 integration tests via `call_tool_raw` (`chain_passthrough_with_working_dir`, `plain_absolute_promoted_when_no_working_dir`, `shell_special_passes_through`)
- All existing tests pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt` clean
- `cargo deny check advisories licenses` clean

## References

- Closes #1101
- PR #1085: previous description-only fix (insufficient; documented why above)
- MCP 2025-11-25 changelog: "Input validation errors should now be returned as Tool Execution Errors rather than Protocol Errors"
- goose `crates/goose/src/agents/platform_extensions/developer/shell.rs`: reference implementation (`working_dir` session-injected, invisible to model)
