### PR TITLE
fix(edit): richer error messages for edit_replace not-found and ambiguous cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.17.3"
+version = "0.18.0"
 dependencies = [
  "base64",
  "blake3",
@@ -1953,9 +1953,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.3"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -23,11 +23,18 @@ pub enum EditError {
     #[error(
         "old_text not found in {path} — verify the text matches exactly, including whitespace and newlines"
     )]
-    NotFound { path: String },
+    NotFound {
+        path: String,
+        first_20_lines: String,
+    },
     #[error(
         "old_text appears {count} times in {path} — make old_text longer and more specific to uniquely identify the block"
     )]
-    Ambiguous { count: usize, path: String },
+    Ambiguous {
+        count: usize,
+        path: String,
+        match_lines: Vec<usize>,
+    },
 }
 
 fn write_file_atomic(path: &Path, content: &str) -> Result<(), EditError> {
@@ -75,15 +82,22 @@ pub fn edit_replace_block(
     let count = content.matches(old_text).count();
     match count {
         0 => {
+            let first_20_lines = content.lines().take(20).collect::<Vec<_>>().join("\n");
             return Err(EditError::NotFound {
                 path: path.display().to_string(),
+                first_20_lines,
             });
         }
         1 => {}
         n => {
+            let match_lines: Vec<usize> = content
+                .match_indices(old_text)
+                .map(|(offset, _)| content[..offset].bytes().filter(|&b| b == b'\n').count() + 1)
+                .collect();
             return Err(EditError::Ambiguous {
                 count: n,
                 path: path.display().to_string(),
+                match_lines,
             });
         }
     }
@@ -154,7 +168,7 @@ mod tests {
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo bar baz").unwrap();
         let err = edit_replace_block(&path, "missing", "x").unwrap_err();
-        std::assert_matches!(err, EditError::NotFound { .. });
+        std::assert_matches!(&err, EditError::NotFound { first_20_lines, .. } if !first_20_lines.is_empty());
     }
 
     #[test]
@@ -163,7 +177,7 @@ mod tests {
         let path = dir.path().join("file.txt");
         std::fs::write(&path, "foo foo baz").unwrap();
         let err = edit_replace_block(&path, "foo", "x").unwrap_err();
-        std::assert_matches!(err, EditError::Ambiguous { count: 2, .. });
+        std::assert_matches!(&err, EditError::Ambiguous { count: 2, match_lines, .. } if match_lines == &[1, 1]);
     }
 
     #[test]

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -20,6 +20,7 @@ pub enum EditError {
     },
     #[error("path is a directory, not a file: {0}")]
     NotAFile(PathBuf),
+    #[non_exhaustive]
     #[error(
         "old_text not found in {path} — verify the text matches exactly, including whitespace and newlines"
     )]
@@ -27,6 +28,7 @@ pub enum EditError {
         path: String,
         first_20_lines: String,
     },
+    #[non_exhaustive]
     #[error(
         "old_text appears {count} times in {path} — make old_text longer and more specific to uniquely identify the block"
     )]

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -20,7 +20,6 @@ pub enum EditError {
     },
     #[error("path is a directory, not a file: {0}")]
     NotAFile(PathBuf),
-    #[non_exhaustive]
     #[error(
         "old_text not found in {path} — verify the text matches exactly, including whitespace and newlines"
     )]
@@ -28,7 +27,6 @@ pub enum EditError {
         path: String,
         first_20_lines: String,
     },
