### PR TITLE
docs(exec): sync README and tool description with v0.20.2 exec changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |
 | `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches; empty `new_text` deletes the block; CRLF normalized before matching | all |
-| `exec_command` | Run a shell command; returns stdout, stderr, exit code; output capped and filtered; optional `timeout_secs`; heredoc missing delimiter rejected before spawn | any |
+| `exec_command` | Run a shell command; returns stdout, stderr, exit code; output capped and filtered; optional `timeout_secs` (kill on expiry) and `drain_timeout_secs` (post-exit drain window); heredoc missing delimiter rejected before spawn | any |
 
 Tool parameters, constraints, and examples are available via your MCP client's tool inspector or `tools/list` response.
 
@@ -207,6 +207,8 @@ analyze_symbol path: /my/project symbol: my_function cursor: eyJvZmZzZXQiOjUwfQ=
 | combined `output_text` | 50,000 chars | Safety net after interleaving |
 
 The 30k stdout cap is data-driven: analysis of 27,981 observed `exec_command` calls shows only 0.33% exceed this limit. When any cap fires, `output_truncated: true` is set in the response and recorded in the JSONL metrics.
+
+`drain_timeout_secs` controls how long the server waits after the child exits for any background subprocess still holding the pipe open. Default is 500 ms (0 or omitted). Negative values return INVALID_PARAMS. When the drain window expires before the pipe closes, `output_truncated: true` is set.
 
 **exec_command output filters**
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3638,7 +3638,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "exec_command",
         title = "Exec Command",
-        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines; stdout at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write commands using relative paths only. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). Note: on macOS, login shell profile sourcing adds ~100-200ms latency per call. For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
+        description = "Execute shell command via sh -c (or $SHELL if set). Returns stdout, stderr, interleaved, exit_code, output_truncated. Output capped at 2000 lines and 50 KB per stream; stdout capped at 30 KB, stderr at 10 KB. Set working_dir to the target directory; write the command using relative paths only. Commands run inside working_dir; omit `cd`. Fails if working_dir does not exist or is not a directory. Pass stdin to pipe UTF-8 content into the process (max 1 MB). For file creation and edits, prefer the edit_* tools. Example queries: Run the test suite and capture output.",
         output_schema = schema_for_type::<ShellOutput>(),
         annotations(
             title = "Exec Command",


### PR DESCRIPTION
## Summary

Sync `README.md` and the `exec_command` tool description in `lib.rs` with the three exec-related commits landed after the v0.20.1 docs sync (`fb8a02e`):

- `fix(exec)`: bound drain_task in non-timeout path (#1162/#1164)
- `fix(exec)`: remove -l login shell on macOS, invert wait/drain order, add rx.close() (#1166)
- `feat(exec)`: add drain_timeout_secs to ExecCommandParams (#1165/#1167)

`AGENTS.md` already received the `drain_timeout_secs` bullet as part of #1167. No changes needed to `docs/` or `crates/aptu-coder-core/README.md`.

## Changes

**`README.md`**
- Tool table: added `drain_timeout_secs` (post-exit drain window) alongside `timeout_secs` in the `exec_command` row
- Output caps section: added a prose paragraph explaining `drain_timeout_secs` semantics (default 500 ms, 0 or omitted; negative = INVALID_PARAMS; `output_truncated: true` on expiry)

**`crates/aptu-coder/src/lib.rs`**
- Removed the stale "Note: on macOS, login shell profile sourcing adds ~100-200ms latency per call" line from the `exec_command` tool description; the `-l` flag was removed in #1166 so the per-call overhead no longer exists
- Aligned output cap wording with README ("50 KB per stream") and added the `omit 'cd'` hint already present in other documentation

Closes #1168
