### PR TITLE
fix(exec_command): replace validate_path with is_dir check for working_dir (#1113)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3299,7 +3299,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; timeout_secs kills the process after N seconds (wall-clock); omit for no limit. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist, is not a directory, or is outside CWD. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, timed_out, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB; timeout_secs kills the process after N seconds (wall-clock); omit for no limit. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",
@@ -3335,12 +3335,12 @@ impl CodeAnalyzer {
         span.record("gen_ai.tool.name", "exec_command");
         span.record("command", &params.command);
 
-        // Validate working_dir if provided
+        // Validate working_dir if provided -- existence + is_dir only, no CWD confinement.
+        // exec_command is a shell runner; CWD confinement applies only to edit_overwrite/edit_replace.
         let working_dir_path = if let Some(ref wd) = params.working_dir {
-            match validate_path(wd, true) {
+            match std::fs::canonicalize(wd) {
                 Ok(p) => {
-                    // Verify it's a directory
-                    if !std::fs::metadata(&p).map(|m| m.is_dir()).unwrap_or(false) {
+                    if !p.is_dir() {
                         span.record("error", true);
                         span.record("error.type", "invalid_params");
                         return Ok(tool_error(format!(
@@ -3355,7 +3355,7 @@ impl CodeAnalyzer {
                     span.record("error.type", "invalid_params");
                     return Ok(tool_error(format!(
                         "working_dir {:?} is not valid: {}. Provide an existing directory path.",
-                        wd, e.message
+                        wd, e
                     )));
                 }
             }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -154,23 +154,21 @@ async fn exec_command_timeout() {
 
 #[tokio::test]
 async fn exec_command_working_dir_rejection() {
-    // Arrange: working_dir=/tmp is outside the server's CWD
+    // exec_command has no CWD confinement; working_dir=/tmp (outside server CWD) must succeed.
+    // Only edit_overwrite/edit_replace enforce CWD confinement.
     let resp = call_exec_command_raw(serde_json::json!({
         "command": "echo hi",
         "working_dir": "/tmp"
     }))
     .await;
 
-    // Assert: handler must reject with isError=true and mention 'outside'
+    // Assert: handler must succeed (no confinement for exec_command)
     assert!(
-        resp["result"]["isError"].as_bool().unwrap_or(false),
-        "expected isError=true for working_dir outside CWD: {resp}"
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "exec_command with working_dir outside CWD must succeed: {resp}"
     );
-    let content_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
-    assert!(
-        content_text.contains("outside"),
-        "error message should contain 'outside': {content_text}"
-    );
+    let sc = &resp["result"]["structuredContent"];
+    assert_eq!(sc["exit_code"], 0, "exit_code mismatch: {sc}");
 }
 
 #[tokio::test]
@@ -838,5 +836,28 @@ async fn test_cd_prefix_shell_special_passes_through() {
     assert!(
         !stdout.trim().is_empty(),
         "pwd after cd ~ must produce output: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn test_exec_command_working_dir_outside_cwd() {
+    // working_dir pointing outside server CWD must succeed (no CWD confinement for exec_command)
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let tmp_path = tmp.path().to_str().expect("utf8").to_owned();
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo hello",
+        "working_dir": tmp_path,
+        "timeout_secs": 10
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "working_dir outside server CWD must succeed for exec_command: {resp}"
+    );
+    let sc = &resp["result"]["structuredContent"];
+    assert_eq!(sc["exit_code"], 0, "exit_code mismatch: {sc}");
+    assert!(
+        sc["stdout"].as_str().unwrap_or("").contains("hello"),
+        "stdout missing 'hello': {sc}"
     );
 }


### PR DESCRIPTION
## Summary
Replace validate_path(wd, true) in exec_command working_dir validation with std::fs::canonicalize() + is_dir() check. This removes the incorrect CWD confinement guard that prevented shell execution in directories outside the server CWD. exec_command is a shell runner and must support any accessible directory; CWD confinement applies only to edit_overwrite and edit_replace.

## Changes
- crates/aptu-coder/src/lib.rs
- crates/aptu-coder/tests/exec_command.rs

## Test plan
- [x] Tests pass (see 03-build.json test_results)
- [x] Linter clean
- [x] Security scan clean

Closes #1113
