### PR TITLE
test(profiles): fix env_var_lock race by switching to tokio::sync::Mutex

### DIFF
--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -7,11 +7,11 @@ use tokio::sync::Mutex as TokioMutex;
 use tracing_subscriber::filter::LevelFilter;
 
 /// Serializes tests that mutate process-global env vars to prevent parallel pollution.
-/// Uses `unwrap_or_else` to recover from mutex poison caused by panicking tests.
-fn env_var_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    let m = LOCK.get_or_init(|| Mutex::new(()));
-    m.lock().unwrap_or_else(|e| e.into_inner())
+/// Returns a `tokio::sync::MutexGuard` that can be held across `.await` points.
+async fn env_var_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<TokioMutex<()>> = OnceLock::new();
+    let m = LOCK.get_or_init(|| TokioMutex::new(()));
+    m.lock().await
 }
 
 fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
@@ -208,10 +208,6 @@ async fn call_tool_with_profile(profile: Option<&str>, tool_name: &str) -> serde
 
 #[tokio::test]
 async fn test_edit_profile_tool_count() {
-    // Arrange: hold guard only during setup; drop before first .await
-    {
-        let _guard = env_var_lock();
-    }
     // Arrange: initialize with edit profile
     let resp = call_tools_list_with_profile(Some("edit")).await;
 
@@ -249,10 +245,6 @@ async fn test_edit_profile_tool_count() {
 
 #[tokio::test]
 async fn test_analyze_profile_tool_count() {
-    // Arrange: hold guard only during setup; drop before first .await
-    {
-        let _guard = env_var_lock();
-    }
     // Arrange: initialize with analyze profile
     let resp = call_tools_list_with_profile(Some("analyze")).await;
 
@@ -298,13 +290,11 @@ async fn test_analyze_profile_tool_count() {
 
 #[tokio::test]
 async fn test_no_profile_tool_count() {
-    // Arrange: hold guard only during setup; drop before first .await
-    {
-        let _guard = env_var_lock();
-        // Arrange: initialize with no profile metadata; env var must be absent.
-        unsafe {
-            std::env::remove_var("APTU_CODER_PROFILE");
-        }
+    // Arrange: hold guard across env var mutation and async call
+    let _guard = env_var_lock().await;
+    // Arrange: initialize with no profile metadata; env var must be absent.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
     }
     let resp = call_tools_list_with_profile(None).await;
 
@@ -322,13 +312,11 @@ async fn test_no_profile_tool_count() {
 
 #[tokio::test]
 async fn test_unknown_profile_tool_count() {
-    // Arrange: hold guard only during setup; drop before first .await
-    {
-        let _guard = env_var_lock();
-        // Arrange: initialize with unknown profile string; env var must be absent.
-        unsafe {
-            std::env::remove_var("APTU_CODER_PROFILE");
-        }
+    // Arrange: hold guard across env var mutation and async call
+    let _guard = env_var_lock().await;
+    // Arrange: initialize with unknown profile string; env var must be absent.
+    unsafe {
+        std::env::remove_var("APTU_CODER_PROFILE");
     }
     let resp = call_tools_list_with_profile(Some("unknown_profile")).await;
 
@@ -346,10 +334,6 @@ async fn test_unknown_profile_tool_count() {
 
 #[tokio::test]
 async fn test_disabled_tool_returns_invalid_params() {
-    // Arrange: hold guard only during setup; drop before first .await
-    {
-        let _guard = env_var_lock();
-    }
     // Arrange: initialize with edit profile and try to call a disabled tool (analyze_directory)
     let resp = call_tool_with_profile(Some("edit"), "analyze_directory").await;
 
@@ -367,13 +351,11 @@ async fn test_disabled_tool_returns_invalid_params() {
 
 #[tokio::test]
 async fn test_profile_env_var_fallback() {
-    // Serialize against other env-var-mutating tests; drop guard before first .await.
-    {
-        let _guard = env_var_lock();
-        // Arrange: set APTU_CODER_PROFILE env var to "edit", initialize with no _meta.
-        unsafe {
-            std::env::set_var("APTU_CODER_PROFILE", "edit");
-        }
+    // Arrange: hold guard across env var mutation, async call, and cleanup
+    let _guard = env_var_lock().await;
+    // Arrange: set APTU_CODER_PROFILE env var to "edit", initialize with no _meta.
+    unsafe {
+        std::env::set_var("APTU_CODER_PROFILE", "edit");
     }
 
     let resp = call_tools_list_with_profile(None).await;
@@ -407,14 +389,12 @@ async fn test_profile_env_var_fallback() {
 
 #[tokio::test]
 async fn test_profile_env_var_ignored_when_meta_present() {
-    // Serialize against other env-var-mutating tests; drop guard before first .await.
-    {
-        let _guard = env_var_lock();
-        // Arrange: set APTU_CODER_PROFILE=edit but initialize with _meta "analyze".
-        // _meta must win.
-        unsafe {
-            std::env::set_var("APTU_CODER_PROFILE", "edit");
-        }
+    // Arrange: hold guard across env var mutation, async call, and cleanup
+    let _guard = env_var_lock().await;
+    // Arrange: set APTU_CODER_PROFILE=edit but initialize with _meta "analyze".
+    // _meta must win.
+    unsafe {
+        std::env::set_var("APTU_CODER_PROFILE", "edit");
     }
 
     let resp = call_tools_list_with_profile(Some("analyze")).await;


### PR DESCRIPTION
## Summary

Fix a flaky test failure in `test_profile_env_var_fallback` (and the related `test_profile_env_var_ignored_when_meta_present`) caused by a race condition in the `env_var_lock()` serialization helper.

## Root cause

`env_var_lock()` returned a `std::sync::MutexGuard<'static, ()>` that was dropped inside an inner `{}` block **before** the `.await` on `call_tools_list_with_profile()`. This left `APTU_CODER_PROFILE` unprotected for the full duration of the MCP initialize handshake. Any parallel test could remove the env var in that window, causing `on_initialized()` to see no env var and return all 7 tools instead of 3.

The bug was introduced by commit `61b2665` (`test: remove redundant empty-file tests; fix MutexGuard held across await`) which correctly resolved the `std::sync::MutexGuard across .await` lint by releasing the guard early, but in doing so created the race window.

## Fix

- Change `env_var_lock()` from `fn` to `async fn`, switching the static `LOCK` from `OnceLock<std::sync::Mutex<()>>` to `OnceLock<tokio::sync::Mutex<()>>`.
- Replace `m.lock().unwrap_or_else(|e| e.into_inner())` with `m.lock().await` (tokio mutexes do not poison on panic).
- Add `.await` at all 5 call sites; hold the guard for the full test body in the 2 tests that mutate `APTU_CODER_PROFILE`, and across the async call in the 2 tests that defensively `remove_var`.
- Remove 3 no-op guard blocks (tests that pass profile via `_meta` and do not touch the env var).

## Testing

- `cargo test -p aptu-coder --test profiles`: 7/7 pass (was 6/7)
- `cargo clippy -p aptu-coder -- -D warnings`: clean
- `cargo fmt --check`: clean

## Scope

Single file: `crates/aptu-coder/tests/profiles.rs`. No production code changes, no new dependencies.
