### PR TITLE
feat(tools): allow empty new_text in edit_replace, login shell PATH on macOS, default max_depth=3

### DIFF
--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -104,7 +104,7 @@ pub struct AnalyzeDirectoryParams {
     /// Directory path to analyze
     pub path: String,
 
-    /// Maximum directory traversal depth for overview mode only. 0 or unset = unlimited depth. Use 1-3 for large monorepos to manage output size. Ignored in other modes.
+    /// Maximum directory traversal depth for overview mode only. Default: 3. Pass 0 for unlimited depth. Use 1-3 for large monorepos to manage output size. Ignored in other modes.
     #[cfg_attr(
         feature = "schemars",
         schemars(schema_with = "crate::schema_helpers::option_integer_schema")
@@ -867,7 +867,7 @@ pub struct EditReplaceParams {
     pub working_dir: Option<String>,
     /// Exact text block to find and replace. Must appear exactly once in the file.
     pub old_text: String,
-    /// Replacement text.
+    /// Replacement text. Pass empty string to delete the matched block.
     pub new_text: String,
 }
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1328,7 +1328,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_directory",
         title = "Analyze Directory",
-        description = "Tree-view of directory with LOC, function/class counts, test markers. Respects .gitignore. Returns per-file stats plus next_cursor for pagination. For large directories the output is automatically compacted to a summary; pass summary=false to get a cursor-paginated per-file flat list instead. Fails if summary=true and cursor. For 1000+ files, use max_depth=2-3 and summary=true. git_ref restricts to files changed since a branch/tag/commit. Empty directories return zero counts. Example queries: Analyze the src/ directory to understand module structure; What files are in the tests/ directory and how large are they?",
+        description = "Tree-view of directory with LOC, function/class counts, test markers. Respects .gitignore. Returns per-file stats plus next_cursor for pagination. Default max_depth is 3; pass 0 for unlimited depth. Large directories (1000+ files) are auto-compacted to a summary; pass summary=false for a cursor-paginated per-file flat list (summary and cursor are mutually exclusive). git_ref restricts to files changed since a branch/tag/commit. Empty directories return zero counts. Example queries: Analyze the src/ directory to understand module structure; What files are in the tests/ directory and how large are they?",
         output_schema = schema_for_type::<analyze::AnalysisOutput>(),
         annotations(
             title = "Analyze Directory",
@@ -1343,7 +1343,9 @@ impl CodeAnalyzer {
         params: Parameters<AnalyzeDirectoryParams>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let params = params.0;
+        let mut params = params.0;
+        // Apply max_depth default: 3. Pass 0 for unlimited depth.
+        params.max_depth = params.max_depth.or(Some(3));
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2959,7 +2961,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
-        description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. Whitespace-sensitive exact match. Use edit_overwrite to replace the whole file. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
+        description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. Whitespace-sensitive exact match. Use edit_overwrite to replace the whole file. Pass empty string for new_text to delete the matched block. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
         output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
             title = "Edit Replace",
@@ -3392,7 +3394,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). Note: on macOS, login shell profile sourcing adds ~100-200ms latency per call. For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",
@@ -3712,15 +3714,32 @@ fn build_exec_command(
     stdin_present: bool,
     resolved_path: Option<&str>,
 ) -> tokio::process::Command {
+    // On macOS the login shell (-l) already sources the profile PATH; suppress the
+    // unused-variable lint that fires when the non-macOS injection block is cfg'd out.
+    #[cfg(target_os = "macos")]
+    let _ = resolved_path;
     let shell = resolve_shell();
     let mut cmd = tokio::process::Command::new(shell);
-    cmd.arg("-c").arg(command);
+
+    #[cfg(target_os = "macos")]
+    {
+        // On macOS, use login shell (-l) to source the user profile for PATH resolution.
+        cmd.args(["-l", "-c", command]);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        cmd.arg("-c").arg(command);
+    }
 
     if let Some(wd) = working_dir_path {
         cmd.current_dir(wd);
     }
 
-    // Inject resolved login shell PATH if available
+    // Inject resolved login shell PATH if available (non-macOS only).
+    // On macOS the login shell (-l) sources the profile which includes the live PATH,
+    // so we skip the stale snapshot injection to avoid overriding it.
+    #[cfg(not(target_os = "macos"))]
     if let Some(path) = resolved_path {
         cmd.env("PATH", path);
     }

--- a/crates/aptu-coder/tests/edit_working_dir.rs
+++ b/crates/aptu-coder/tests/edit_working_dir.rs
@@ -237,3 +237,68 @@ async fn edit_replace_invalid_working_dir_no_path_leak() {
         "error message must not contain working_dir path: {msg}"
     );
 }
+
+#[tokio::test]
+async fn test_edit_replace_empty_new_text_deletes_block() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "delete_block.txt";
+    let file_path = temp_dir.path().join(file_name);
+    std::fs::write(&file_path, "line one\nDELETE ME\nline three\n").expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "DELETE ME\n",
+            "new_text": "",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success, got: {resp}"
+    );
+    let content = std::fs::read_to_string(&file_path).expect("should read updated file");
+    assert_eq!(content, "line one\nline three\n");
+}
+
+#[tokio::test]
+async fn test_edit_replace_empty_new_text_entire_file() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "whole_file.txt";
+    let file_path = temp_dir.path().join(file_name);
+    std::fs::write(&file_path, "entire content").expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "entire content",
+            "new_text": "",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success, got: {resp}"
+    );
+    let content = std::fs::read_to_string(&file_path).expect("should read updated file");
+    assert_eq!(
+        content, "",
+        "file should be empty after full-content deletion"
+    );
+}

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -792,3 +792,73 @@ async fn test_analyze_module_directory_error_no_path_leak() {
         "error message must not contain directory path: {msg}"
     );
 }
