### PR TITLE
refactor(types): remove force, verbose, and ast_recursion_limit parameters (#1129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder-core/src/schema_helpers.rs
+++ b/crates/aptu-coder-core/src/schema_helpers.rs
@@ -30,19 +30,6 @@ pub fn option_integer_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     Schema::from(map)
 }
 
-/// Returns a nullable integer schema for `Option<usize>` `ast_recursion_limit` fields.
-/// `None` = library default, `0` = unlimited traversal depth, `n` = limit to n levels.
-pub fn option_ast_limit_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
-    let map = json!({
-        "type": ["integer", "null"],
-        "minimum": 0
-    })
-    .as_object()
-    .expect("json! object literal is always a Value::Object")
-    .clone();
-    Schema::from(map)
-}
-
 /// Regex matching all supported source file extensions (case-insensitive).
 ///
 /// Used as the `inputSchema` `pattern` constraint on `path` fields in

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -88,13 +88,9 @@ pub struct PaginationParams {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct OutputControlParams {
-    /// Return full output even when it exceeds the 50K char limit. Prefer summary=true or narrowing scope over force=true; force=true can produce very large responses.
-    pub force: Option<bool>,
     /// true = compact summary (totals plus directory tree, no per-file function lists); false = full output; unset = auto-summarize when output exceeds 50K chars.
     /// Mutually exclusive with cursor; passing both returns INVALID_PARAMS.
     pub summary: Option<bool>,
-    /// true = full output with section headers and imports (Markdown-style); false or unset = compact one-line-per-item format (default).
-    pub verbose: Option<bool>,
 }
 
 #[non_exhaustive]
@@ -154,13 +150,6 @@ pub struct AnalyzeFileParams {
         schemars(schema_with = "crate::schema_helpers::supported_file_path_schema")
     )]
     pub path: String,
-
-    /// AST traversal depth limit for tree-sitter queries. Leave unset in normal use; increase only for deeply nested generated code. None=library default, 0=unlimited, n=limit to n levels.
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::schema_helpers::option_ast_limit_schema")
-    )]
-    pub ast_recursion_limit: Option<usize>,
 
     /// Limit output to specific sections. Valid values: "functions", "classes", "imports", "all".
     /// The FILE header (path, line count, section counts) is always emitted regardless.
@@ -227,13 +216,6 @@ pub struct AnalyzeSymbolParams {
         schemars(schema_with = "crate::schema_helpers::option_integer_schema")
     )]
     pub max_depth: Option<u32>,
-
-    /// AST traversal depth limit for tree-sitter queries. Leave unset in normal use; increase only for deeply nested generated code. None=library default, 0=unlimited, n=limit to n levels.
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::schema_helpers::option_ast_limit_schema")
-    )]
-    pub ast_recursion_limit: Option<usize>,
 
     #[serde(flatten)]
     pub pagination: PaginationParams,
@@ -763,10 +745,6 @@ mod tests {
             "page_size must be top-level in AnalyzeDirectoryParams schema"
         );
         assert!(
-            dir_props.contains_key("force"),
-            "force must be top-level in AnalyzeDirectoryParams schema"
-        );
-        assert!(
             dir_props.contains_key("summary"),
             "summary must be top-level in AnalyzeDirectoryParams schema"
         );
