### PR TITLE
chore(release): v0.20.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.2"
+version = "0.20.3"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version from 0.20.2 to 0.20.3.

Closes no issue -- version bump only.
