### PR TITLE
chore(release): bump version to 0.18.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.2"
+version = "0.18.3"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version to 0.18.3 for release.

### What's Changed

- **`exec_command`: remove `memory_limit_mb` and `cpu_limit_secs` parameters** (#1120, closes #1119): These parameters called `setrlimit(0, 0)` when passed as `0`, killing the child process immediately with no output. `timeout_secs` already covers runaway-process prevention. The `nix` dependency is dropped -- its sole use was `setrlimit`. Integration tests for the removed parameters are also removed.

Closes #1119
