### PR TITLE
fix(analyze_symbol): add missing no_cache_meta to pagination error responses

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -285,7 +285,7 @@ fn err_to_tool_result_from_pagination(
     e: aptu_coder_core::pagination::PaginationError,
 ) -> CallToolResult {
     let msg = format!("Pagination error: {}", e);
-    CallToolResult::error(vec![Content::text(msg)])
+    CallToolResult::error(vec![Content::text(msg)]).with_meta(Some(no_cache_meta()))
 }
 
 fn no_cache_meta() -> Meta {

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -56,6 +56,37 @@ fn test_call_tool_result_cache_hint_metadata() {
 }
 
 #[tokio::test]
+async fn test_no_cache_meta_on_pagination_error() {
+    // Arrange: Trigger a DefUse pagination error by passing an invalid cursor.
+    // Analyze_symbol with def_use=true requires a valid cursor to paginate through
+    // def-use results; an invalid/corrupted cursor should trigger PaginationError,
+    // which should return with cache_hint: no-cache in _meta.
+
+    let resp = call_tool_raw(
+        "analyze_symbol",
+        serde_json::json!({
+            "path": ".",
+            "symbol": "test_symbol",
+            "follow_depth": 1,
+            "max_depth": 3,
+            "page_size": 100,
+            "def_use": true,
+            "cursor": "INVALID_CORRUPTED_CURSOR_12345"
+        }),
+    )
+    .await;
+
+    // Assert the response has cache_hint: no-cache in _meta
+    assert_eq!(
+        resp["result"]["_meta"]
+            .get("cache_hint")
+            .and_then(|v| v.as_str()),
+        Some("no-cache"),
+        "Expected _meta.cache_hint to be 'no-cache' in pagination error response: {resp}"
+    );
+}
+
+#[tokio::test]
 async fn test_analyze_directory_bounded_traversal_skips_deep() {
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Add missing `.with_meta(Some(no_cache_meta()))` to `err_to_tool_result_from_pagination` in `crates/aptu-coder/src/lib.rs`.

## Problem

`err_to_tool_result_from_pagination` (lib.rs ~line 288) returned `CallToolResult::error()` without attaching `no_cache_meta()`. The two sibling helpers `err_to_tool_result` and `tool_error` both attach it correctly. MCP clients that respect cache hints could cache the pagination error and return stale failures on retry.

## Fix

Chain `.with_meta(Some(no_cache_meta()))` onto the `CallToolResult::error()` return value -- the same pattern used by 10 other error/success paths in the file.

## Tests

Added `test_no_cache_meta_on_pagination_error` integration test that triggers a DefUse pagination error with an invalid cursor and asserts `_meta.cache_hint == "no-cache"` in the response.

## Changes

- crates/aptu-coder/src/lib.rs: Add `.with_meta(Some(no_cache_meta()))` to pagination error response
- crates/aptu-coder/tests/integration_tests.rs: Add regression test for cache_hint on pagination errors

## Test Plan

- All 289 integration and unit tests pass
- Linter clean
- Security scan clean
