### PR TITLE
fix(edit): normalize CRLF to LF in edit_replace_block before matching

### DIFF
--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -145,7 +145,9 @@ pub fn edit_replace_block(
     }
     let bytes_before = content.len();
     // Find match offset in normalized space, then map back to original byte range
-    let norm_match_offset = norm_content.find(&norm_old).unwrap();
+    let norm_match_offset = norm_content
+        .find(&norm_old)
+        .expect("match was verified above via count check; find must succeed");
     let original_start = norm_offset_to_original(&content, norm_match_offset);
     let original_end = norm_offset_to_original_from(&content, norm_old.len(), original_start);
     let updated = [

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -64,6 +64,9 @@ fn norm_offset_to_original_from(
     norm_offset: usize,
     original_start: usize,
 ) -> usize {
+    // Performance: O(n) byte walk is acceptable for the file sizes MCP tools operate on
+    // (source files, typically <1 MB). If very large file support becomes a requirement,
+    // a pre-built CRLF offset index could reduce this to O(log n) per lookup.
     let bytes = original.as_bytes();
     let mut norm_pos = 0usize;
     let mut i = original_start;

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -51,6 +51,40 @@ fn write_file_atomic(path: &Path, content: &str) -> Result<(), EditError> {
     Ok(())
 }
 
+/// Normalize content for matching: replace `\r\n` with `\n`.
+/// Single `\r` bytes are left unchanged.
+fn normalize_for_match(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}
+
+/// Map a byte offset in normalized content (CRLF -> LF) back to the corresponding
+/// byte offset in the original content, starting from `original_start`.
+fn norm_offset_to_original_from(
+    original: &str,
+    norm_offset: usize,
+    original_start: usize,
+) -> usize {
+    let bytes = original.as_bytes();
+    let mut norm_pos = 0usize;
+    let mut i = original_start;
+    while i < bytes.len() && norm_pos < norm_offset {
+        if bytes[i] == b'\r' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+            norm_pos += 1;
+            i += 2;
+        } else {
+            norm_pos += 1;
+            i += 1;
+        }
+    }
+    i
+}
+
+/// Map a byte offset in normalized content back to the corresponding byte offset
+/// in the original content.
+fn norm_offset_to_original(original: &str, norm_offset: usize) -> usize {
+    norm_offset_to_original_from(original, norm_offset, 0)
+}
+
 pub fn edit_overwrite_content(
     path: &Path,
     content: &str,
@@ -79,7 +113,9 @@ pub fn edit_replace_block(
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
     let content = std::fs::read_to_string(path)?;
-    let count = content.matches(old_text).count();
+    let norm_content = normalize_for_match(&content);
+    let norm_old = normalize_for_match(old_text);
+    let count = norm_content.matches(&norm_old).count();
     match count {
         0 => {
             let first_20_lines = content.lines().take(20).collect::<Vec<_>>().join("\n");
@@ -90,9 +126,15 @@ pub fn edit_replace_block(
         }
         1 => {}
         n => {
-            let match_lines: Vec<usize> = content
-                .match_indices(old_text)
-                .map(|(offset, _)| content[..offset].bytes().filter(|&b| b == b'\n').count() + 1)
+            let match_lines: Vec<usize> = norm_content
+                .match_indices(&norm_old)
+                .map(|(offset, _)| {
+                    norm_content[..offset]
+                        .bytes()
+                        .filter(|&b| b == b'\n')
+                        .count()
+                        + 1
+                })
                 .collect();
             return Err(EditError::Ambiguous {
                 count: n,
@@ -102,7 +144,16 @@ pub fn edit_replace_block(
         }
     }
     let bytes_before = content.len();
-    let updated = content.replacen(old_text, new_text, 1);
+    // Find match offset in normalized space, then map back to original byte range
+    let norm_match_offset = norm_content.find(&norm_old).unwrap();
+    let original_start = norm_offset_to_original(&content, norm_match_offset);
+    let original_end = norm_offset_to_original_from(&content, norm_old.len(), original_start);
+    let updated = [
+        &content[..original_start],
+        new_text,
+        &content[original_end..],
+    ]
+    .concat();
     let bytes_after = updated.len();
     write_file_atomic(path, &updated)?;
     Ok(EditReplaceOutput {
@@ -185,5 +236,61 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let err = edit_replace_block(dir.path(), "old", "new").unwrap_err();
         std::assert_matches!(err, EditError::NotAFile(_));
+    }
+
+    #[test]
+    fn edit_replace_block_crlf_file_lf_oldtext() {
+        // CRLF file + LF old_text => match succeeds and non-replaced lines retain CRLF bytes
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crlf.txt");
+        // Write raw CRLF bytes: "foo\r\nbar\r\nbaz"
+        std::fs::write(&path, b"foo\r\nbar\r\nbaz").unwrap();
+        let result = edit_replace_block(&path, "bar", "qux").unwrap();
+        // The result should contain "foo\r\nqux\r\nbaz" (non-replaced lines retain CRLF)
+        let output = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(output, "foo\r\nqux\r\nbaz");
+        assert_eq!(result.bytes_before, 13); // "foo\r\nbar\r\nbaz" = 13 bytes
+        assert_eq!(result.bytes_after, 13); // "foo\r\nqux\r\nbaz" = 13 bytes
+    }
+
+    #[test]
+    fn edit_replace_block_lf_file_crlf_oldtext() {
+        // LF file + CRLF old_text => match succeeds
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lf.txt");
+        std::fs::write(&path, b"foo\nbar\nbaz").unwrap();
+        let result = edit_replace_block(&path, "bar\r\n", "qux\n").unwrap();
+        // old_text "bar\r\n" is normalized to "bar\n", matches "bar\n" in file
+        let output = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(output, "foo\nqux\nbaz");
+        assert_eq!(result.bytes_before, 11); // "foo\nbar\nbaz" = 11 bytes
+        assert_eq!(result.bytes_after, 11); // "foo\nqux\nbaz" = 11 bytes
+    }
+
+    #[test]
+    fn edit_replace_block_crlf_file_crlf_oldtext() {
+        // CRLF file + CRLF old_text => both normalized, match succeeds
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bothcrlf.txt");
+        std::fs::write(&path, b"line1\r\nline2\r\nline3").unwrap();
+        let result = edit_replace_block(&path, "line2\r\n", "replaced\n").unwrap();
+        let output = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(output, "line1\r\nreplaced\nline3");
+        assert_eq!(result.bytes_before, 19); // "line1\r\nline2\r\nline3" = 19 bytes
+    }
+
+    #[test]
+    fn edit_replace_block_trailing_spaces_distinct() {
+        // Two blocks differing only by trailing spaces remain distinct after normalization
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spaces.txt");
+        std::fs::write(&path, "foo  \nbar\nfoo\nbar").unwrap();
+        // old_text "foo\nbar" should match the SECOND occurrence ("foo\nbar"),
+        // not the first ("foo  \nbar"), because trailing spaces are not stripped
+        let result = edit_replace_block(&path, "foo\nbar", "replaced").unwrap();
+        let output = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(output, "foo  \nbar\nreplaced");
+        assert_eq!(result.bytes_before, 17); // "foo  \nbar\nfoo\nbar" = 17 bytes
+        assert_eq!(result.bytes_after, 18); // "foo  \nbar\nreplaced" = 18 bytes
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2965,7 +2965,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
-        description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. CRLF line endings in old_text are normalized to LF before matching; file content is preserved exactly except for the replaced block. Use edit_overwrite to replace the whole file. Pass empty string for new_text to delete the matched block. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
+        description = "Replaces a unique exact text block; old_text must appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. CRLF line endings in old_text are normalized to LF before matching; all other whitespace is matched exactly. Use edit_overwrite to replace the whole file. Pass empty string for new_text to delete the matched block. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
         output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
             title = "Edit Replace",

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -2965,7 +2965,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
-        description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. Whitespace-sensitive exact match. Use edit_overwrite to replace the whole file. Pass empty string for new_text to delete the matched block. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
+        description = "Replaces a unique exact text block; old_text must match character-for-character and appear exactly once. Returns path, bytes_before, bytes_after. Fails if zero matches; fails if multiple matches (extend old_text to be more specific). If invalid_params is returned, re-read the target file with analyze_file or analyze_module before retrying. CRLF line endings in old_text are normalized to LF before matching; file content is preserved exactly except for the replaced block. Use edit_overwrite to replace the whole file. Pass empty string for new_text to delete the matched block. working_dir sets the base directory for path resolution (default: server CWD). Example queries: Update the function signature in lib.rs.",
         output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
             title = "Edit Replace",

--- a/crates/aptu-coder/tests/edit_replace_errors.rs
+++ b/crates/aptu-coder/tests/edit_replace_errors.rs
@@ -503,3 +503,100 @@ async fn test_circuit_breaker_edit_overwrite_resets() {
         "error message must not contain working_dir: {seventh_msg}"
     );
 }
+
+/// CRLF file + LF old_text => match succeeds, non-replaced lines retain CRLF bytes.
+#[tokio::test]
+async fn test_edit_replace_crlf_file_lf_oldtext() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "crlf.txt";
+    let file_path = temp_dir.path().join(file_name);
+    // Write raw CRLF bytes
+    std::fs::write(&file_path, b"foo\r\nbar\r\nbaz").expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "bar",
+            "new_text": "qux",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success but got error: {resp}"
+    );
+    let output = std::fs::read_to_string(&file_path).expect("should read file");
+    assert_eq!(output, "foo\r\nqux\r\nbaz");
+}
+
+/// LF file + CRLF old_text => match succeeds (old_text normalized to LF).
+#[tokio::test]
+async fn test_edit_replace_lf_file_crlf_oldtext() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "lf.txt";
+    let file_path = temp_dir.path().join(file_name);
+    std::fs::write(&file_path, b"foo\nbar\nbaz").expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "bar\r\n",
+            "new_text": "qux\n",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success but got error: {resp}"
+    );
+    let output = std::fs::read_to_string(&file_path).expect("should read file");
+    assert_eq!(output, "foo\nqux\nbaz");
+}
+
+/// CRLF file + CRLF old_text (both normalized) => match succeeds.
+#[tokio::test]
+async fn test_edit_replace_crlf_file_crlf_oldtext() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "bothcrlf.txt";
+    let file_path = temp_dir.path().join(file_name);
+    std::fs::write(&file_path, b"line1\r\nline2\r\nline3").expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "line2\r\n",
+            "new_text": "replaced\n",
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success but got error: {resp}"
+    );
+    let output = std::fs::read_to_string(&file_path).expect("should read file");
+    assert_eq!(output, "line1\r\nreplaced\nline3");
+}


### PR DESCRIPTION
## Summary

Normalizes CRLF line endings to LF in `edit_replace_block` before matching, resolving the residual 7.5% `edit_replace` error rate documented in #1135.

## Changes

- `crates/aptu-coder-core/src/edit.rs`: Add `normalize_for_match` (CRLF->LF), `norm_offset_to_original_from` (byte-offset mapping), and modify `edit_replace_block` to match on normalized copies while splicing replacement into original content at mapped byte positions. Non-replaced lines are preserved exactly. Add `// Performance:` comment documenting O(n) complexity and the O(log n) upgrade path for large-file scenarios.
- `crates/aptu-coder/src/lib.rs`: Update `edit_replace` tool description -- remove "match character-for-character" and "Whitespace-sensitive exact match"; replace with accurate two-part statement: CRLF line endings normalized to LF before matching, all other whitespace matched exactly.
- `crates/aptu-coder/tests/edit_replace_errors.rs`: Add 3 integration tests (CRLF file + LF old_text, LF file + CRLF old_text, CRLF + CRLF).
- `crates/aptu-coder-core/src/edit.rs` (unit tests): Add 4 unit tests including trailing-space non-normalization edge case.

## Test plan

- [x] Tests pass (627 all tests pass)
- [x] Linter clean (cargo clippy -- -D warnings)
- [x] Security scan clean

Closes #1135
