### PR TITLE
docs: sync AGENTS, README, and docs with v0.20.1 features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,27 +31,14 @@ Dependency freshness: new Cargo.lock entries must be >=7 days old; bypass with S
 
 ## Observability
 
-By default, the server operates with noop telemetry providers (zero overhead). Telemetry export is opt-in via environment variables:
+Two parallel telemetry channels; neither blocks tool execution.
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT` -- Set to an OTLP HTTP endpoint URL (e.g., `http://localhost:4318`) to enable export of traces, logs, and metrics via OTLP/HTTP. When unset, the OpenTelemetry SDK is initialized with noop providers incurring no cost. Exports are asynchronous and do not block tool execution.
-
-- `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` -- Reserved per OpenTelemetry GenAI semantic conventions for opt-in capture of tool arguments and results. aptu-coder does not implement this: individual bounded parameters (path, symbol, depth) are recorded as span attributes instead of serializing the full tool call arguments or results, ensuring credentials and file content are never emitted.
-
-- `XDG_DATA_HOME` -- Base directory for the always-on JSONL metrics channel. The server writes daily-rotated metrics to `$XDG_DATA_HOME/aptu-coder/` and retains them for 30 days. Defaults to `~/.local/share` if unset.
-
-**Instrumentation:** Each tool invocation is wrapped in a span carrying OpenTelemetry GenAI semantic attributes (`gen_ai.system`, `gen_ai.operation.name`, `gen_ai.tool.name`). W3C Trace Context is extracted from the MCP `_meta` field, allowing MCP clients to propagate their trace context so tool spans become children in a distributed trace.
-
-**Metrics:**
-- JSONL channel: always-on, fire-and-forget, zero latency cost. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the metric record schema and 30-day retention policy.
-- OpenTelemetry: optional, parallel to JSONL. Configured at server init; no runtime reconfiguration.
-
-For span attribute policy and the never-record list, see [OBSERVABILITY.md](OBSERVABILITY.md) at the repository root.
+- **JSONL (always-on):** daily-rotated files at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl`; 30-day retention. See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for schema and span attribute policy.
+- **OpenTelemetry (opt-in):** set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable OTLP/HTTP export; noop providers when unset. W3C Trace Context extracted from MCP `_meta` so tool spans appear as children in the calling agent's distributed trace.
 
 ### JSONL Metrics Analysis
 
-Daily-rotated JSONL files live at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (default: `~/.local/share/aptu-coder/`). See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full field reference.
-
-Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool), `language` (nullable string), `file_ext` (nullable string), `filter_applied` (nullable string), `output_truncated` (nullable bool).
+Files: `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (default: `~/.local/share/aptu-coder/`). Full schema in [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md).
 
 Five validated jq one-liners (run from `~/.local/share/aptu-coder/`). Always `cd` there first -- globs expand against CWD and silently match nothing from a different directory.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ For span attribute policy and the never-record list, see [OBSERVABILITY.md](OBSE
 
 Daily-rotated JSONL files live at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (default: `~/.local/share/aptu-coder/`). See [docs/OBSERVABILITY.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/OBSERVABILITY.md) for the full field reference.
 
-Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool).
+Key schema fields: `ts` (u64), `tool` (string), `duration_ms` (u64), `output_chars` (usize), `result` (string), `error_type` (nullable), `session_id` (nullable), `seq` (nullable), `cache_hit` (nullable), `cache_tier` (nullable), `exit_code` (nullable), `timed_out` (bool), `language` (nullable string), `file_ext` (nullable string), `filter_applied` (nullable string), `output_truncated` (nullable bool).
 
 Five validated jq one-liners (run from `~/.local/share/aptu-coder/`). Always `cd` there first -- globs expand against CWD and silently match nothing from a different directory.
 
@@ -92,12 +92,16 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 
 - `summary=true` and `cursor` are mutually exclusive; passing both returns INVALID_PARAMS.
 - `impl_only=true` restricts `analyze_symbol` callers to `impl Trait for Type` blocks; returns INVALID_PARAMS for non-Rust directories.
