### PR TITLE
fix(filters): tighten maybe_inject_no_stat word-boundary check (#1171)

### DIFF
--- a/crates/aptu-coder/src/filters.rs
+++ b/crates/aptu-coder/src/filters.rs
@@ -287,8 +287,8 @@ pub(crate) fn load_filter_table(cwd: &Path) -> Vec<CompiledRule> {
 
 /// Inject --no-stat flag for git pull if not already present.
 pub(crate) fn maybe_inject_no_stat(command: &str) -> String {
-    if command.starts_with("git")
-        && command.contains("pull")
+    if command.starts_with("git ")
+        && command.split_whitespace().nth(1) == Some("pull")
         && !command.contains("--stat")
         && !command.contains("--no-stat")
         && !command.contains("--verbose")

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -6142,6 +6142,23 @@ mod tests {
     }
 
     #[test]
+    fn test_no_stat_word_boundary_cases() {
+        let cases: &[(&str, &str)] = &[
+            ("gitpull some-arg", "gitpull some-arg"),
+            ("git log upstream/pull/123", "git log upstream/pull/123"),
+            (
+                "git pull origin main --rebase",
+                "git pull origin main --rebase --no-stat",
+            ),
+            ("git pull --no-stat", "git pull --no-stat"),
+            ("git log --stat", "git log --stat"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(maybe_inject_no_stat(input), *expected, "input: {input}");
+        }
+    }
+
+    #[test]
     fn test_filter_applied_field_present() {
         // Test apply_filter() end-to-end and verify filter_applied field is set correctly
         let rule = types::FilterRule {


### PR DESCRIPTION
## Summary

Fixes two confirmed false positives in `maybe_inject_no_stat` (`filters.rs:290-291`).

**False positive 1 -- non-git binary:** `"gitpull some-arg"` matched `starts_with("git")`, causing `--no-stat` to be appended to an unrelated binary.

**False positive 2 -- git log with PR ref:** `"git log upstream/pull/123"` matched `contains("pull")` via the path component, silently suppressing the diffstat.

## Changes

- `crates/aptu-coder/src/filters.rs`: two-line fix
  - `starts_with("git")` -> `starts_with("git ")` (word boundary via trailing space)
  - `contains("pull")` -> `command.split_whitespace().nth(1) == Some("pull")` (token-level check)
- `crates/aptu-coder/src/lib.rs`: single parameterized test `test_no_stat_word_boundary_cases` covering all 5 behaviors

## Tests

All tests pass. `test_no_stat_word_boundary_cases` covers:
- `"gitpull some-arg"` -- must NOT inject
- `"git log upstream/pull/123"` -- must NOT inject
- `"git pull origin main --rebase"` -- must still inject
- `"git pull --no-stat"` -- must pass through
- `"git log --stat"` -- must NOT inject

Closes #1171
