### PR TITLE
chore(release): bump version to 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump version to 0.20.1 and update Cargo.lock.

## What's in this release

### Features

- **`edit_replace`: stale-context circuit breaker for consecutive invalid_params failures** (#1132, closes #1118): After 5 consecutive `not_found` or `ambiguous` failures on the same `(session_id, canonical_path)` pair, `edit_replace` returns an `EDIT_STALE_CONTEXT` directive error instructing the model to re-read the file before retrying. The failure counter resets on any successful `edit_replace` or `edit_overwrite` on that path.

### Bug Fixes

- **`edit_replace`: normalize CRLF to LF before matching** (#1137): `edit_replace_block` now strips `\r` from both the file content and the `old_text` needle before attempting a match, so files with Windows line endings no longer produce spurious `not_found` failures.

- **`validation`: replace ancestor-walk with parent-dir validation in `require_exists=false` branch** (#1136, closes #1134): The old ancestor-walk left `canonical_base` pointing at `working_dir` when no real ancestor was found, causing `write_file_atomic` to receive a malformed path and return an opaque `internal_error`. The new approach validates the immediate parent directory, rejects paths whose parent does not exist with a clear `INVALID_PARAMS` message, and aligns all "path is outside the allowed root" error messages to "path is outside the working directory".

### Documentation

- **`exec_command`: reframe `cd` prohibition as mechanical fact in tool description** (#1133): Replaces the prohibition-style "Do not prepend cd to the command" with "Commands run inside working_dir; omit `cd`." -- grounding model behavior in stated runtime reality rather than a rule.

### Maintenance

- **Dependency update**: `bytes` 1.12.0, `getrandom` 0.4.3 (#1138).

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.20.0...v0.20.1