-    #[non_exhaustive]
     #[error(
         "old_text appears {count} times in {path} — make old_text longer and more specific to uniquely identify the block"
     )]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.17", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.18", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3038,6 +3038,7 @@ impl CodeAnalyzer {
             Ok(Err(aptu_coder_core::EditError::NotFound {
                 path: notfound_path,
                 first_20_lines,
+                ..
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
@@ -3112,6 +3113,7 @@ impl CodeAnalyzer {
                 count,
                 path: ambiguous_path,
                 match_lines,
+                ..
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3028,6 +3028,7 @@ impl CodeAnalyzer {
 
         let old_text = params.old_text.clone();
         let new_text = params.new_text.clone();
+        let old_text_for_hint = old_text.clone();
         let handle = tokio::task::spawn_blocking(move || {
             aptu_coder_core::edit_replace_block(&resolved_path, &old_text, &new_text)
         });
@@ -3036,6 +3037,7 @@ impl CodeAnalyzer {
             Ok(Ok(v)) => v,
             Ok(Err(aptu_coder_core::EditError::NotFound {
                 path: notfound_path,
+                first_20_lines,
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
@@ -3060,11 +3062,45 @@ impl CodeAnalyzer {
                     output_truncated: None,
                     ..Default::default()
                 });
-                return Ok(err_to_tool_result(ErrorData::new(
-                    rmcp::model::ErrorCode::INVALID_PARAMS,
+
+                let message = if first_20_lines.is_empty() {
                     format!(
                         "old_text not found (0 matches) in {notfound_path}. Re-read the file with analyze_file or analyze_module to obtain the current content, then derive old_text from the live file before retrying."
-                    ),
+                    )
+                } else {
+                    let first_old_line = old_text_for_hint.lines().next().unwrap_or("");
+                    let mut best_line_idx = 1usize;
+                    let mut best_line = "";
+                    let mut best_lcp = 0usize;
+
+                    for (i, file_line) in first_20_lines.lines().enumerate() {
+                        let lcp = file_line
+                            .chars()
+                            .zip(first_old_line.chars())
+                            .take_while(|(a, b)| a == b)
+                            .count();
+                        if lcp > best_lcp {
+                            best_lcp = lcp;
+                            best_line = file_line;
+                            best_line_idx = i + 1;
+                        }
+                    }
+
+                    let numbered_lines: String = first_20_lines
+                        .lines()
+                        .enumerate()
+                        .map(|(i, line)| format!("  Line {}: {}", i + 1, line))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+
+                    format!(
+                        "old_text not found (0 matches) in {notfound_path}.\nThe file begins:\n{numbered_lines}\n\nNearest match: line {best_line_idx} contains \"{best_line}\" which shares {best_lcp} characters with the start of old_text.\nRe-read the file with analyze_file or analyze_module to obtain the current content, then derive old_text from the live file before retrying."
+                    )
+                };
+
+                return Ok(err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    message,
                     Some(error_meta(
                         "validation",
                         false,
@@ -3075,6 +3111,7 @@ impl CodeAnalyzer {
             Ok(Err(aptu_coder_core::EditError::Ambiguous {
                 count,
                 path: ambiguous_path,
+                match_lines,
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
@@ -3099,10 +3136,15 @@ impl CodeAnalyzer {
                     output_truncated: None,
                     ..Default::default()
                 });
+                let line_numbers_csv = match_lines
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     format!(
-                        "old_text matched {count} locations in {ambiguous_path}. Extend old_text with more surrounding context to make it unique, or re-read with analyze_file to confirm the exact text."
+                        "old_text matched {count} locations in {ambiguous_path}.\nOccurrences at lines: {line_numbers_csv}\nExtend old_text with more surrounding context to make it unique, or re-read with analyze_file to confirm the exact text."
                     ),
                     Some(error_meta(
                         "validation",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3038,7 +3038,6 @@ impl CodeAnalyzer {
             Ok(Err(aptu_coder_core::EditError::NotFound {
                 path: notfound_path,
                 first_20_lines,
-                ..
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
@@ -3113,7 +3112,6 @@ impl CodeAnalyzer {
                 count,
                 path: ambiguous_path,
                 match_lines,
-                ..
             })) => {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");

--- a/crates/aptu-coder/tests/edit_replace_errors.rs
+++ b/crates/aptu-coder/tests/edit_replace_errors.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use common::call_tool_raw;
+
+/// When old_text is not found, the error message includes "The file begins:"
+/// with a preview of the first 20 lines of the file.
+#[tokio::test]
+async fn test_edit_replace_not_found_shows_file_preview() {
+    // Arrange: create a temp file inside CWD with known content
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "line one\nline two\nline three\n";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    // Act: call edit_replace with old_text that does not exist
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "nonexistent text",
+            "new_text": "replacement",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert: error response with file preview
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+    let msg = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have error text");
+    assert!(
+        msg.contains("The file begins:"),
+        "error message should contain 'The file begins:' but got: {msg}"
+    );
+    assert!(
+        msg.contains("line one"),
+        "error message should contain file content but got: {msg}"
+    );
+    assert!(
+        msg.contains("Nearest match:"),
+        "error message should contain nearest match hint but got: {msg}"
+    );
+}
+
+/// When old_text matches multiple locations, the error message includes
+/// "Occurrences at lines:" with the 1-based line numbers of each match.
+#[tokio::test]
+async fn test_edit_replace_ambiguous_shows_line_numbers() {
+    // Arrange: create a temp file inside CWD with duplicate content on different lines
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "alpha\nbeta\nalpha\n";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    // Act: call edit_replace with old_text that appears twice
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "alpha",
+            "new_text": "replacement",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert: error response with line numbers
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+    let msg = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have error text");
+    assert!(
+        msg.contains("Occurrences at lines:"),
+        "error message should contain 'Occurrences at lines:' but got: {msg}"
+    );
+    assert!(
+        msg.contains("2 locations"),
+        "error message should mention match count but got: {msg}"
+    );
+}


### PR DESCRIPTION
Closes #1093

## Summary

Extends `edit_replace` error messages for the two failure cases:

- **Not-found (0 matches):** `EditError::NotFound` now carries `first_20_lines: String`. The handler formats a numbered file preview and a nearest-match hint (longest-common-prefix heuristic against the first line of `old_text`). Empty-file edge case handled gracefully.
- **Ambiguous (multiple matches):** `EditError::Ambiguous` now carries `match_lines: Vec<usize>` (1-based). The handler formats `Occurrences at lines: N, M, ...` in the error message.

## Changes

- `crates/aptu-coder-core/src/edit.rs`: extended enum variants; populated new fields in `edit_replace_block`; updated unit tests.
- `crates/aptu-coder/src/lib.rs`: updated handler match arms to format richer messages.
- `crates/aptu-coder/tests/edit_replace_errors.rs`: new integration tests via `call_tool_raw` for both error paths.

## Testing

- `cargo test`: all tests pass
- `cargo clippy -- -D warnings`: clean
- No new dependencies added
