### PR TITLE
chore(release): bump version to 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Summary

Bump workspace version to 0.18.1 for patch release.

Closes #1109 (via #1110).

## Changes

- `Cargo.toml`: `0.18.0` -> `0.18.1`
- `Cargo.lock`: updated

## What's in this release

**fix(exec_command): remove spurious warn on macOS and imperative doc language (#1110)**

- Removes the `warn!` call that fired on every macOS invocation when `memory_limit_mb` was supplied (non-Linux platforms do not enforce the limit, but the warning was noise with no actionable consequence).
- Rewrites the `exec_command` tool description to remove imperative "use timeout_secs" phrasing.
- Removes "Complements timeout_secs (wall-clock)" from the `cpu_limit_secs` doc comment.
