### PR TITLE
fix(validation): replace ancestor-walk with parent-dir validation in require_exists=false branch

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -5024,16 +5024,20 @@ mod tests {
 
     #[test]
     fn test_validate_path_creates_parent_for_nonexistent_file() {
-        // Edge case: non-existent file with non-existent parent should still be accepted
-        // if the ancestor chain leads back to CWD.
-        let result = validate_path("nonexistent_dir/nonexistent_file.txt", false);
+        // Edge case: non-existent file with existing parent should be accepted.
+        let cwd = std::env::current_dir().expect("should get cwd");
+        let parent = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+        let parent_path = parent.path().to_path_buf();
+        let child = parent_path.join("new_file.txt");
+
+        let child_str = child.to_str().expect("path should be valid UTF-8");
+        let result = validate_path(child_str, false);
         assert!(
             result.is_ok(),
-            "validate_path should accept non-existent file with non-existent parent (require_exists=false)"
+            "validate_path should accept non-existent file with existing parent (require_exists=false)"
         );
         let path = result.unwrap();
-        let cwd = std::env::current_dir().expect("should get cwd");
-        let canonical_cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
+        let canonical_cwd = std::fs::canonicalize(&cwd).expect("should canonicalize cwd");
         assert!(
             path.starts_with(&canonical_cwd),
             "Resolved path should be within CWD: {:?} should start with {:?}",
@@ -5102,17 +5106,10 @@ mod tests {
         // Act: try to traverse outside working_dir with ../../../etc/passwd
         let result = validate_path_in_dir("../../../etc/passwd", false, temp_path);
 
-        // Assert: should reject path traversal attack
+        // Assert: should reject path traversal attack (via parent canonicalize failure)
         assert!(
             result.is_err(),
             "validate_path_in_dir should reject path traversal outside working_dir"
-        );
-        let err = result.unwrap_err();
-        let err_msg = err.message.to_lowercase();
-        assert!(
-            err_msg.contains("outside") || err_msg.contains("working"),
-            "Error message should mention 'outside' or 'working': {}",
-            err.message
         );
     }
 
@@ -5336,25 +5333,13 @@ mod tests {
     #[test]
     fn test_validate_path_in_dir_nonexistent_deep_path() {
         // Deeply nested non-existent path: a/b/c/d/new.txt -- none of the
-        // intermediate directories exist.  The loop must walk up all four
-        // segments and anchor at working_dir, then rejoin the full suffix.
+        // intermediate directories exist.  With parent-directory validation,
+        // this is rejected because the parent a/b/c/d does not exist.
         let temp_dir = tempfile::TempDir::new().expect("should create temp dir");
         let result = validate_path_in_dir("a/b/c/d/new.txt", false, temp_dir.path());
         assert!(
-            result.is_ok(),
-            "validate_path_in_dir should accept deeply nested non-existent path: {:?}",
-            result.err()
-        );
-        let resolved = result.unwrap();
-        let canonical_wd =
-            std::fs::canonicalize(temp_dir.path()).expect("should canonicalize temp dir");
-        assert!(
-            resolved.starts_with(&canonical_wd),
-            "Resolved path must be within working_dir: {resolved:?}"
-        );
-        assert!(
-            resolved.ends_with("a/b/c/d/new.txt"),
-            "Full suffix must be preserved: {resolved:?}"
+            result.is_err(),
+            "validate_path_in_dir should reject deeply nested non-existent path"
         );
     }
 

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -3,9 +3,98 @@
 //! Path validation helpers used by the edit_overwrite and edit_replace tool handlers.
 
 use rmcp::model::ErrorData;
-use tracing::warn;
 
 use crate::error_meta;
+
+/// Validates that the parent directory of `path` exists, is a directory,
+/// and is within `root`.  Returns the resolved path (canonical_parent.join(file_name)).
+fn validate_parent_in_root(
+    path: &str,
+    root: &std::path::Path,
+) -> Result<std::path::PathBuf, ErrorData> {
+    let p = std::path::Path::new(path);
+
+    // Reject paths where file_name is None (bare '..', '.', or trailing slash).
+    let file_name = p.file_name().ok_or_else(|| {
+        ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_PARAMS,
+            "path must include a filename component".to_string(),
+            Some(error_meta(
+                "validation",
+                false,
+                "provide a path with a filename, not ending in '..' or '/'",
+            )),
+        )
+    })?;
+
+    // Extract parent; empty or '.' maps to root directly.
+    // Note: if `path` is absolute, `root.join(parent)` discards `root` and returns
+    // the absolute path as-is (standard Rust Path::join behaviour).  The
+    // `starts_with(root)` check below then rejects it, so absolute paths that
+    // escape root are handled correctly without a separate is_absolute() guard.
+    let parent = p.parent().unwrap_or(std::path::Path::new(""));
+    let parent_path = if parent.as_os_str().is_empty() || parent == std::path::Path::new(".") {
+        root.to_path_buf()
+    } else {
+        root.join(parent)
+    };
+
+    // Canonicalize parent.
+    let canonical_parent = std::fs::canonicalize(&parent_path).map_err(|e| {
+        io_error_to_path_error(
+            &e,
+            parent.to_str().unwrap_or("(invalid utf-8)"),
+            "provide a valid parent directory within the working directory",
+        )
+    })?;
+
+    // Verify canonicalized parent is within root.
+    if !canonical_parent.starts_with(root) {
+        return Err(ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_PARAMS,
+            "path is outside the working directory".to_string(),
+            Some(error_meta(
+                "validation",
+                false,
+                "provide a path within the working directory",
+            )),
+        ));
+    }
+
+    // Verify canonicalized parent is a directory, not a file.
+    if !std::fs::metadata(&canonical_parent)
+        .map(|m| m.is_dir())
+        .unwrap_or(false)
+    {
+        return Err(ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_PARAMS,
+            "parent path is not a directory".to_string(),
+            Some(error_meta(
+                "validation",
+                false,
+                "provide a path whose parent is a directory",
+            )),
+        ));
+    }
+
+    // Join parent with file_name to form the resolved path.
+    let resolved_path = canonical_parent.join(file_name);
+
+    // Final security check: resolved path must be within root.
+    if !resolved_path.starts_with(root) {
+        return Err(ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_PARAMS,
+            "path is outside the working directory".to_string(),
+            Some(error_meta(
+                "validation",
+                false,
+                "provide a path within the working directory",
+            )),
+        ));
+    }
+
+    Ok(resolved_path)
+}
 
 /// Validates that a path is within the current working directory.
 /// For `require_exists=true`, the path must exist and be canonicalizable.