-- `analyze_module` supports `path` only -- pagination, summary, force, and verbose are not supported.
+- `analyze_module` supports `path` only -- pagination and summary are not supported.
 - `import_lookup=true` on `analyze_symbol` requires a non-empty `symbol` (the module path to search for); returns INVALID_PARAMS if symbol is empty. Mutually exclusive with normal call-graph lookup.
 - `def_use=true` on `analyze_symbol` triggers def-use extraction; `def_use_sites` is populated in `structuredContent` only when paginating in DefUse cursor mode, not on the initial call (the handler clears it on the first response and bootstraps a cursor to page through def-use results).
 - `git_ref` is supported on both `analyze_directory` and `analyze_symbol` to restrict analysis to files changed relative to a git ref.
 - `working_dir` on `edit_overwrite` and `edit_replace` sets the base directory for path resolution (default: server CWD). The resolved target path must be within working_dir.
-- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (3 tools); `analyze` disables edit_* tools (5 tools); absent/unknown enables all 7 tools. By default, all 7 tools are available.
+- `edit_replace` accepts empty `new_text` to delete the matched block. CRLF line endings in `old_text` are normalized to LF before matching. A stale-context circuit breaker fires after 5 consecutive `not_found` or `ambiguous` failures on the same (session_id, path) pair, returning a directive error; the map is capped at 1024 entries.
+- `exec_command` accepts an optional `timeout_secs` (integer >= 0; 0 or omitted means no limit). When the child process exceeds the limit it is killed; `timed_out: true` is set in the response and `exit_code` is null. Heredoc syntax with a missing closing delimiter is rejected before spawn.
+- `analyze_symbol` uses an L2 on-disk call-graph cache in addition to the L1 in-memory LRU. Configure with `APTU_CODER_DISK_CACHE_DIR` (default: `$XDG_DATA_HOME/aptu-coder/analysis-cache`); disable with `APTU_CODER_DISK_CACHE_DISABLED=1`.
+- `call_frequency` on `analyze_symbol` is filtered out when the `Functions` field is not in the projected fields set.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (4 tools: analyze_directory, analyze_file, analyze_module, analyze_symbol); `analyze` disables edit_* tools (5 tools: edit_overwrite, edit_replace, exec_command, and aliases); absent/unknown enables all 7 tools. By default, all 7 tools are available.
 
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`); returns graceful fallback (empty index with note) for unsupported extensions | all |
 | `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |
-| `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches; pass empty `new_text` to delete the matched block; CRLF line endings in `old_text` are normalized to LF before matching | all |
-| `exec_command` | Run a shell command; returns stdout, stderr, and exit code; supports progress notifications; output capped and filtered automatically; optional `timeout_secs` kills the child on expiry (`timed_out: true` in response); heredoc syntax with a missing closing delimiter is rejected before spawn | any |
+| `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches; empty `new_text` deletes the block; CRLF normalized before matching | all |
+| `exec_command` | Run a shell command; returns stdout, stderr, exit code; output capped and filtered; optional `timeout_secs`; heredoc missing delimiter rejected before spawn | any |
 
 Tool parameters, constraints, and examples are available via your MCP client's tool inspector or `tools/list` response.
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | Variable | Default | Description |
 |---|---|---|
 | `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | LRU cache size for directory-analysis results. |
-| `APTU_CODER_DISK_CACHE_DIR` | `$XDG_DATA_HOME/aptu-coder/analysis-cache` | Directory for the L2 on-disk call-graph cache used by `analyze_symbol`. |
+| `APTU_CODER_DISK_CACHE_DIR` | `$XDG_DATA_HOME/aptu-coder/analysis-cache` | Directory for the L2 on-disk call-graph cache used by `analyze_symbol`. Created automatically if it does not exist. |
 | `APTU_CODER_DISK_CACHE_DISABLED` | unset | Set to `1` to disable the L2 disk cache entirely. |
 | `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | LRU cache size for `exec_command` results. |
 | `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result cache. |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AeroDyn integration audit task on Claude Code against [OpenFAST](https://github.
 
 ## Overview
 
-aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports Rust, Python, Go, Java, Kotlin, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, Markdown, HTML, CSS, YAML, Astro, JSON, and TOML, and integrates with any MCP-compatible orchestrator.
+aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports 18 languages (see [Supported Languages](#supported-languages)) and integrates with any MCP-compatible orchestrator.
 
 ## Supported Languages
 
@@ -43,24 +43,24 @@ All languages are enabled by default. Disable individual languages at compile ti
 
 | Language | Extensions | Feature flag |
 |----------|------------|--------------|
-| Rust | `.rs` | `lang-rust` |
-| Python | `.py` | `lang-python` |
-| TypeScript | `.ts` | `lang-typescript` |
-| TSX | `.tsx` | `lang-tsx` |
-| Go | `.go` | `lang-go` |
-| Java | `.java` | `lang-java` |
-| Kotlin | `.kt`, `.kts` | `lang-kotlin` |
-| Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | `lang-fortran` |
-| JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
+| Astro | `.astro` | always-on (regex via TypeScript frontmatter extractor) |
 | C/C++ | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` | `lang-cpp` |
 | C# | `.cs` | `lang-csharp` |