+
+#[tokio::test]
+async fn test_analyze_directory_default_max_depth_is_three() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let base = temp_dir.path();
+
+    std::fs::create_dir_all(base.join("a/b/c/d")).unwrap();
+    std::fs::write(base.join("a/d1.rs"), "fn d1() {}").unwrap();
+    std::fs::write(base.join("a/b/d2.rs"), "fn d2() {}").unwrap();
+    std::fs::write(base.join("a/b/c/d3.rs"), "fn d3() {}").unwrap();
+    // depth 4 -- must NOT appear with default max_depth=3
+    std::fs::write(base.join("a/b/c/d/d4.rs"), "fn d4() {}").unwrap();
+
+    let resp = call_tool_raw(
+        "analyze_directory",
+        serde_json::json!({
+            "path": base.to_str().expect("path is valid UTF-8"),
+            "page_size": 100
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success, got: {resp}"
+    );
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    // Summary/overview mode rolls up individual files into directory nodes;
+    // assert the depth-3 directory "c/" appears and depth-4 content does not.
+    assert!(
+        text.contains("c/") || text.contains("/c"),
+        "depth-3 directory must appear: {text}"
+    );
+    assert!(
+        !text.contains("d4.rs") && !text.contains("  d/"),
+        "depth-4 content must NOT appear with default max_depth=3: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_analyze_directory_explicit_max_depth_zero_unlimited() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let base = temp_dir.path();
+
+    // depth 4 -- must appear when max_depth=0 (unlimited)
+    std::fs::create_dir_all(base.join("a/b/c/d")).unwrap();
+    std::fs::write(base.join("a/b/c/d/deep.rs"), "fn deep() {}").unwrap();
+
+    let resp = call_tool_raw(
+        "analyze_directory",
+        serde_json::json!({
+            "path": base.to_str().expect("path is valid UTF-8"),
+            "max_depth": 0,
+            "page_size": 100
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success, got: {resp}"
+    );
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("deep.rs"),
+        "depth-4 file must appear when max_depth=0 (unlimited): {text}"
+    );
+}


### PR DESCRIPTION
## Summary

Bundles three independent handler-only features. No core parser changes, no schema changes, no new dependencies.

---

### #1094 -- edit_replace: allow empty new_text for block deletion

`edit_replace` already handled empty string replacement at the core level (`content.replacen(old_text, "", 1)`). This PR documents the behavior and adds tests. No logic or schema change; `new_text` remains `String`.

**Changes:**
- `lib.rs`: tool description updated -- "Pass empty string for new_text to delete the matched block."
- `types.rs`: `EditReplaceParams.new_text` doc comment updated
- `tests/edit_working_dir.rs`: two new tests -- block deletion and whole-file deletion edge case

---

### #1095 -- exec_command: resolve login shell PATH on macOS

macOS GUI-launched processes (VS Code, Claude Desktop, Goose) inherit only `/usr/bin:/bin`, missing Homebrew `/opt/homebrew/bin`, nix, and `~/.cargo/bin`. The fix adds a `#[cfg(target_os = "macos")]` block in `build_exec_command` that rebuilds the `Command` with `.args(["-l", "-c", command])`, sourcing `.zprofile`/`.bash_profile`/`.profile` on each invocation.

The startup PATH snapshot injection (`cmd.env("PATH", ...)`) is skipped on macOS so a stale snapshot does not override the live profile PATH. Non-macOS platforms are unchanged.

**Tradeoff:** ~100-200ms added latency per `exec_command` call on macOS (documented in tool description). Users with slow profiles (nix, pyenv, rbenv) may see higher latency; `APTU_SHELL` override remains available.

**Changes:**
- `lib.rs`: `#[cfg(target_os = "macos")]` block in `build_exec_command`; `#[cfg(not(target_os = "macos"))]` guard on PATH injection; tool description latency note
- No integration tests added (CI runs Linux ARM64; macOS PATH behavior cannot be tested there)

---

### #1096 -- analyze_directory: default max_depth from 0 (unlimited) to 3

**Breaking change:** consumers omitting `max_depth` previously got unlimited traversal; they now get depth-3. Pass `max_depth=0` explicitly for unlimited traversal (unchanged behavior).

Implementation: handler-level `params.max_depth.or(Some(3))` before passing to `walk_directory`. No serde default change (avoids cache key schema inconsistency). `Some(0)` passes through unchanged -- `or(Some(3))` only fires on `None`.

**Changes:**
- `lib.rs`: `params.max_depth = params.max_depth.or(Some(3))` in `analyze_directory` handler; tool description updated -- "Default: 3. Pass 0 for unlimited depth."
- `types.rs`: `AnalyzeDirectoryParams.max_depth` doc comment updated
- `tests/integration_tests.rs`: two new tests -- default depth-3 limit and explicit `max_depth=0` unlimited passthrough

---

## Test results

- All test suites passed (0 failed)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt`: clean

Closes #1094
Closes #1095
Closes #1096