@@ -18,7 +107,7 @@ pub(crate) fn validate_path(
     let cwd = std::env::current_dir().map_err(|_| {
         ErrorData::new(
             rmcp::model::ErrorCode::INVALID_PARAMS,
-            "path is outside the allowed root".to_string(),
+            "path is outside the working directory".to_string(),
             Some(error_meta(
                 "validation",
                 false,
@@ -29,7 +118,7 @@ pub(crate) fn validate_path(
     let allowed_root = std::fs::canonicalize(&cwd).map_err(|_| {
         ErrorData::new(
             rmcp::model::ErrorCode::INVALID_PARAMS,
-            "path is outside the allowed root".to_string(),
+            "path is outside the working directory".to_string(),
             Some(error_meta(
                 "validation",
                 false,
@@ -43,7 +132,7 @@ pub(crate) fn validate_path(
             let msg = match e.kind() {
                 std::io::ErrorKind::NotFound => "path not found".to_string(),
                 std::io::ErrorKind::PermissionDenied => "permission denied".to_string(),
-                _ => "path is outside the allowed root".to_string(),
+                _ => "path is outside the working directory".to_string(),
             };
             ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -56,56 +145,13 @@ pub(crate) fn validate_path(
             )
         })?
     } else {
-        // For non-existent files (edit_overwrite), walk up the path until we find an existing ancestor.
-        // `..` components are safe here: file_name() returns None for `..`, so the
-        // loop hits the else branch and resets ancestor to allowed_root, anchoring
-        // the resolved path inside allowed_root.  The starts_with check below catches
-        // any residual traversal regardless.
-        let p = std::path::Path::new(path);
-        let mut ancestor = p.to_path_buf();
-        // Collect suffix components in reverse order, then reassemble without
-        // join(PathBuf::new()) to avoid a trailing separator on the first push.
-        let mut suffix_components: Vec<std::ffi::OsString> = Vec::new();
-
-        loop {
-            if ancestor.exists() {
-                break;
-            }
-            if let Some(parent) = ancestor.parent()
-                && let Some(file_name) = ancestor.file_name()
-            {
-                suffix_components.push(file_name.to_owned());
-                ancestor = parent.to_path_buf();
-            } else {
-                // No existing ancestor found — use allowed_root as anchor
-                ancestor = allowed_root.clone();
-                break;
-            }
-        }
-
-        // Reassemble suffix in the original (forward) order without trailing separator.
-        let suffix_empty = suffix_components.is_empty();
-        let suffix: std::path::PathBuf = suffix_components.into_iter().rev().collect();
-
-        let canonical_base = std::fs::canonicalize(&ancestor).unwrap_or_else(|e| {
-            warn!(
-                path = %ancestor.display(),
-                error = %e,
-                "canonicalize of existing ancestor failed (race condition); falling back to allowed_root"
-            );
-            allowed_root.clone()
-        });
-        if suffix_empty {
-            canonical_base
-        } else {
-            canonical_base.join(&suffix)
-        }
+        validate_parent_in_root(path, &allowed_root)?
     };
 
     if !canonical_path.starts_with(&allowed_root) {
         return Err(ErrorData::new(
             rmcp::model::ErrorCode::INVALID_PARAMS,
-            "path is outside the allowed root".to_string(),
+            "path is outside the working directory".to_string(),
             Some(error_meta(
                 "validation",
                 false,
@@ -145,6 +191,9 @@ pub(crate) fn io_error_to_path_error(
 
 /// Validates a path relative to a working directory.
 /// The working_dir may be anywhere on disk; it is not restricted to the server CWD.
+/// For `require_exists=true`, the path must exist and be canonicalizable within working_dir.
+/// For `require_exists=false`, the parent directory must exist, be a directory, and be
+/// within working_dir.  The filename is then appended without canonicalization.
 /// The resolved path must be within the working_dir.
 pub(crate) fn validate_path_in_dir(
     path: &str,
@@ -193,47 +242,7 @@ pub(crate) fn validate_path_in_dir(
             )
         })?
     } else {
-        // For non-existent files, walk up the path until we find an existing ancestor.
-        // `..` components are safe here: file_name() returns None for `..`, so the
-        // loop hits the else branch and resets ancestor to PathBuf::new(), anchoring
-        // the resolved path inside canonical_working_dir.  The starts_with check
-        // below catches any residual traversal regardless.
-        let p = std::path::Path::new(path);
-        let mut ancestor = p.to_path_buf();
-        // Collect suffix components in reverse order, then reassemble without
-        // join(PathBuf::new()) to avoid a trailing separator on the first push.
-        let mut suffix_components: Vec<std::ffi::OsString> = Vec::new();
-
-        loop {
-            let full_path = canonical_working_dir.join(&ancestor);
-            if full_path.exists() {
-                break;
-            }
-            if let Some(parent) = ancestor.parent()
-                && let Some(file_name) = ancestor.file_name()
-            {
-                suffix_components.push(file_name.to_owned());
-                ancestor = parent.to_path_buf();
-            } else {
-                // No existing ancestor found (or path contains `..`) --
-                // use working_dir as anchor; starts_with below enforces the boundary.
-                ancestor = std::path::PathBuf::new();
-                break;
-            }
-        }
-
-        // Reassemble suffix in the original (forward) order without trailing separator.
-        let suffix_empty = suffix_components.is_empty();
-        let suffix: std::path::PathBuf = suffix_components.into_iter().rev().collect();
-
-        let canonical_base = canonical_working_dir.join(&ancestor);
-        let canonical_base =
-            std::fs::canonicalize(&canonical_base).unwrap_or(canonical_working_dir.clone());
-        if suffix_empty {
-            canonical_base
-        } else {
-            canonical_base.join(&suffix)
-        }
+        validate_parent_in_root(path, &canonical_working_dir)?
     };
 
     // Verify the resolved path is within working_dir.

--- a/crates/aptu-coder/tests/edit_working_dir.rs
+++ b/crates/aptu-coder/tests/edit_working_dir.rs
@@ -310,3 +310,176 @@ async fn test_edit_replace_empty_new_text_entire_file() {
         "file should be empty after full-content deletion"
     );
 }
+
+/// edit_overwrite with a path whose parent directory does not exist returns INVALID_PARAMS.
+#[tokio::test]
+async fn test_edit_overwrite_new_file_missing_parent_dir() {
+    // Arrange: create temp working_dir and try to write into a non-existent subdirectory
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    // The parent "nonexistent" does not exist inside working_dir
+    let file_name = "nonexistent/new_file.txt";
+
+    // Act
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "should not be written",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+}
+
+/// edit_overwrite with a ../ traversal path that escapes working_dir returns INVALID_PARAMS.
+#[tokio::test]
+async fn test_edit_overwrite_new_file_traversal_path() {
+    // Arrange: create temp working_dir, try to escape it with ..
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    // ../foo.txt should escape working_dir
+    let file_name = "../escaped_file.txt";
+
+    // Act
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "should not be written",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+}
+
+/// edit_overwrite with a deeply nested path where only the top-level parent exists returns INVALID_PARAMS.
+#[tokio::test]
+async fn test_edit_overwrite_new_file_deeply_nested() {
+    // Arrange: create temp working_dir with only a/ directory
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    // Create only the top-level a/ directory
+    std::fs::create_dir(temp_dir.path().join("a")).expect("should create dir a");
+    // a/b/c/new.txt -- b/c does not exist
+    let file_name = "a/b/c/new.txt";
+
+    // Act
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "should not be written",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+}
+
+/// edit_overwrite where the parent is a symlink to a valid directory succeeds.
+#[tokio::test]
+async fn test_edit_overwrite_new_file_symlink_parent() {
+    // Arrange: create a temp working_dir, a subdirectory, and a symlink pointing to it
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir.path();
+    // Create a real subdirectory
+    let real_sub = working_dir.join("real_dir");
+    std::fs::create_dir(&real_sub).expect("should create real_dir");
+    // Create a symlink pointing to the real subdirectory
+    let symlink_path = working_dir.join("link_to_real");
+    std::os::unix::fs::symlink(&real_sub, &symlink_path)
+        .expect("should create symlink to real_dir");
+    let working_dir_str = working_dir.to_str().expect("temp dir path is valid UTF-8");
+    let file_name = "link_to_real/through_symlink.txt";
+
+    // Act
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "written via symlink parent",
+            "working_dir": working_dir_str
+        }),
+    )
+    .await;
+
+    // Assert: success, file exists in the canonical real_dir
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected success but got error: {resp}"
+    );
+    let expected_path = real_sub.join("through_symlink.txt");
+    assert!(
+        expected_path.exists(),
+        "file should exist inside real_dir at {:?}",
+        expected_path
+    );
+    let written =
+        std::fs::read_to_string(&expected_path).expect("should read written file via symlink");
+    assert_eq!(written, "written via symlink parent");
+}
+
+/// edit_overwrite where the parent component is a regular file returns INVALID_PARAMS.
+#[tokio::test]
+async fn test_edit_overwrite_parent_is_file() {
+    // Arrange: create temp working_dir with a file that will be used as a "parent"
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    // Create a regular file
+    let file_path = temp_dir.path().join("not_a_dir.txt");
+    std::fs::write(&file_path, "i am a file, not a directory").expect("should write test file");
+    // Try to write "inside" that file as if it were a directory
+    let file_name = "not_a_dir.txt/child.txt";
+
+    // Act
+    let resp = call_tool_raw(
+        "edit_overwrite",
+        serde_json::json!({
+            "path": file_name,
+            "content": "should not be written",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    // Assert
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+}


### PR DESCRIPTION
## Summary

Replaces the defective ancestor-walk loop in the `require_exists=false` branch of both `validate_path` and `validate_path_in_dir` with parent-directory validation, extracted into a shared `validate_parent_in_root` helper.

The old code left `ancestor` as `PathBuf::new()` when no real ancestor was found, causing `canonical_working_dir.join(PathBuf::new()).exists()` (always true) to exit the loop prematurely. The `unwrap_or_else` fallback on `canonicalize` then silently left `canonical_base` pointing at `working_dir` itself, and the unvalidated suffix was joined onto that wrong base, producing a malformed path that `write_file_atomic` rejected as `internal_error`.

New approach (shared by both functions via `validate_parent_in_root`):
1. Extract `file_name` from path; reject with `INVALID_PARAMS` if `None` (path ends with `..` or `/`)
2. Extract parent; if empty or `.` use `root` directly
3. Canonicalize parent; verify `starts_with(root)` and `is_dir()`
4. Join parent + `file_name`; verify final path still `starts_with(root)`

Deeply nested non-existent paths (e.g. `a/b/c/new.txt` where only `a/` exists) are now rejected at validation time with a clear `INVALID_PARAMS` message rather than reaching `write_file_atomic` and failing with an opaque `internal_error`. This is a correctness improvement: `write_file_atomic` has always required the immediate parent to exist; the old code never delivered on an implicit promise to create intermediate directories.

Also aligns all "path is outside the allowed root" error messages to "path is outside the working directory" for consistency.

## Changes

- `crates/aptu-coder/src/validation.rs` -- extract `validate_parent_in_root` helper; replace ancestor-walk loop in both `validate_path` and `validate_path_in_dir`; align error message wording; add comment explaining absolute-path rejection via `starts_with`
- `crates/aptu-coder/tests/edit_working_dir.rs` -- 5 new integration tests: missing parent dir, traversal path, deeply nested path, symlink parent, parent-is-file
- `crates/aptu-coder/src/lib.rs` -- update unit tests to match new validation semantics; simplify `test_validate_path_creates_parent_for_nonexistent_file` setup

## Test plan

- [x] 140 tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Deny clean (`cargo deny check advisories licenses`)
- [x] All inline review comments resolved

Closes #1134
