### PR TITLE
feat(tools): add unsupported field to FileAnalysisOutput and ModuleInfo, reorder tool descriptions (#1127)

### DIFF
--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -130,6 +130,14 @@ pub struct FileAnalysisOutput {
         )
     )]
     pub next_cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(
+            description = "True when the file extension is not supported; semantic fields are empty and formatted contains a raw preview"
+        )
+    )]
+    pub unsupported: Option<bool>,
 }
 
 impl FileAnalysisOutput {
@@ -146,6 +154,7 @@ impl FileAnalysisOutput {
             semantic,
             line_count,
             next_cursor,
+            unsupported: None,
         }
     }
 }

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -656,6 +656,15 @@ pub struct ModuleInfo {
     pub functions: Vec<ModuleFunctionInfo>,
     /// Import statements (module and items only)
     pub imports: Vec<ModuleImportInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(
+            description = "True when the file extension is not supported; semantic fields are empty"
+        )
+    )]
+    /// True when the file extension is not supported; semantic fields are empty.
+    pub unsupported: Option<bool>,
 }
 
 impl ModuleInfo {
@@ -674,6 +683,7 @@ impl ModuleInfo {
             language,
             functions,
             imports,
+            unsupported: None,
         }
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -910,6 +910,8 @@ impl CodeAnalyzer {
                         None,
                     );
                     let _ = ext;
+                    let mut output = output;
+                    output.unsupported = Some(true);
                     Ok((std::sync::Arc::new(output), CacheTier::Miss))
                 }
                 _ => Err(ErrorData::new(
@@ -2508,7 +2510,9 @@ impl CodeAnalyzer {
                             ..Default::default()
                         });
                         return {
-                            let mi = types::ModuleInfo::new(name, line_count, ext, vec![], vec![]);
+                            let mut mi =
+                                types::ModuleInfo::new(name, line_count, ext, vec![], vec![]);
+                            mi.unsupported = Some(true);
                             let text = format_module_info(&mi);
                             let content_hash = format!("{}", blake3::hash(text.as_bytes()));
                             let mut meta = no_cache_meta().0;


### PR DESCRIPTION
## Summary

Add `unsupported: Option<bool>` to FileAnalysisOutput (in analyze.rs) and ModuleInfo (in types.rs) using field-direct-set at the 2 fallback sites in lib.rs only, leaving all non-fallback construction sites untouched. Simultaneously move the supported-language list to the opening clause of the analyze_file and analyze_module tool descriptions in lib.rs.

## Changes

- crates/aptu-coder-core/src/analyze.rs
- crates/aptu-coder-core/src/types.rs
- crates/aptu-coder/src/lib.rs

## Test plan

- [x] Tests pass: 598 passed, 0 failed
- [x] Linter clean: clippy clean
- [x] Format clean: fmt clean
- [x] Security scan clean: no critical/high findings

Closes #1127
