### PR TITLE
fix(exec): bound drain_task in non-timeout path to prevent indefinite hang (#1162)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -48,6 +48,10 @@ pub(crate) const EDIT_STALE_THRESHOLD: u8 = 5;
 /// missed trip per session per path after an eviction cycle.
 pub(crate) const EDIT_FAILURE_MAP_CAP: usize = 1024;
 
+/// Default drain timeout for the no-timeout path: prevents indefinite hang when a login
+/// shell profile blocks (macOS).
+const DEFAULT_DRAIN_TIMEOUT_SECS: u64 = 30;
+
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct ExecCommandParams {
@@ -4168,8 +4172,33 @@ async fn run_with_timeout(
             }
         }
         _ => {
-            drain_task.await.ok();
-            post_exit.await
+            // Default drain timeout to prevent indefinite hang when no timeout_secs
+            // is provided (macOS login shell profile sourcing).
+            let drain_result = tokio::time::timeout(
+                std::time::Duration::from_secs(DEFAULT_DRAIN_TIMEOUT_SECS),
+                drain_task,
+            )
+            .await;
+
+            if drain_result.is_err() {
+                // Drain timed out: child is holding pipes open (e.g. login shell
+                // profile on macOS). Kill the child and abort the drain task so
+                // the receiver loop in exec_command does not hang on rx.recv().
+                drop(post_exit);
+                child.start_kill().ok();
+                drain_abort.abort();
+                let _ = child.wait().await;
+                ExecutionResult {
+                    exit_code: None,
+                    output_truncated: false,
+                    output_collection_error: Some(
+                        "drain timeout: child process held stdout/stderr open".to_string(),
+                    ),
+                    timed_out: false,
+                }
+            } else {
+                post_exit.await
+            }
         }
     }
 }

--- a/crates/aptu-coder/tests/exec_timeout.rs
+++ b/crates/aptu-coder/tests/exec_timeout.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use common::call_tool_raw;
+use std::time::Duration;
+
+/// Regression test: the no-timeout path (timeout_secs omitted or None) must
+/// not hang indefinitely when the child process holds stdout open (e.g. a
+/// macOS login shell profile that blocks).
+///
+/// The fix wraps drain_task with a 30-second timeout in the `_ =>` catch-all
+/// arm of `run_with_timeout`. When the drain timeout fires, the child is
+/// killed and the drain task aborted so the caller does not hang on rx.recv().
+///
+/// This test spawns a child that writes one line then sleeps (keeping stdout
+/// open), and asserts the call returns within 35 seconds.
+#[tokio::test]
+async fn test_exec_drain_bounded_when_pipe_held_open() {
+    let fut = async {
+        let resp = call_tool_raw(
+            "exec_command",
+            serde_json::json!({
+                "command": "sh -c 'printf \"line\\n\"; sleep 300'"
+            }),
+        )
+        .await;
+
+        // The call should return some result (the key invariant is that it
+        // returns at all within 35s, not that any particular field is set).
+        assert!(
+            !resp["result"]["isError"].as_bool().unwrap_or(false),
+            "expected no tool error from bounded drain: {resp}"
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(!text.is_empty(), "expected non-empty output text: {resp}");
+    };
+
+    tokio::time::timeout(Duration::from_secs(35), fut)
+        .await
+        .expect("drain did not complete within 35s: the no-timeout path may still hang");
+}


### PR DESCRIPTION
## Summary

The non-timeout path in run_with_timeout (the `_ =>` catch-all arm) awaits drain_task without any timeout, causing exec_command to hang indefinitely on macOS when a login shell profile blocks. The fix wraps drain_task with tokio::time::timeout(Duration::from_secs(DEFAULT_DRAIN_TIMEOUT_SECS), drain_task) using a new module-level const, and adds a regression integration test that spawns a process holding stdout open to verify the bounded return.

## Changes

crates/aptu-coder/src/lib.rs
crates/aptu-coder/tests/exec_timeout.rs

## Test plan

- [x] Tests pass (156 passed, 0 failed)
- [x] Linter clean (cargo clippy -- -D warnings)
- [x] Formatter clean (cargo fmt --check)
- [x] Deny checks clean (cargo deny check advisories licenses)
- [x] Security scan clean

Closes #1162