@@ -786,10 +764,6 @@ mod tests {
         assert!(
             file_props.contains_key("page_size"),
             "page_size must be top-level in AnalyzeFileParams schema"
-        );
-        assert!(
-            file_props.contains_key("force"),
-            "force must be top-level in AnalyzeFileParams schema"
         );
         assert!(
             file_props.contains_key("summary"),
@@ -813,30 +787,38 @@ mod tests {
             "page_size must be top-level in AnalyzeSymbolParams schema"
         );
         assert!(
-            symbol_props.contains_key("force"),
-            "force must be top-level in AnalyzeSymbolParams schema"
-        );
-        assert!(
             symbol_props.contains_key("summary"),
             "summary must be top-level in AnalyzeSymbolParams schema"
         );
 
-        // Verify ast_recursion_limit enforces minimum: 0 in both parameter schemas.
-        let file_ast = file_props
-            .get("ast_recursion_limit")
-            .expect("ast_recursion_limit must be present in AnalyzeFileParams schema");
-        assert_eq!(
-            file_ast.get("minimum").and_then(|v| v.as_u64()),
-            Some(0),
-            "ast_recursion_limit in AnalyzeFileParams must have minimum: 0"
+        // Verify verbose is NOT present in either param schema (removed per issue 1129)
+        assert!(
+            !file_props.contains_key("verbose"),
+            "verbose must be removed from AnalyzeFileParams schema"
         );
-        let symbol_ast = symbol_props
-            .get("ast_recursion_limit")
-            .expect("ast_recursion_limit must be present in AnalyzeSymbolParams schema");
-        assert_eq!(
-            symbol_ast.get("minimum").and_then(|v| v.as_u64()),
-            Some(0),
-            "ast_recursion_limit in AnalyzeSymbolParams must have minimum: 0"
+        assert!(
+            !symbol_props.contains_key("verbose"),
+            "verbose must be removed from AnalyzeSymbolParams schema"
+        );
+
+        // Verify force is NOT present in either param schema (removed per issue 1129)
+        assert!(
+            !file_props.contains_key("force"),
+            "force must be removed from AnalyzeFileParams schema"
+        );
+        assert!(
+            !symbol_props.contains_key("force"),
+            "force must be removed from AnalyzeSymbolParams schema"
+        );
+
+        // Verify ast_recursion_limit is NOT present in either param schema (removed per issue 1129)
+        assert!(
+            !file_props.contains_key("ast_recursion_limit"),
+            "ast_recursion_limit must be removed from AnalyzeFileParams schema"
+        );
+        assert!(
+            !symbol_props.contains_key("ast_recursion_limit"),
+            "ast_recursion_limit must be removed from AnalyzeSymbolParams schema"
         );
     }
 }

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.19", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.20", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -836,7 +836,7 @@ impl CodeAnalyzer {
         }
 
         // Cache miss or no cache key, analyze and optionally store
-        match analyze::analyze_file(&params.path, params.ast_recursion_limit) {
+        match analyze::analyze_file(&params.path, None) {
             Ok(output) => {
                 let arc_output = std::sync::Arc::new(output);
                 if let Some(key) = cache_key {
@@ -988,7 +988,6 @@ impl CodeAnalyzer {
         let match_mode_owned = analysis_params.match_mode.clone();
         let follow_depth = analysis_params.follow_depth;
         let max_depth = analysis_params.max_depth;
-        let ast_recursion_limit = analysis_params.ast_recursion_limit;
         let use_summary = analysis_params.use_summary;
         let impl_only = analysis_params.impl_only;
         let def_use = analysis_params.def_use;
@@ -999,7 +998,7 @@ impl CodeAnalyzer {
                 match_mode: match_mode_owned,
                 follow_depth,
                 max_depth,
-                ast_recursion_limit,
+                ast_recursion_limit: None,
                 use_summary,
                 impl_only,
                 def_use,
@@ -1120,8 +1119,7 @@ impl CodeAnalyzer {
         total_files: usize,
         progress_token: Option<ProgressToken>,
     ) -> Result<analyze::FocusedAnalysisOutput, ErrorData> {
-        let use_summary_for_task = params.output_control.force != Some(true)
-            && params.output_control.summary == Some(true);
+        let use_summary_for_task = params.output_control.summary == Some(true);
 
         let analysis_params_initial = FocusedAnalysisParams {
             use_summary: use_summary_for_task,
@@ -1140,10 +1138,7 @@ impl CodeAnalyzer {
             )
             .await?;
 
-        if params.output_control.summary.is_none()
-            && params.output_control.force != Some(true)
-            && output.formatted.len() > SIZE_LIMIT
-        {
+        if params.output_control.summary.is_none() && output.formatted.len() > SIZE_LIMIT {
             tracing::debug!(
                 auto_summary = true,
                 message = "output exceeded size limit, retrying with summary"
@@ -1170,7 +1165,7 @@ impl CodeAnalyzer {
             } else {
                 let estimated_tokens = output.formatted.len() / 4;
                 let message = format!(
-                    "Output exceeds 50K chars ({} chars, ~{} tokens). Use summary=true or force=true.",
+                    "Output exceeds 50K chars ({} chars, ~{} tokens). Use summary=true or narrow your scope.",
                     output.formatted.len(),
                     estimated_tokens
                 );
@@ -1180,18 +1175,16 @@ impl CodeAnalyzer {
                     Some(error_meta(
                         "validation",
                         false,
-                        "use summary=true or force=true",
+                        "use summary=true or narrow scope",
                     )),
                 ));
             }
         } else if output.formatted.len() > SIZE_LIMIT
-            && params.output_control.force != Some(true)
             && params.output_control.summary == Some(false)
         {
             let estimated_tokens = output.formatted.len() / 4;
             let message = format!(
                 "Output exceeds 50K chars ({} chars, ~{} tokens). Use one of:\n\
-                 - force=true to return full output\n\
                  - summary=true to get compact summary\n\
                  - Narrow your scope (smaller directory, specific file)",
                 output.formatted.len(),
@@ -1203,7 +1196,7 @@ impl CodeAnalyzer {
                 Some(error_meta(
                     "validation",
                     false,
-                    "use force=true, summary=true, or narrow scope",
+                    "use summary=true or narrow scope",
                 )),
             ));
         }
@@ -1269,7 +1262,7 @@ impl CodeAnalyzer {
             params.follow_depth.unwrap_or(1),
             &params.match_mode.clone().unwrap_or_default(),
             params.impl_only.unwrap_or(false),
-            params.ast_recursion_limit,
+            None,
         );
 
         // Check L1 cache first.
@@ -1286,7 +1279,6 @@ impl CodeAnalyzer {
             match_mode: params.match_mode.clone().unwrap_or_default(),
             follow_depth: params.follow_depth.unwrap_or(1),
             max_depth: params.max_depth,
-            ast_recursion_limit: params.ast_recursion_limit,
             use_summary: false,
             impl_only: params.impl_only,
             def_use: params.def_use.unwrap_or(false),
@@ -1423,14 +1415,11 @@ impl CodeAnalyzer {
         // Determine output mode:
         //   summary=true  -> compact summary (format_summary)
         //   summary=false -> explicit paginated flat list (format_structure_paginated)
-        //   summary=None, force=true -> tree as-is (format_structure, no auto-compact)
         //   summary=None, small output (<=SIZE_LIMIT) -> tree as-is (format_structure)
         //   summary=None, large output (>SIZE_LIMIT)  -> compact summary (format_summary)
         let use_summary = if params.output_control.summary == Some(true) {
             true
-        } else if params.output_control.summary == Some(false)
-            || params.output_control.force == Some(true)
-        {
+        } else if params.output_control.summary == Some(false) {
             false
         } else {
             output.formatted.len() > SIZE_LIMIT
@@ -1485,14 +1474,13 @@ impl CodeAnalyzer {
                 }
             };
 
-        let verbose = params.output_control.verbose.unwrap_or(false);
         if use_paginated {
             output.formatted = format_structure_paginated(
                 &paginated.items,
                 paginated.total,
                 params.max_depth,
                 Some(Path::new(&params.path)),
-                verbose,
+                false,
             );
         }
 
@@ -1682,9 +1670,7 @@ impl CodeAnalyzer {
         let line_count = arc_output.line_count;
 
         // Apply summary/output size limiting logic
-        let use_summary = if params.output_control.force == Some(true) {
-            false
-        } else if params.output_control.summary == Some(true) {
+        let use_summary = if params.output_control.summary == Some(true) {
             true
         } else if params.output_control.summary == Some(false) {
             false
@@ -1694,15 +1680,14 @@ impl CodeAnalyzer {
 
         if use_summary {
             formatted = format_file_details_summary(&arc_output.semantic, &params.path, line_count);
-        } else if formatted.len() > SIZE_LIMIT && params.output_control.force != Some(true) {
+        } else if formatted.len() > SIZE_LIMIT {
             span.record("error", true);
             span.record("error.type", "invalid_params");
             let estimated_tokens = formatted.len() / 4;
             let message = format!(
                 "Output exceeds 50K chars ({} chars, ~{} tokens). Use one of:\n\
-                 - force=true to return full output\n\
-                 - Use fields to limit output to specific sections (functions, classes, or imports)\n\
-                 - Use summary=true for a compact overview",
+                 - Use summary=true for a compact overview\n\
+                 - Use fields to limit output to specific sections (functions, classes, or imports)",
                 formatted.len(),
                 estimated_tokens
             );
@@ -1772,7 +1757,6 @@ impl CodeAnalyzer {
         let is_unsupported_fallback = arc_output
             .formatted
             .contains("[Unsupported extension: semantic analysis not available]");
-        let verbose = params.output_control.verbose.unwrap_or(false);
         if !use_summary && !is_unsupported_fallback {
             // fields: serde rejects unknown enum variants at deserialization; no runtime validation required
             formatted = format_file_details_paginated(
@@ -1782,7 +1766,7 @@ impl CodeAnalyzer {
                 &params.path,
                 line_count,
                 offset,
-                verbose,
+                false,
                 params.fields.as_deref(),
             );
         }
@@ -1954,7 +1938,6 @@ impl CodeAnalyzer {
             let symbol = params.symbol.clone();
             let git_ref = params.git_ref.clone();
             let max_depth = params.max_depth;
-            let ast_recursion_limit = params.ast_recursion_limit;
 
             let handle = tokio::task::spawn_blocking(move || {
                 let path = path_owned.as_path();
@@ -1994,12 +1977,7 @@ impl CodeAnalyzer {
                 } else {
                     raw_entries
                 };
-                let output = match analyze::analyze_import_lookup(
-                    path,
-                    &symbol,
-                    &entries,
-                    ast_recursion_limit,
-                ) {
+                let output = match analyze::analyze_import_lookup(path, &symbol, &entries, None) {
                     Ok(v) => v,
                     Err(e) => {
                         return Err(ErrorData::new(
@@ -2106,11 +2084,7 @@ impl CodeAnalyzer {
             PaginationMode::Callers
         };
 
-        let mut use_summary = params.output_control.summary == Some(true);
-        if params.output_control.force == Some(true) {
-            use_summary = false;
-        }
-        let verbose = params.output_control.verbose.unwrap_or(false);
+        let use_summary = params.output_control.summary == Some(true);
 
         let mut callee_cursor = match cursor_mode {
             PaginationMode::Callers => {
@@ -2127,7 +2101,6 @@ impl CodeAnalyzer {
                 if !use_summary
                     && (paginated_next.is_some()
                         || offset > 0
-                        || !verbose
                         || !output.outgoing_chains.is_empty())
                 {
                     let base_path = Path::new(&params.path);
@@ -2142,7 +2115,7 @@ impl CodeAnalyzer {
                         output.def_count,
                         offset,
                         Some(base_path),
-                        verbose,
+                        false,
                     );
                     paginated_next
                 } else {
@@ -2160,7 +2133,7 @@ impl CodeAnalyzer {
                     Err(e) => return Ok(err_to_tool_result(e)),
                 };
 
-                if paginated_next.is_some() || offset > 0 || !verbose {
+                if paginated_next.is_some() || offset > 0 {
                     let base_path = Path::new(&params.path);
                     output.formatted = format_focused_paginated(
                         &paginated_items,
@@ -2173,7 +2146,7 @@ impl CodeAnalyzer {
                         output.def_count,
                         offset,
                         Some(base_path),
-                        verbose,
+                        false,
                     );
                     paginated_next
                 } else {
@@ -2204,7 +2177,7 @@ impl CodeAnalyzer {
                 };
 
                 // Always regenerate formatted output for DefUse mode so the
-                // first page (offset=0, verbose=true) is not skipped.
+                // first page (offset=0) is not skipped.
                 if !use_summary {
                     let base_path = Path::new(&params.path);
                     output.formatted = format_focused_paginated_defuse(
@@ -2213,7 +2186,7 @@ impl CodeAnalyzer {
                         &params.symbol,
                         offset,
                         Some(base_path),
-                        verbose,
+                        false,
                     );
                 }
 
@@ -2325,7 +2298,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "analyze_module",
         title = "Analyze Module",
-        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination, summary, force, verbose, git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Astro, C/C++, C#, CSS, Fortran, Go, HTML, Java, JavaScript, JSON, Kotlin, Markdown, Python, Rust, TOML, TSX, TypeScript, YAML. Example queries: What functions are defined in src/analyze.rs?",
+        description = "Function and import index for a single source file with minimal token cost: name, line_count, language, function names with line numbers, import list only (~75% smaller than analyze_file). Fails if directory path supplied. Pagination and git_ref not supported. Use analyze_file when you need signatures, types, or class details. Supported: Astro, C/C++, C#, CSS, Fortran, Go, HTML, Java, JavaScript, JSON, Kotlin, Markdown, Python, Rust, TOML, TSX, TypeScript, YAML. Example queries: What functions are defined in src/analyze.rs?",
         output_schema = schema_for_type::<types::ModuleInfo>(),
         annotations(
             title = "Analyze Module",
@@ -4062,7 +4035,6 @@ struct FocusedAnalysisParams {
     match_mode: SymbolMatchMode,
     follow_depth: u32,
     max_depth: Option<u32>,
-    ast_recursion_limit: Option<usize>,
     use_summary: bool,
     impl_only: Option<bool>,
     def_use: bool,
@@ -4474,7 +4446,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_overview_mode_verbose_no_summary_block() {
+    async fn test_handle_overview_mode_no_summary_block() {
         use aptu_coder_core::types::AnalyzeDirectoryParams;
         use tempfile::TempDir;
 
@@ -4494,7 +4466,6 @@ mod tests {
 
         let params: AnalyzeDirectoryParams = serde_json::from_value(serde_json::json!({
             "path": tmp.path().to_str().unwrap(),
-            "verbose": true,
         }))
         .unwrap();
 

--- a/crates/aptu-coder/tests/annotations.rs
+++ b/crates/aptu-coder/tests/annotations.rs
@@ -134,7 +134,7 @@ fn test_all_tool_parameters_have_descriptions() {
 #[test]
 fn test_flatten_fields_have_descriptions() {
     let tools = CodeAnalyzer::list_tools();
-    let flatten_fields = ["cursor", "page_size", "summary", "force", "verbose"];
+    let flatten_fields = ["cursor", "page_size", "summary"];
     for tool in &tools {
         let tool_name = tool.name.as_ref();
         if tool_name == "analyze_module" {

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -231,7 +231,6 @@ async fn test_fields_functions_only_structured() {
         "analyze_file",
         serde_json::json!({
             "path": f.path().to_str().unwrap(),
-            "ast_recursion_limit": null,
             "page_size": null,
             "fields": ["functions"]
         }),
@@ -289,7 +288,6 @@ async fn test_fields_classes_only_structured() {
         "analyze_file",
         serde_json::json!({
             "path": f.path().to_str().unwrap(),
-            "ast_recursion_limit": null,
             "page_size": null,
             "fields": ["classes"]
         }),
@@ -347,7 +345,6 @@ async fn test_fields_imports_only_structured() {
         "analyze_file",
         serde_json::json!({
             "path": f.path().to_str().unwrap(),
-            "ast_recursion_limit": null,
             "page_size": null,
             "fields": ["imports"]
         }),
@@ -405,7 +402,6 @@ async fn test_fields_none_structured_full() {
         "analyze_file",
         serde_json::json!({
             "path": f.path().to_str().unwrap(),
-            "ast_recursion_limit": null,
             "page_size": null
         }),
     )

--- a/crates/aptu-coder/tests/mcp_smoke.rs
+++ b/crates/aptu-coder/tests/mcp_smoke.rs
@@ -136,7 +136,7 @@ fn test_mcp_server_recovers_after_tool_error() {
         thread::sleep(Duration::from_millis(500));
 
         // Tool call with a nonexistent path — must return isError=true, not crash.
-        let bad = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"analyze_file","arguments":{"path":"/nonexistent/does_not_exist.py","ast_recursion_limit":null,"page_size":null}}}"#;
+        let bad = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"analyze_file","arguments":{"path":"/nonexistent/does_not_exist.py","page_size":null}}}"#;
         stdin.write_all(bad.as_bytes()).expect("write bad call");
         stdin.write_all(b"\n").expect("newline");
 


### PR DESCRIPTION
Closes #1129

## Summary

Removes 4 unused/noisy parameters from MCP tool param structs as specified in issue 1129:

- `force: Option<bool>` and `verbose: Option<bool>` from `OutputControlParams`
- `ast_recursion_limit: Option<usize>` from `AnalyzeFileParams`
- `ast_recursion_limit: Option<usize>` from `AnalyzeSymbolParams`

## Changes

- `crates/aptu-coder-core/src/types.rs`: remove 4 struct fields with their serde/schemars annotations
- `crates/aptu-coder-core/src/schema_helpers.rs`: remove `option_ast_limit_schema` (now unreferenced)
- `crates/aptu-coder/src/lib.rs`: replace all `output_control.force` reads with hardcoded `false`; replace all `output_control.verbose` reads with hardcoded `false`; replace `ast_recursion_limit` pass-throughs with `None`; update tool descriptions
- `crates/aptu-coder/tests/annotations.rs`: remove `force` and `verbose` from `flatten_fields` list
- `crates/aptu-coder/tests/integration_tests.rs`: strip `ast_recursion_limit: null` from 4 JSON test params
- `crates/aptu-coder/tests/mcp_smoke.rs`: strip `ast_recursion_limit: null` from 1 JSON test param

## Backward compatibility

`serde` does not use `deny_unknown_fields` on these structs. Existing callers passing the removed parameters will have them silently ignored until they update.

## Test results

640 tests passed, 0 failed. Clippy clean. Format clean.
