### PR TITLE
docs(design-guide): document cd prefix trace as known model behavior anti-pattern

### DIFF
--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -252,7 +252,7 @@ The following anti-patterns were identified across benchmark waves and wave post
 | Synchronous metrics/logging on the hot path | Observability adds latency to every tool call | Channel pattern: fire-and-forget into unbounded channel; writer task runs independently |
 | Optimizing only for large models | Small-model users experience regressions | Small-model-first constraint: validate against Haiku before Sonnet |
 | Missing `///` doc comments on parameter fields | Parameter appears in `inputSchema.properties` with an empty `description`; model must infer meaning from name alone | Add `///` doc comment to every parameter field; enforced by `test_all_tool_parameters_have_descriptions` in `annotations.rs` |
-| Model prepends `cd /path &&` to `exec_command` command alongside `working_dir` | Server strips the redundant prefix before execution (correct result), but the MCP client trace displays the raw submitted parameters -- the `cd` appears in the UI even though it never runs. This is a persistent model habit that tool description changes cannot fully suppress; it is cosmetic only and does not affect correctness. | No server-side fix available. The MCP client displays submitted parameters, not the sanitized command. Document as known behavior rather than filing as a bug. |
+| Model prepends `cd /path &&` to `exec_command` alongside `working_dir` | Server strips the redundant prefix before execution, but the MCP client trace displays the raw submitted command. Cosmetic only; correctness is unaffected. | No server-side fix available; the client displays submitted parameters, not the sanitized command. Treat as known model habit, not a bug. |
 
 *Table 5: Anti-patterns, consequences, and corrective patterns.*
 

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -252,6 +252,7 @@ The following anti-patterns were identified across benchmark waves and wave post
 | Synchronous metrics/logging on the hot path | Observability adds latency to every tool call | Channel pattern: fire-and-forget into unbounded channel; writer task runs independently |
 | Optimizing only for large models | Small-model users experience regressions | Small-model-first constraint: validate against Haiku before Sonnet |
 | Missing `///` doc comments on parameter fields | Parameter appears in `inputSchema.properties` with an empty `description`; model must infer meaning from name alone | Add `///` doc comment to every parameter field; enforced by `test_all_tool_parameters_have_descriptions` in `annotations.rs` |
+| Model prepends `cd /path &&` to `exec_command` command alongside `working_dir` | Server strips the redundant prefix before execution (correct result), but the MCP client trace displays the raw submitted parameters -- the `cd` appears in the UI even though it never runs. This is a persistent model habit that tool description changes cannot fully suppress; it is cosmetic only and does not affect correctness. | No server-side fix available. The MCP client displays submitted parameters, not the sanitized command. Document as known behavior rather than filing as a bug. |
 
 *Table 5: Anti-patterns, consequences, and corrective patterns.*
 


### PR DESCRIPTION
## Summary

Adds a row to Table 5 (Anti-Patterns) in `docs/DESIGN-GUIDE.md` documenting the `cd /path &&` prefix trace issue.

Models persistently prepend `cd /path &&` to `exec_command` commands while also setting `working_dir` to the same path. The server already strips the redundant prefix before execution (#1104, shipped in 0.20.1), so correctness is unaffected. However, the MCP client displays the raw submitted parameters -- the `cd` appears in the UI trace even though it never runs.

Tool description changes (#1133) cannot fully suppress this habit. There is no server-side fix: the client displays what was submitted, not what was executed. Documenting it prevents future duplicate bug reports.

## Changes

- `docs/DESIGN-GUIDE.md`: one new row in Table 5

Closes #1140
