### PR TITLE
test(ci): schema compliance test for uint format emissions, fix semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,8 @@ jobs:
     name: semver checks
     runs-on: ubuntu-24.04-arm
     if: github.event_name == 'pull_request'
-    # This PR renames the crate; no published or git baseline exists for aptu-coder-core yet.
-    # Re-enable without continue-on-error after aptu-coder-core is first published on crates.io.
-    continue-on-error: true
+    # aptu-coder-core is published on crates.io with 25+ versions.
+    # If the crate is not yet found (e.g. first publish after rename), the step skips gracefully.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -253,17 +252,19 @@ jobs:
       - name: Check crate is published on crates.io
         id: published
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://crates.io/api/v1/crates/aptu-coder-core)
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -A 'rust-cargo/1.0' https://crates.io/api/v1/crates/aptu-coder-core)
           if [[ "$STATUS" == "200" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
             echo "aptu-coder-core not yet published on crates.io (HTTP $STATUS); skipping semver check."
           fi
-      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+      - name: Install cargo-semver-checks
         if: steps.published.outputs.available == 'true'
-        with:
-          package: aptu-coder-core
+        run: cargo install --locked cargo-semver-checks
+      - name: Run semver checks
+        if: steps.published.outputs.available == 'true'
+        run: cargo semver-checks --package aptu-coder-core
 
   ci-result:
     name: CI Result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,16 @@ jobs:
           fi
       - name: Install cargo-semver-checks
         if: steps.published.outputs.available == 'true'
-        run: cargo install --locked cargo-semver-checks
+        env:
+          VERSION: "0.48.0"
+          SHA256: "1bc0d4d70af9c3ae086af958e67da2a12eaa4978896596f5499792755b62ea60"
+        run: |
+          curl -fsSL "https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v${VERSION}/cargo-semver-checks-aarch64-unknown-linux-gnu.tar.gz" \
+            -o cargo-semver-checks.tar.gz
+          echo "${SHA256}  cargo-semver-checks.tar.gz" | sha256sum -c -
+          tar -xzf cargo-semver-checks.tar.gz
+          mv cargo-semver-checks ~/.cargo/bin/cargo-semver-checks
+          chmod +x ~/.cargo/bin/cargo-semver-checks
       - name: Run semver checks
         if: steps.published.outputs.available == 'true'
         run: cargo semver-checks --package aptu-coder-core

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -49,3 +49,4 @@ tokio = { workspace = true }
 tempfile = { workspace = true }
 serial_test = "=3.5.0"
 tower = { version = "=0.5.3", features = ["util"] }
+rmcp = { workspace = true, features = ["client"] }

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -550,3 +550,116 @@ async fn test_analyze_module_unsupported_fallback() {
         "imports must be empty for unsupported extension"
     );
 }
+
+/// Recursively walk a `serde_json::Value` (a raw JSON Schema object), collecting paths
+/// where `"format"` equals one of the forbidden values.
+/// Covers: properties, $defs, allOf, anyOf, oneOf, items, additionalProperties.
+fn collect_forbidden_formats(
+    val: &serde_json::Value,
+    forbidden: &[&str],
+    path: &str,
+    found: &mut Vec<String>,
+) {
+    let serde_json::Value::Object(map) = val else {
+        return;
+    };
+    if let Some(fmt) = map.get("format").and_then(|v| v.as_str()) {
+        if forbidden.contains(&fmt) {
+            found.push(format!("{path}: format={fmt}"));
+        }
+    }
+    for (key, child) in map {
+        let child_path = if path.is_empty() {
+            key.clone()
+        } else {
+            format!("{path}.{key}")
+        };
+        match key.as_str() {
+            "properties" | "$defs" => {
+                if let Some(props) = child.as_object() {
+                    for (name, val) in props {
+                        collect_forbidden_formats(
+                            val,
+                            forbidden,
+                            &format!("{child_path}.{name}"),
+                            found,
+                        );
+                    }
+                }
+            }
+            "allOf" | "anyOf" | "oneOf" => {
+                if let Some(arr) = child.as_array() {
+                    for (i, item) in arr.iter().enumerate() {
+                        collect_forbidden_formats(
+                            item,
+                            forbidden,
+                            &format!("{child_path}[{i}]"),
+                            found,
+                        );
+                    }
+                }
+            }
+            "items" => collect_forbidden_formats(child, forbidden, &child_path, found),
+            "additionalProperties" => {
+                if child.is_object() {
+                    collect_forbidden_formats(child, forbidden, &child_path, found);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_schema_compliance_no_nonstandard_formats() {
+    use common::make_test_analyzer;
+    use rmcp::ServiceExt as _;
+
+    // Spin up the MCP server and connect a typed rmcp client over an in-process duplex pipe.
+    let analyzer = make_test_analyzer();
+    let (client_io, server_io) = tokio::io::duplex(65536);
+    tokio::spawn(async move {
+        let (rx, tx) = tokio::io::split(server_io);
+        if let Ok(svc) = rmcp::serve_server(analyzer, (rx, tx)).await {
+            let _ = svc.waiting().await;
+        }
+    });
+    let (client_rx, client_tx) = tokio::io::split(client_io);
+    let client = ().serve((client_rx, client_tx)).await.expect("client handshake failed");
+
+    let result = client
+        .peer()
+        .list_tools(None)
+        .await
+        .expect("tools/list failed");
+
+    assert!(!result.tools.is_empty(), "expected at least one tool");
+
+    let forbidden = &["uint", "uint64"];
+    let mut found = Vec::new();
+
+    for tool in &result.tools {
+        // inputSchema is a serde_json::Value on rmcp's Tool struct.
+        collect_forbidden_formats(
+            &serde_json::to_value(&tool.input_schema).expect("inputSchema serialization failed"),
+            forbidden,
+            &tool.name,
+            &mut found,
+        );
+        // outputSchema is optional.
+        if let Some(output_schema) = &tool.output_schema {
+            collect_forbidden_formats(
+                &serde_json::to_value(output_schema).expect("outputSchema serialization failed"),
+                forbidden,
+                &format!("{}.outputSchema", tool.name),
+                &mut found,
+            );
+        }
+    }
+
+    assert!(
+        found.is_empty(),
+        "found forbidden format values in tool schemas:\n{}",
+        found.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

Add an integration test that validates all 7 MCP tools' input and output schemas contain no
non-standard `format` values (`uint`, `uint64`). Guards against regressions of the class fixed
in #1102 on future schemars version bumps.

Also fix the semver-checks CI job, which was silently broken in two ways:
- `curl` had no `User-Agent` header, so crates.io always returned 403 and the publication
  check was a no-op
- `cargo-semver-checks-action` downloads an x86-64 binary unconditionally; on our
  `ubuntu-24.04-arm` runner this produced `Syntax error: "(" unexpected` and was masked by
  `continue-on-error: true`

## Changes

- `crates/aptu-coder/Cargo.toml` -- add `rmcp = { workspace = true, features = ["client"] }`
  to `[dev-dependencies]` so the schema test can use the typed rmcp client API
- `crates/aptu-coder/tests/integration_tests.rs` -- add
  `test_schema_compliance_no_nonstandard_formats`: spins up the server in-process via
  `rmcp::serve_server`, connects a typed client with `().serve(...)`, calls
  `peer.list_tools(None)`, and recursively walks every tool's `inputSchema` and `outputSchema`
  asserting no forbidden format values
- `.github/workflows/ci.yml` -- replace `obi1kenobi/cargo-semver-checks-action` with
  `cargo install --locked cargo-semver-checks` + inline `cargo semver-checks` (correct
  aarch64 binary); add `-A 'rust-cargo/1.0'` to the crates.io `curl`; remove
  `continue-on-error: true`; update stale comment

## Test plan

- [x] `test_schema_compliance_no_nonstandard_formats` passes
- [x] All other tests pass (140 total)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] aptu review: Approve

Closes #1103
