### PR TITLE
chore(ci): bump clouatre-labs/aptu action to v0.10.1

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Aptu Triage
-        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
+        uses: clouatre-labs/aptu@5545c56f0f4bf52a3dc918ec48a56c309280447c # v0.10.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
+        uses: clouatre-labs/aptu@5545c56f0f4bf52a3dc918ec48a56c309280447c # v0.10.1
         continue-on-error: true  # Non-blocking - AI review is advisory
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `clouatre-labs/aptu` from v0.8.6 to v0.10.1 (SHA-pinned) in both
GitHub Actions workflows.

## Changes

- `.github/workflows/issue-triage.yml`: SHA pin updated
- `.github/workflows/pr-review.yml`: SHA pin updated

Old SHA: `93ca6d6613ebc2bb47f92caf48d10509ad0920e3` (v0.8.6)
New SHA: `5545c56f0f4bf52a3dc918ec48a56c309280447c` (v0.10.1)

## Review against v0.10.1 guidance

Reviewed both workflows against the v0.10.1 `action.yml` and
`docs/GITHUB_ACTION.md`. All inputs remain aligned:

- `issue-triage.yml`: `no-comment: 'true'` and `apply-labels` defaulting
  to `true` are correct for issue triage.
- `pr-review.yml`: `skip-labeled: 'false'`, `repo-path`, `instructions-file`,
  `provider`, `model`, `fallback-provider`, and `fallback-model` all match
  v0.10.1 defaults and guidance. `deep` is intentionally omitted (auto
  call-graph based on budget). Prompt budget inputs use compiled-in defaults,
  which are appropriate for this codebase.

No new inputs need to be wired in; all new budget parameters introduced
between v0.8.6 and v0.10.1 default to reasonable values.

## Notable changes in v0.9 and v0.10

- v0.9: WASM portability, hardened CI
- v0.10: Provider refactor; `max_diff_chars` / `max_patch_chars_per_file`
  now configurable via action inputs
- v0.10.1: `min_budget_for_call_graph` coupling enforced; CSS and YAML
  language support in aptu-coder-core dependency

