### PR TITLE
docs(exec_command): reframe cd prohibition as mechanical fact in tool description

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3371,7 +3371,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write the command using relative paths only. Do not prepend cd to the command. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). Note: on macOS, login shell profile sourcing adds ~100-200ms latency per call. For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write the command using relative paths only. Commands run inside working_dir; omit `cd`. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). Note: on macOS, login shell profile sourcing adds ~100-200ms latency per call. For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",


### PR DESCRIPTION
## Summary

Replaces the prohibition-style instruction in the `exec_command` tool description with a mechanical fact grounded in how the shell process is actually spawned.

**Before:**
> Do not prepend cd to the command.

**After:**
> Commands run inside working_dir; omit `cd`.

## Motivation

Anthropic's guidance on reducing hallucinations recommends grounding model behavior in stated mechanical reality rather than issuing prohibitions. Models weight "this is what happens" more consistently than "do not do X". The new phrasing describes the actual runtime state (shell starts in working_dir) and follows naturally with the omission of `cd` as a consequence, not a rule.

The server-side `strip_cd_prefix` (introduced in #1104) already handles the redundant `cd` case, but the goal is to eliminate the noise at the source.

## Changes

- `crates/aptu-coder/src/lib.rs`: one-line description update in the `exec_command` tool attribute.

## Testing

`cargo fmt --check` and `cargo clippy -- -D warnings` both pass. No behavioral change; description only.
