### PR TITLE
chore(release): bump version to 0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.2"
+version = "0.17.3"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
# What's Changed

### Bug Fixes

- **`exec_command`: add `cd` prefix sanitizer, prohibit `cd` in description, clean up `working_dir` validation errors** (#1104, closes #1101): When `working_dir` is set, a leading `cd <path> &&` prefix in the command is now stripped automatically if the extracted path resolves to the same directory as `working_dir` (provably redundant). Load-bearing chains such as `cd sub && build && cd ../other && build` pass through unmodified. The tool description is updated to prohibit bare `cd` and guide callers toward `working_dir`. `io_error_to_path_error` no longer embeds raw paths in error messages to prevent path leakage. A `tool_error` helper is introduced to eliminate `no_cache_meta` repetition at call sites. 76 lines of new integration tests cover chain passthrough, redundant-prefix stripping, and working_dir validation error wording.

- **`analyze_*` / `edit_*`: replace non-standard `uint`/`uint64` JSON Schema `format` values with draft-07 compliant `integer` type** (#1102): `schemars` 0.8 emits `"format":"uint64"` for `u64` fields and `"format":"uint"` for `usize` fields. These are not valid JSON Schema draft-07 format strings and cause strict validators (Claude, OpenAI, Zod) to reject the schema. Custom `JsonSchema` impls now emit `{"type":"integer","minimum":0}` for `u64` and `{"type":"integer","minimum":0}` for `usize`, removing the non-standard format annotations. A schema-compliance integration test in `tests/integration_tests.rs` uses the rmcp typed client API (`serve_client` + `Peer::list_tools`) to assert that no tool input schema contains a `format` field with value `uint` or `uint64`.

### Documentation & CI

- **docs: guard JSONL metrics queries against CWD, surface metrics path in MCP instructions** (#1100): AGENTS.md and `docs/OBSERVABILITY.md` now require an explicit `cd $XDG_DATA_HOME/aptu-coder/` before any jq glob pattern -- glob expansion against a different CWD silently matches nothing. The MCP server instructions (`get_info`) append the JSONL metrics directory path and the cd-first rule so clients always know where metrics land and how to query them safely.

- **ci: fix `cargo-semver-checks` on ARM64, add schema compliance test, use rmcp typed client API** (#1105): `cargo-semver-checks-action` downloads an x86-64 binary unconditionally, which fails on `ubuntu-24.04-arm` with `Syntax error: ( unexpected`. Replaced with a direct download of the pre-built `aarch64-unknown-linux-gnu` tarball from the GitHub release (SHA256-verified, sub-second extraction). The crates.io publication check gains `-A 'rust-cargo/1.0'` (was always 403 without it, making the check a no-op) and drops `continue-on-error: true`. The schema compliance test migrates from hand-rolled JSON-RPC over a duplex pipe to `serve_client` + `Peer::list_tools`, removing 107 lines of protocol boilerplate from `common/mod.rs`.

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.17.2...v0.17.3