-| Markdown | `.md`, `.mdx` | `lang-markdown` |
-| HTML | `.html`, `.htm` | `lang-html` (stub; no extraction) |
 | CSS | `.css` | `lang-css` (tree-sitter; regex fallback when disabled) |
-| YAML | `.yaml`, `.yml` | `lang-yaml` (tree-sitter; regex fallback when disabled) |
-| Astro | `.astro` | always-on (regex via TypeScript frontmatter extractor) |
+| Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | `lang-fortran` |
+| Go | `.go` | `lang-go` |
+| HTML | `.html`, `.htm` | `lang-html` (stub; no extraction) |
+| Java | `.java` | `lang-java` |
+| JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
 | JSON | `.json` | always-on (regex; first-level key extraction) |
+| Kotlin | `.kt`, `.kts` | `lang-kotlin` |
+| Markdown | `.md`, `.mdx` | `lang-markdown` |
+| Python | `.py` | `lang-python` |
+| Rust | `.rs` | `lang-rust` |
 | TOML | `.toml` | always-on (regex; section header extraction) |
+| TSX | `.tsx` | `lang-tsx` |
+| TypeScript | `.ts` | `lang-typescript` |
+| YAML | `.yaml`, `.yml` | `lang-yaml` (tree-sitter; regex fallback when disabled) |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ AeroDyn integration audit task on Claude Code against [OpenFAST](https://github.
 
 ## Overview
 
-aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports Rust, Python, Go, Java, Kotlin, TypeScript, TSX, Fortran, JavaScript, C/C++, and C#, and integrates with any MCP-compatible orchestrator.
+aptu-coder is a Model Context Protocol server that gives AI agents precise structural context about a codebase: directory trees, symbol definitions, and call graphs, without reading raw files. It supports Rust, Python, Go, Java, Kotlin, TypeScript, TSX, Fortran, JavaScript, C/C++, C#, Markdown, HTML, CSS, YAML, Astro, JSON, and TOML, and integrates with any MCP-compatible orchestrator.
 
 ## Supported Languages
 
@@ -167,8 +167,6 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `summary` | boolean | auto | Compact output; auto-triggers above 50K chars |
 | `cursor` | string | -- | Pagination cursor from a previous response's `next_cursor` |
 | `page_size` | integer | 100 | Items per page |
-| `force` | boolean | false | Bypass output size warning |
-| `verbose` | boolean | false | Full output with section headers and imports |
 
 | Tool | Purpose | Languages |
 |------|---------|-----------|
@@ -177,8 +175,8 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`); returns graceful fallback (empty index with note) for unsupported extensions | all |
 | `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |
-| `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches | all |
-| `exec_command` | Run a shell command; returns stdout, stderr, and exit code; supports progress notifications; output capped and filtered automatically | any |
+| `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches; pass empty `new_text` to delete the matched block; CRLF line endings in `old_text` are normalized to LF before matching | all |
+| `exec_command` | Run a shell command; returns stdout, stderr, and exit code; supports progress notifications; output capped and filtered automatically; optional `timeout_secs` kills the child on expiry (`timed_out: true` in response); heredoc syntax with a missing closing delimiter is rejected before spawn | any |
 
 Tool parameters, constraints, and examples are available via your MCP client's tool inspector or `tools/list` response.
 
@@ -243,11 +241,13 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | Variable | Default | Description |
 |---|---|---|
 | `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | LRU cache size for directory-analysis results. |
-| `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
+| `APTU_CODER_DISK_CACHE_DIR` | `$XDG_DATA_HOME/aptu-coder/analysis-cache` | Directory for the L2 on-disk call-graph cache used by `analyze_symbol`. |
+| `APTU_CODER_DISK_CACHE_DISABLED` | unset | Set to `1` to disable the L2 disk cache entirely. |
 | `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | LRU cache size for `exec_command` results. |
 | `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result cache. |
 | `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export on shutdown. |
+| `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
 | `APTU_CODER_PROFILE` | unset | Tool subset: `edit` (edit tools + `exec_command` only), `analyze` (analyze tools + `exec_command` only). Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
 | `APTU_SHELL` | unset | Shell for `exec_command`. Defaults to `bash` then `/bin/sh`. |
 

--- a/crates/aptu-coder-core/README.md
+++ b/crates/aptu-coder-core/README.md
@@ -77,8 +77,8 @@ For any other extension, `analyze_file` returns a graceful fallback (line count 
 use aptu_coder_core::AnalysisConfig;
 
 let config = AnalysisConfig {
-    max_file_bytes: Some(1_000_000), // reserved, currently a no-op
-    parse_timeout_micros: None,      // parse timeout in microseconds; None disables timeout
+    max_file_bytes: None,            // skip files exceeding this size; None = no limit (reserved, currently a no-op)
+    parse_timeout_micros: Some(500_000), // kill parse after 500 ms; None = no timeout
     cache_capacity: None,            // use default LRU capacity
 };
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | **`aptu-coder-core`** | | |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
-| `cache` | `crates/aptu-coder-core/src/cache.rs` | LRU cache with mtime invalidation and lock_or_recover pattern |
+| `cache` | `crates/aptu-coder-core/src/cache.rs` | Two-tier caching: L1 in-memory LRU (`AnalysisCache`, `CallGraphCache`) with mtime invalidation and lock_or_recover pattern; L2 on-disk call-graph cache (`DiskCache`) keyed by canonical path + git HEAD SHA, configurable via `APTU_CODER_DISK_CACHE_DIR` and `APTU_CODER_DISK_CACHE_DISABLED` |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
 | `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all seven tools |
 | `graph` | `crates/aptu-coder-core/src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
@@ -149,7 +149,7 @@ Exported from `aptu_coder_core` as a public API for library consumers that hold 
 
 Two independent telemetry channels run in parallel; neither blocks tool execution.
 
-**JSONL metrics (always-on):** Every tool handler fires a `MetricEvent` into an unbounded Tokio channel at return. `MetricsWriter` drains the channel in a background task and appends to a daily-rotated JSONL file at `$XDG_DATA_HOME/aptu-coder/metrics/`. File retention is 30 days. `migrate_legacy_metrics_dir()` runs on startup to rename the old `code-analyze-mcp` directory to `aptu-coder` if the new path does not yet exist.
+**JSONL metrics (always-on):** Every tool handler fires a `MetricEvent` into an unbounded Tokio channel at return. `MetricsWriter` drains the channel in a background task and appends to a daily-rotated JSONL file at `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (no `/metrics/` subdirectory). File retention is 30 days. `migrate_legacy_metrics_dir()` runs on startup to rename the old `code-analyze-mcp` directory to `aptu-coder` if the new path does not yet exist.
 
 **OpenTelemetry (opt-in):** When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, `otel.rs` initializes three providers (trace, log, meter) via OTLP/HTTP with `BatchSpanProcessor` / `PeriodicReader` export. The `tracing-opentelemetry` bridge wires `#[instrument]` spans into the OTel trace provider. `opentelemetry-appender-tracing` forwards log events as OTel `LogRecord`s, injecting `trace_id` and `span_id`. When the env var is unset, noop providers are used with zero runtime overhead; noop span creation costs ~6.6 µs.
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -42,7 +42,8 @@ Each line in the JSONL file is one JSON object:
 | `seq` | `u32 \| null` | 0-indexed call sequence within session; incremented atomically when emitting each `MetricEvent` at handler return |
 | `cache_tier` | `string \| null` | Disk cache tier hit: `l1_memory` or `l2_disk`; `null` if not applicable |
 | `cache_write_failure` | `bool \| null` | `true` if cache write failed (dir, tempfile, write, or rename); `null` if not applicable |
-| `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable |
+| `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable or if the process was killed due to timeout |
+| `timed_out` | `bool` | `true` when the child process was killed because it exceeded `timeout_secs`; `false` otherwise. Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`). |
 | `output_truncated` | `bool \| null` | `true` if any truncation occurred (line cap, per-stream byte cap, or combined cap); `false` if the command completed without truncation; `null` for all non-`exec_command` tools and for `exec_command` calls emitted by older server versions |
 | `filter_applied` | `string \| null` | Name of the filter rule that matched and transformed the output (e.g., `"git pull"`, `"cargo build"`); `null` when no filter fired or for non-`exec_command` tools. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
 | `chars_threshold_breach` | `bool` | `true` when `output_chars > 30,000`; fires for the top ~0.33% of `exec_command` calls (p99.7 of 27,981 observed calls). Early-warning signal for responses approaching the per-stream byte-cap threshold (MAX_STDOUT_BYTES = 30,000). Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`); defaults to `false` on parse for backward compatibility. |
@@ -62,8 +63,14 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 | `session_id` | early | `null` |
 | `seq` | early | `null` |
 | `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
-| `chars_threshold_breach` | current | `false` (omitted from JSONL when false; safe to query with `// false`) |
-| `filter_applied` | current | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
+| `chars_threshold_breach` | v0.14.2 | `false` (omitted from JSONL when false; safe to query with `// false`) |
+| `filter_applied` | v0.14.2 | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
+| `cache_tier` | v0.18.x | `null` (omitted when null; `l1_memory` or `l2_disk` on a cache hit) |
+| `cache_write_failure` | v0.18.x | `null` (omitted when null; `true` only when an L2 disk write failed) |
+| `error_subtype` | v0.18.x | `null` (omitted when null; e.g. `not_found`, `ambiguous` for `edit_replace` errors) |
+| `language` | v0.20.x | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
+| `file_ext` | v0.20.x | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
+| `timed_out` | v0.20.1 | `false` (omitted from JSONL when false; set when child process was killed by `timeout_secs`) |
 
 The five jq one-liners in `AGENTS.md` do not reference `output_truncated` and are unaffected. To query truncation events across all retained JSONL files:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -166,6 +166,39 @@ Four PRs shipped together to make `exec_command` output safe for large contexts:
 
 ---
 
+### [Complete] Language expansion: Markdown, HTML, CSS, YAML, Astro, JSON, TOML (#1063--#1073)
+
+Added six new languages with varying extraction depth:
+
+- **#1066**: Markdown language support (`lang-markdown` feature; extracts headings as functions, links/images as imports).
+- **#1063, #1073**: CSS and YAML tree-sitter grammar support (`lang-css`, `lang-yaml`; full selector/rule extraction for CSS, key extraction for YAML). Regex fallback applies when the feature flag is disabled.
+- **#1069**: Regex-based extraction for Astro (TypeScript frontmatter), CSS, YAML, JSON (first-level key extraction), and TOML (section header extraction). Astro, JSON, and TOML are always-on regardless of feature flags.
+- **#1067, #1068**: Graceful fallback for unsupported extensions in `analyze_file` and `analyze_module`: returns file extension as language label plus a structured `unsupported: true` marker instead of an error.
+- **#1077**: `INVALID_PARAMS` references updated; `analyze_file` no longer rejects unsupported extensions -- it falls back gracefully.
+- **#1084**: Language table and supported-extension audit completed; all entries verified.
+
+### [Complete] Observability and schema extensions (v0.17--v0.20)
+
+Several incremental improvements to the metrics schema and runtime behavior:
+
+- **#1127, #1128**: `unsupported: Option<bool>` field added to `FileAnalysisOutput` and `ModuleInfo` structs. Set to `true` when a file extension has no AST handler. Tool descriptions reordered for clarity.
+- **#1129, #1130**: `force`, `verbose`, and `ast_recursion_limit` parameters removed from `analyze_file` and `analyze_symbol`. These were vestigial no-ops; removing them reduces schema noise and prevents agents from passing dead options.
+- **#1131**: Missing `no_cache_meta` on `analyze_symbol` pagination error responses fixed.
+- **#1132**: Stale-context circuit breaker added to `edit_replace`. After 5 consecutive `not_found` or `ambiguous` failures on the same (session_id, canonical_path) pair, the handler returns a directive error instructing the agent to re-read the file. The failure counter map is capped at 1024 entries to prevent unbounded growth.
+- **#1136**: Path validation fix: replaced ancestor-walk with parent-dir validation in the `require_exists=false` branch of `validate_path`.
+- **#1137**: CRLF line endings in `old_text` are now normalized to LF before matching in `edit_replace`. Prevents spurious `not_found` errors when editing files with Windows line endings.
+- **#1147, #1148, #1149**: L2 on-disk call-graph cache added to `analyze_symbol`. Cache is keyed by canonical path + git HEAD SHA. Configurable via `APTU_CODER_DISK_CACHE_DIR` (default: `$XDG_DATA_HOME/aptu-coder/analysis-cache`) and `APTU_CODER_DISK_CACHE_DISABLED=1`. `cache_tier: l1_memory | l2_disk` added to `MetricEvent`; `cache_write_failure` field tracks disk write failures.
+- **#1150, #1154**: `language` field added to JSONL `MetricEvent` schema. Populated for `analyze_file` and `analyze_module` calls with the human-readable language name (e.g., `"rust"`, `"python"`). Omitted from JSONL when null for backward compatibility.
+- **#1153**: `exec_command` now rejects heredoc syntax (`<<MARKER`) where the closing delimiter is absent before spawning the child process, returning `INVALID_PARAMS` with a diagnostic message.
+- **#1155**: `timeout_secs` parameter re-added to `exec_command` (was removed in #1122). When set to a positive integer, the child process is killed after that many seconds; `timed_out: true` is set in `ShellOutput` and `MetricEvent`; `exit_code` is null. A value of 0 or omitted means no limit.
+- **#1156**: `call_frequency` on `analyze_symbol` output is now filtered out when the `Functions` field is not in the projected fields set, reducing response size for callers that only request caller/callee lists.
+- **#1124**: Raw path interpolation removed from model-visible error messages (security fix).
+- **#1125**: `edit_replace` accepts empty `new_text` to delete the matched block. `max_depth` defaults to 3 when omitted. Login shell PATH snapshot on macOS now uses `$SHELL` first for correct profile sourcing.
+- **#1102**: JSON Schema `uint`/`uint64` formats replaced with draft-07 compliant `integer`.
+- **#1085, #1133**: `exec_command` tool description updated to prefer `working_dir` over `cd` and to frame the `cd` prohibition as a mechanical fact rather than a policy.
+
+---
+
 ## Direction (Tentative)
 
 Unimplemented and pertinent:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,22 +82,7 @@ Completes the Fortran language handler that was partially implemented:
 
 ## Benchmark-Driven Development
 
-Each Wave closes with a benchmark run validating the Wave's hypotheses.
-
-**Benchmark location:** `docs/benchmarks/vN/` (v3–v10, v12 present)
-
-**Scoring rubric (v12+):** 3 dimensions scored 0–3 each:
-- `structural_accuracy`
-- `cross_module_tracing`
-- `approach_quality`
-
-`quality_score = sum` (max 9)
-
-Earlier benchmarks (v3–v10) used a 4-dimension rubric including `tool_efficiency` (max 12). The `tool_efficiency` dimension was dropped in v12; see each benchmark's `methodology.md` for the rubric in effect at the time.
-
-**Evaluation protocol:** Blind scoring — scorer does not see condition labels during evaluation.
-
-**Statistical method:** Mann-Whitney U with Bonferroni correction; 15 pairwise tests at alpha = 0.05/15 = 0.0033.
+Each Wave closes with a benchmark run. Benchmarks live in `docs/benchmarks/vN/`. Scoring rubric (v12+): 3 dimensions × 0–3 = max 9 (`structural_accuracy`, `cross_module_tracing`, `approach_quality`). Earlier benchmarks (v3–v10) used a 4-dimension rubric including `tool_efficiency` (max 12). Blind scoring; Mann-Whitney U with Bonferroni correction. See [DESIGN-GUIDE.md](DESIGN-GUIDE.md) for methodology detail.
 
 ---
 
@@ -111,23 +96,7 @@ These models follow tool descriptions literally; they do not apply contextual re
 
 ## Shared Exclusion List
 
-The following directories are non-source and excluded from SUGGESTION footer logic (`src/formatter.rs`) and server instruction guidance (`src/lib.rs`). The constant is defined in `src/lib.rs`:
-
-```
-node_modules, vendor, .git, __pycache__, target, dist, build, .venv
-```
-
-This list is a single constant in the codebase:
-
-```rust
-// src/lib.rs
-pub(crate) const EXCLUDED_DIRS: &[&str] = &[
-    "node_modules", "vendor", ".git", "__pycache__",
-    "target", "dist", "build", ".venv",
-];
-```
-
-Do not duplicate this constant across modules. Both `#341` and `#342` reference `EXCLUDED_DIRS` from `src/lib.rs`.
+`EXCLUDED_DIRS` in `src/lib.rs` lists non-source directories skipped by SUGGESTION footer logic and server instruction guidance: `node_modules`, `vendor`, `.git`, `__pycache__`, `target`, `dist`, `build`, `.venv`. Do not duplicate this constant.
 
 ---
 
@@ -205,43 +174,8 @@ Unimplemented and pertinent:
 
 - MCP SEP adoption: #1487 (`trustedHint`), #1561 (`unsafeOutputHint`), #1913 (trust/sensitivity annotations), #1984 (governance annotations) -- open upstream; no action until specs stabilize. #1560 (`secretHint`) closed 2026-03-23; evaluate adoption once merged into spec.
 
-## Wave 9: Editing Tools [Complete, Partially Removed]
+## Wave 9: Editing Tools [Complete]
 
-Augmented aptu-coder with five tools in two phases: one read-only file-content tool (`analyze_raw`) and four mechanical code-editing tools (`edit_overwrite`, `edit_replace`, `edit_rename`, `edit_insert`). The existing analysis tools and composition API remain unchanged. This wave completed the read-analyze-write loop that the coder-build agent (#664, #665) required without introducing a second MCP server.
-
-Note: `edit_rename` and `edit_insert` were removed in issue #779 due to limited adoption and maintenance burden. The two remaining edit tools (`edit_overwrite`, `edit_replace`) continue to support the core write workflow.
-
-### Rationale
-
-Both a combined server and two separate servers inject into the same model context window. Token cost is identical. A single server with one MCP config entry, one binary, and one version pin is operationally simpler. Five editing tools keep the total tool count below the reliable SML selection ceiling (~10-12 tools).
-
-The `ToolRouter::merge()` / `Add` / `AddAssign` API (verified against rmcp 1.5.0 source) supports multi-group composition with no breaking changes from 1.1.0. Write tools are placed in a second `#[tool_router(router = write_router, vis = "pub")]` impl block and merged at construction.
-
-### Phase 1: Mechanical tools [Complete]
-
-Three tools with no tree-sitter dependency. These validated the BUILD agent workflow and established the write-path integration before adding AST complexity.
-
-- `analyze_raw(path, start_line?, end_line?)` -- "Raw file content with optional line range. Prefer start_line/end_line to limit tokens on large files; omit both for full content. Use analyze_file for structure, not content. Example queries: Read lines 10-40 of src/lib.rs; Show the full contents of config.toml." `read_only_hint=true`, `idempotent_hint=true`
-- `edit_overwrite(path, content)` -- "Create or overwrite a file at path with content. Creates parent directories if needed. Overwrites without confirmation; use edit_replace to replace a specific block instead of the whole file. Example queries: Write a new test file at tests/foo_test.rs; Overwrite src/config.rs with updated content." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
-- `edit_replace(path, old_text, new_text)` -- "Replace a unique exact text block in a file. Errors if old_text appears zero times or more than once -- fix by making old_text longer and more specific. Use edit_overwrite to replace the whole file. Example queries: Replace the error handling block in src/main.rs; Update the function signature in lib.rs." `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`
-
-Cache invalidation: `edit_overwrite` and `edit_replace` call `cache.invalidate_file(path)` after every write. mtime-based cache keys self-invalidate in the common case, but mtime granularity is 1 second on some filesystems (HFS+, some ext4 configurations); explicit invalidation prevents stale reads within the same second.
-
-### Phase 2: AST-backed tools [Removed in issue #779]
-
-Two tools that required `aptu-coder-core` (formerly `code-analyze-core`) capture data were implemented but later removed due to limited adoption and maintenance burden.
-
-- `edit_rename(path, old_name, new_name, kind?)` -- [REMOVED] AST-aware rename within a single file. Matched by node kind, not string -- identifiers in string literals and comments were excluded.
-- `edit_insert(path, symbol_name, position, content)` -- [REMOVED] Insert content immediately before or after a named AST node. Used start_byte/end_byte from the capture pipeline.
-
-### Annotation posture update
-
-Wave 9 write tools were the exception to the annotation freeze established in the Annotation Posture Policy section. Write tools (`edit_overwrite`, `edit_replace`) carry `read_only_hint=false`, `destructive_hint=true`, `idempotent_hint=false`. Read tools (all existing analysis tools) retain `read_only_hint=true`. The per-tool `#[tool(annotations(...))]` macro attribute in rmcp 1.5.0 is confirmed to support mixed postures within one server.
-
-Note: `read_only_hint` is a hint surfaced to MCP clients in `tools/list`; rmcp 1.5.0 has no per-tool access control enforcement.
-
-### SML validation requirement
-
-Per the Small-Model-First Constraint: the editing tools were evaluated against Haiku, Mistral-small-2603, and MiniMax-M2.5 before Sonnet in a Wave 9 benchmark. Tool descriptions followed literal-instruction style -- SML models follow tool descriptions literally.
+Added `edit_overwrite` and `edit_replace` to complete the read-analyze-write loop (#664, #665). `analyze_raw`, `edit_rename`, and `edit_insert` were removed in #779 due to limited adoption. Write tools carry `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`; `exec_command` additionally sets `openWorldHint=true`.
 
 


### PR DESCRIPTION
## Summary

Documentation sync for v0.20.1. Fixes stale references and adds coverage for features shipped since the last docs pass.

## Changes

### README.md
- Extended overview language list to all 18 supported languages (Markdown, HTML, CSS, YAML, Astro, JSON, TOML were missing)
- Removed `force` and `verbose` from the shared parameters table (both removed in #1129)
- Added `edit_replace` notes: empty `new_text` deletion, CRLF normalization
- Added `exec_command` notes: `timeout_secs`, `timed_out`, heredoc rejection before spawn
- Added `APTU_CODER_DISK_CACHE_DIR` and `APTU_CODER_DISK_CACHE_DISABLED` to the environment variables table (#1147)

### AGENTS.md
- Corrected `edit` profile tool count from 3 to 4 (analyze_directory, analyze_file, analyze_module, analyze_symbol)
- Removed stale `force, and verbose` from the `analyze_module` constraint line
- Added tool parameter bullets: `edit_replace` stale-context circuit breaker + CRLF normalization + empty `new_text`; `exec_command` `timeout_secs` + `timed_out` + heredoc rejection; `analyze_symbol` L2 disk cache env vars; `call_frequency` field projection filtering
- Expanded JSONL schema field list: added `language`, `file_ext`, `filter_applied`, `output_truncated`

### docs/OBSERVABILITY.md
- Added `timed_out` row to the schema table (was absent despite being in `MetricEvent`)
- Clarified `exit_code` null semantics when process killed by timeout
- Expanded backward compatibility table from 5 to 11 rows: added `cache_tier`, `cache_write_failure`, `error_subtype`, `language`, `file_ext`, `timed_out` with version and default-when-absent

### docs/ARCHITECTURE.md
- Fixed JSONL metrics path: `$XDG_DATA_HOME/aptu-coder/metrics/` (wrong) -> `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl`
- Updated cache module entry to describe the two-tier architecture (L1 in-memory LRU + L2 on-disk `DiskCache`) with env var names

### docs/ROADMAP.md
- Added `[Complete] Language expansion: Markdown, HTML, CSS, YAML, Astro, JSON, TOML (#1063--#1073)`
- Added `[Complete] Observability and schema extensions (v0.17--v0.20)` covering #1102, #1124, #1125, #1127--#1137, #1147--#1156

## Testing

Docs-only change. No code modified.
