### PR TITLE
chore(exec): fix SIZE_LIMIT comment, add heredoc metrics, record injected command on span (#1172)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -811,25 +811,16 @@ impl CodeAnalyzer {
                                 failures,
                                 "L2 disk cache write failed"
                             );
-                            metrics_tx.send(crate::metrics::MetricEvent {
-                                ts: crate::metrics::unix_ms(),
-                                tool: "analyze_directory",
-                                duration_ms: 0,
-                                output_chars: 0,
-                                param_path_depth: 0,
-                                max_depth: None,
-                                result: "ok",
-                                error_type: None,
-                                session_id: sid,
-                                seq: None,
-                                cache_hit: None,
-                                cache_write_failure: Some(true),
-                                cache_tier: None,
-                                exit_code: None,
-                                timed_out: false,
-                                output_truncated: None,
-                                ..Default::default()
-                            });
+                            metrics_tx.send(
+                                crate::metrics::MetricEventBuilder::new(
+                                    "analyze_directory",
+                                    "ok",
+                                    0,
+                                )
+                                .session_id(sid)
+                                .cache_write_failure(Some(true))
+                                .build(),
+                            );
                         }
                     });
                 }
@@ -924,25 +915,12 @@ impl CodeAnalyzer {
                                 failures,
                                 "L2 disk cache write failed"
                             );
-                            metrics_tx.send(crate::metrics::MetricEvent {
-                                ts: crate::metrics::unix_ms(),
-                                tool: "analyze_file",
-                                duration_ms: 0,
-                                output_chars: 0,
-                                param_path_depth: 0,
-                                max_depth: None,
-                                result: "ok",
-                                error_type: None,
-                                session_id: sid,
-                                seq: None,
-                                cache_hit: None,
-                                cache_write_failure: Some(true),
-                                cache_tier: None,
-                                exit_code: None,
-                                timed_out: false,
-                                output_truncated: None,
-                                ..Default::default()
-                            });
+                            metrics_tx.send(
+                                crate::metrics::MetricEventBuilder::new("analyze_file", "ok", 0)
+                                    .session_id(sid)
+                                    .cache_write_failure(Some(true))
+                                    .build(),
+                            );
                         }
                     });
                 }
@@ -1453,25 +1431,12 @@ impl CodeAnalyzer {
                         failures,
                         "L2 disk cache write failed"
                     );
-                    metrics_tx.send(crate::metrics::MetricEvent {
-                        ts: crate::metrics::unix_ms(),
-                        tool: "analyze_symbol",
-                        duration_ms: 0,
-                        output_chars: 0,
-                        param_path_depth: 0,
-                        max_depth: None,
-                        result: "ok",
-                        error_type: None,
-                        session_id: sid,
-                        seq: None,
-                        cache_hit: None,
-                        cache_write_failure: Some(true),
-                        cache_tier: None,
-                        exit_code: None,
-                        timed_out: false,
-                        output_truncated: None,
-                        ..Default::default()
-                    });
+                    metrics_tx.send(
+                        crate::metrics::MetricEventBuilder::new("analyze_symbol", "ok", 0)
+                            .session_id(sid)
+                            .cache_write_failure(Some(true))
+                            .build(),
+                    );
                 }
             });
         }
@@ -1676,25 +1641,17 @@ impl CodeAnalyzer {
         let structured = serde_json::to_value(&output).unwrap_or(Value::Null);
         result.structured_content = Some(structured);
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "analyze_directory",
-            duration_ms: dur,
-            output_chars: final_text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: max_depth_val,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: Some(dir_cache_hit != CacheTier::Miss),
-            cache_write_failure: None,
-            cache_tier: Some(dir_cache_hit.as_str()),
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("analyze_directory", "ok", dur)
+                .output_chars(final_text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .max_depth(max_depth_val)
+                .session_id(sid)
+                .seq(Some(seq))
+                .cache_hit(Some(dir_cache_hit != CacheTier::Miss))
+                .cache_tier(Some(dir_cache_hit.as_str()))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -1796,27 +1753,16 @@ impl CodeAnalyzer {
                     rmcp::model::ErrorCode::INTERNAL_ERROR => Some("internal_error".to_string()),
                     _ => None,
                 };
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "analyze_file",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type,
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    file_ext: crate::metrics::path_file_ext(&param_path),
-                    language: crate::metrics::path_language(&param_path),
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("analyze_file", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(error_type)
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .file_ext(crate::metrics::path_file_ext(&param_path))
+                        .language(crate::metrics::path_language(&param_path))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(e));
             }
         };
@@ -1971,27 +1917,18 @@ impl CodeAnalyzer {
         let structured = serde_json::to_value(&response_output).unwrap_or(Value::Null);
         result.structured_content = Some(structured);
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "analyze_file",
-            duration_ms: dur,
-            output_chars: final_text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: None,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: Some(file_cache_hit != CacheTier::Miss),
-            cache_write_failure: None,
-            cache_tier: Some(file_cache_hit.as_str()),
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            file_ext: crate::metrics::path_file_ext(&param_path),
-            language: crate::metrics::path_language(&param_path),
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("analyze_file", "ok", dur)
+                .output_chars(final_text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .session_id(sid)
+                .seq(Some(seq))
+                .cache_hit(Some(file_cache_hit != CacheTier::Miss))
+                .cache_tier(Some(file_cache_hit.as_str()))
+                .file_ext(crate::metrics::path_file_ext(&param_path))
+                .language(crate::metrics::path_language(&param_path))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -2184,25 +2121,17 @@ impl CodeAnalyzer {
             let structured = serde_json::to_value(&output).unwrap_or(Value::Null);
             result.structured_content = Some(structured);
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "analyze_symbol",
-                duration_ms: dur,
-                output_chars: final_text.len(),
-                param_path_depth: crate::metrics::path_component_count(&param_path),
-                max_depth: max_depth_val,
-                result: "ok",
-                error_type: None,
-                session_id: sid,
-                seq: Some(seq),
-                cache_hit: Some(false),
-                cache_tier: Some(CacheTier::Miss.as_str()),
-                cache_write_failure: None,
-                exit_code: None,
-                timed_out: false,
-                output_truncated: None,
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("analyze_symbol", "ok", dur)
+                    .output_chars(final_text.len())
+                    .param_path_depth(crate::metrics::path_component_count(&param_path))
+                    .max_depth(max_depth_val)
+                    .session_id(sid)
+                    .seq(Some(seq))
+                    .cache_hit(Some(false))
+                    .cache_tier(Some(CacheTier::Miss.as_str()))
+                    .build(),
+            );
             return Ok(result);
         }
 
@@ -2434,25 +2363,17 @@ impl CodeAnalyzer {
         let structured = serde_json::to_value(&output).unwrap_or(Value::Null);
         result.structured_content = Some(structured);
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "analyze_symbol",
-            duration_ms: dur,
-            output_chars: final_text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: max_depth_val,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: Some(graph_cache_tier != CacheTier::Miss),
-            cache_tier: Some(graph_cache_tier.as_str()),
-            cache_write_failure: None,
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("analyze_symbol", "ok", dur)
+                .output_chars(final_text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .max_depth(max_depth_val)
+                .session_id(sid)
+                .seq(Some(seq))
+                .cache_hit(Some(graph_cache_tier != CacheTier::Miss))
+                .cache_tier(Some(graph_cache_tier.as_str()))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -2513,25 +2434,14 @@ impl CodeAnalyzer {
             span.record("error", true);
             span.record("error.type", "invalid_params");
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "analyze_module",
-                duration_ms: dur,
-                output_chars: 0,
-                param_path_depth: crate::metrics::path_component_count(&param_path),
-                max_depth: None,
-                result: "error",
-                error_type: Some("invalid_params".to_string()),
-                session_id: sid.clone(),
-                seq: Some(seq),
-                cache_hit: None,
-                cache_write_failure: None,
-                cache_tier: None,
-                exit_code: None,
-                timed_out: false,
-                output_truncated: None,
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("analyze_module", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(&param_path))
+                    .error_type(Some("invalid_params".to_string()))
+                    .session_id(sid.clone())
+                    .seq(Some(seq))
+                    .build(),
+            );
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 "path is a directory; use analyze_directory for directories, or pass a file path to analyze_module",
@@ -2554,27 +2464,16 @@ impl CodeAnalyzer {
             Ok(b) => b,
             Err(_e) => {
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "analyze_module",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    file_ext: crate::metrics::path_file_ext(&param_path),
-                    language: crate::metrics::path_language(&param_path),
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("analyze_module", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .file_ext(crate::metrics::path_file_ext(&param_path))
+                        .language(crate::metrics::path_language(&param_path))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     "failed to read file; check file path and permissions",
@@ -2622,27 +2521,15 @@ impl CodeAnalyzer {
                             .and_then(|x| x.to_str())
                             .unwrap_or("unknown")
                             .to_string();
-                        self.metrics_tx.send(crate::metrics::MetricEvent {
-                            ts: crate::metrics::unix_ms(),
-                            tool: "analyze_module",
-                            duration_ms: dur,
-                            output_chars: 0,
-                            param_path_depth: crate::metrics::path_component_count(&param_path),
-                            max_depth: None,
-                            result: "ok",
-                            error_type: None,
-                            session_id: sid.clone(),
-                            seq: Some(seq),
-                            cache_hit: None,
-                            cache_write_failure: None,
-                            cache_tier: None,
-                            exit_code: None,
-                            timed_out: false,
-                            output_truncated: None,
-                            file_ext: crate::metrics::path_file_ext(&param_path),
-                            language: crate::metrics::path_language(&param_path),
-                            ..Default::default()
-                        });
+                        self.metrics_tx.send(
+                            crate::metrics::MetricEventBuilder::new("analyze_module", "ok", dur)
+                                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                                .session_id(sid.clone())
+                                .seq(Some(seq))
+                                .file_ext(crate::metrics::path_file_ext(&param_path))
+                                .language(crate::metrics::path_language(&param_path))
+                                .build(),
+                        );
                         return {
                             let mut mi =
                                 types::ModuleInfo::new(name, line_count, ext, vec![], vec![]);
@@ -2677,27 +2564,16 @@ impl CodeAnalyzer {
                             Some(error_meta("internal", false, "report this as a bug")),
                         ),
                     );
-                    self.metrics_tx.send(crate::metrics::MetricEvent {
-                        ts: crate::metrics::unix_ms(),
-                        tool: "analyze_module",
-                        duration_ms: dur,
-                        output_chars: 0,
-                        param_path_depth: crate::metrics::path_component_count(&param_path),
-                        max_depth: None,
-                        result: "error",
-                        error_type,
-                        session_id: sid.clone(),
-                        seq: Some(seq),
-                        cache_hit: None,
-                        cache_write_failure: None,
-                        cache_tier: None,
-                        exit_code: None,
-                        timed_out: false,
-                        output_truncated: None,
-                        file_ext: crate::metrics::path_file_ext(&param_path),
-                        language: crate::metrics::path_language(&param_path),
-                        ..Default::default()
-                    });
+                    self.metrics_tx.send(
+                        crate::metrics::MetricEventBuilder::new("analyze_module", "error", dur)
+                            .param_path_depth(crate::metrics::path_component_count(&param_path))
+                            .error_type(error_type)
+                            .session_id(sid.clone())
+                            .seq(Some(seq))
+                            .file_ext(crate::metrics::path_file_ext(&param_path))
+                            .language(crate::metrics::path_language(&param_path))
+                            .build(),
+                    );
                     return Ok(err_to_tool_result(error_data));
                 }
             };
@@ -2721,25 +2597,12 @@ impl CodeAnalyzer {
                             failures,
                             "L2 disk cache write failed"
                         );
-                        metrics_tx2.send(crate::metrics::MetricEvent {
-                            ts: crate::metrics::unix_ms(),
-                            tool: "analyze_module",
-                            duration_ms: 0,
-                            output_chars: 0,
-                            param_path_depth: 0,
-                            max_depth: None,
-                            result: "ok",
-                            error_type: None,
-                            session_id: sid2,
-                            seq: None,
-                            cache_hit: None,
-                            cache_write_failure: Some(true),
-                            cache_tier: None,
-                            exit_code: None,
-                            timed_out: false,
-                            output_truncated: None,
-                            ..Default::default()
-                        });
+                        metrics_tx2.send(
+                            crate::metrics::MetricEventBuilder::new("analyze_module", "ok", 0)
+                                .session_id(sid2)
+                                .cache_write_failure(Some(true))
+                                .build(),
+                        );
                     }
                 });
             }
@@ -2773,27 +2636,18 @@ impl CodeAnalyzer {
         };
         result.structured_content = Some(structured);
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "analyze_module",
-            duration_ms: dur,
-            output_chars: text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: None,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: Some(module_tier != CacheTier::Miss),
-            cache_tier: Some(module_tier.as_str()),
-            cache_write_failure: None,
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            file_ext: crate::metrics::path_file_ext(&param_path),
-            language: crate::metrics::path_language(&param_path),
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("analyze_module", "ok", dur)
+                .output_chars(text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .session_id(sid)
+                .seq(Some(seq))
+                .cache_hit(Some(module_tier != CacheTier::Miss))
+                .cache_tier(Some(module_tier.as_str()))
+                .file_ext(crate::metrics::path_file_ext(&param_path))
+                .language(crate::metrics::path_language(&param_path))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -2873,25 +2727,14 @@ impl CodeAnalyzer {
             span.record("error", true);
             span.record("error.type", "invalid_params");
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "edit_overwrite",
-                duration_ms: dur,
-                output_chars: 0,
-                param_path_depth: crate::metrics::path_component_count(&param_path),
-                max_depth: None,
-                result: "error",
-                error_type: Some("invalid_params".to_string()),
-                session_id: sid.clone(),
-                seq: Some(seq),
-                cache_hit: None,
-                cache_write_failure: None,
-                cache_tier: None,
-                exit_code: None,
-                timed_out: false,
-                output_truncated: None,
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("edit_overwrite", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(&param_path))
+                    .error_type(Some("invalid_params".to_string()))
+                    .session_id(sid.clone())
+                    .seq(Some(seq))
+                    .build(),
+            );
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 "path is a directory; cannot write to a directory".to_string(),
@@ -2914,25 +2757,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_overwrite",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("invalid_params".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_overwrite", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("invalid_params".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     "path is a directory".to_string(),
@@ -2947,25 +2779,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_overwrite",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_overwrite", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     "I/O error writing file; check file path and permissions".to_string(),
@@ -2991,25 +2812,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_overwrite",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_overwrite", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     e.to_string(),
@@ -3024,25 +2834,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_overwrite",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_overwrite", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     e.to_string(),
@@ -3084,25 +2883,14 @@ impl CodeAnalyzer {
             counts.remove(&(sid_str, canonical));
         }
 
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "edit_overwrite",
-            duration_ms: dur,
-            output_chars: text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: None,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: None,
-            cache_write_failure: None,
-            cache_tier: None,
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("edit_overwrite", "ok", dur)
+                .output_chars(text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .session_id(sid)
+                .seq(Some(seq))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -3182,25 +2970,14 @@ impl CodeAnalyzer {
             span.record("error", true);
             span.record("error.type", "invalid_params");
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "edit_replace",
-                duration_ms: dur,
-                output_chars: 0,
-                param_path_depth: crate::metrics::path_component_count(&param_path),
-                max_depth: None,
-                result: "error",
-                error_type: Some("invalid_params".to_string()),
-                session_id: sid.clone(),
-                seq: Some(seq),
-                cache_hit: None,
-                cache_write_failure: None,
-                cache_tier: None,
-                exit_code: None,
-                timed_out: false,
-                output_truncated: None,
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(&param_path))
+                    .error_type(Some("invalid_params".to_string()))
+                    .session_id(sid.clone())
+                    .seq(Some(seq))
+                    .build(),
+            );
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
                 "path is a directory; cannot edit a directory".to_string(),
@@ -3246,26 +3023,15 @@ impl CodeAnalyzer {
                 let canonical = notfound_path.clone();
                 let tripped = increment_failure(&canonical);
                 if tripped {
-                    self.metrics_tx.send(crate::metrics::MetricEvent {
-                        ts: crate::metrics::unix_ms(),
-                        tool: "edit_replace",
-                        duration_ms: dur,
-                        output_chars: 0,
-                        param_path_depth: crate::metrics::path_component_count(&param_path),
-                        max_depth: None,
-                        result: "error",
-                        error_type: Some("invalid_params".to_string()),
-                        error_subtype: Some("stale_context".to_string()),
-                        session_id: sid.clone(),
-                        seq: Some(seq),
-                        cache_hit: None,
-                        cache_write_failure: None,
-                        cache_tier: None,
-                        exit_code: None,
-                        timed_out: false,
-                        output_truncated: None,
-                        ..Default::default()
-                    });
+                    self.metrics_tx.send(
+                        crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                            .param_path_depth(crate::metrics::path_component_count(&param_path))
+                            .error_type(Some("invalid_params".to_string()))
+                            .error_subtype(Some("stale_context".to_string()))
+                            .session_id(sid.clone())
+                            .seq(Some(seq))
+                            .build(),
+                    );
                     return Ok(err_to_tool_result(ErrorData::new(
                         rmcp::model::ErrorCode::INVALID_PARAMS,
                         format!(
@@ -3280,26 +3046,15 @@ impl CodeAnalyzer {
                     )));
                 }
 
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("invalid_params".to_string()),
-                    error_subtype: Some("not_found".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("invalid_params".to_string()))
+                        .error_subtype(Some("not_found".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
 
                 let message = if first_20_lines.is_empty() {
                     "old_text not found (0 matches). Re-read the file with analyze_file or analyze_module to obtain the current content, then derive old_text from the live file before retrying."
@@ -3363,26 +3118,15 @@ impl CodeAnalyzer {
                 let canonical = ambiguous_path.clone();
                 let tripped = increment_failure(&canonical);
                 if tripped {
-                    self.metrics_tx.send(crate::metrics::MetricEvent {
-                        ts: crate::metrics::unix_ms(),
-                        tool: "edit_replace",
-                        duration_ms: dur,
-                        output_chars: 0,
-                        param_path_depth: crate::metrics::path_component_count(&param_path),
-                        max_depth: None,
-                        result: "error",
-                        error_type: Some("invalid_params".to_string()),
-                        error_subtype: Some("stale_context".to_string()),
-                        session_id: sid.clone(),
-                        seq: Some(seq),
-                        cache_hit: None,
-                        cache_write_failure: None,
-                        cache_tier: None,
-                        exit_code: None,
-                        timed_out: false,
-                        output_truncated: None,
-                        ..Default::default()
-                    });
+                    self.metrics_tx.send(
+                        crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                            .param_path_depth(crate::metrics::path_component_count(&param_path))
+                            .error_type(Some("invalid_params".to_string()))
+                            .error_subtype(Some("stale_context".to_string()))
+                            .session_id(sid.clone())
+                            .seq(Some(seq))
+                            .build(),
+                    );
                     return Ok(err_to_tool_result(ErrorData::new(
                         rmcp::model::ErrorCode::INVALID_PARAMS,
                         format!(
@@ -3397,26 +3141,15 @@ impl CodeAnalyzer {
                     )));
                 }
 
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("invalid_params".to_string()),
-                    error_subtype: Some("ambiguous".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("invalid_params".to_string()))
+                        .error_subtype(Some("ambiguous".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
 
                 let line_numbers_csv = match_lines
                     .iter()
@@ -3445,25 +3178,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "invalid_params");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("invalid_params".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("invalid_params".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INVALID_PARAMS,
                     "path is a directory".to_string(),
@@ -3478,25 +3200,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     "I/O error editing file; check file path and permissions".to_string(),
@@ -3522,25 +3233,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     e.to_string(),
@@ -3555,25 +3255,14 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "edit_replace",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(&param_path),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code: None,
-                    timed_out: false,
-                    output_truncated: None,
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(&param_path))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(ErrorData::new(
                     rmcp::model::ErrorCode::INTERNAL_ERROR,
                     e.to_string(),
@@ -3618,25 +3307,14 @@ impl CodeAnalyzer {
             counts.remove(&(sid_str, canonical));
         }
 
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "edit_replace",
-            duration_ms: dur,
-            output_chars: text.len(),
-            param_path_depth: crate::metrics::path_component_count(&param_path),
-            max_depth: None,
-            result: "ok",
-            error_type: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: None,
-            cache_write_failure: None,
-            cache_tier: None,
-            exit_code: None,
-            timed_out: false,
-            output_truncated: None,
-            ..Default::default()
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("edit_replace", "ok", dur)
+                .output_chars(text.len())
+                .param_path_depth(crate::metrics::path_component_count(&param_path))
+                .session_id(sid)
+                .seq(Some(seq))
+                .build(),
+        );
         Ok(result)
     }
 
@@ -3817,27 +3495,17 @@ impl CodeAnalyzer {
             span.record("error", true);
             span.record("error.type", "invalid_params");
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "exec_command",
-                duration_ms: dur,
-                output_chars: 0,
-                param_path_depth: crate::metrics::path_component_count(
-                    param_path.as_deref().unwrap_or(""),
-                ),
-                max_depth: None,
-                result: "error",
-                error_type: Some("invalid_params".to_string()),
-                session_id: sid,
-                seq: Some(seq),
-                cache_hit: None,
-                cache_write_failure: None,
-                cache_tier: None,
-                exit_code: None,
-                timed_out: false,
-                output_truncated: Some(false),
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("exec_command", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(
+                        param_path.as_deref().unwrap_or(""),
+                    ))
+                    .error_type(Some("invalid_params".to_string()))
+                    .session_id(sid)
+                    .seq(Some(seq))
+                    .output_truncated(Some(false))
+                    .build(),
+            );
             return Ok(err_to_tool_result(e));
         }
 
@@ -3891,27 +3559,18 @@ impl CodeAnalyzer {
                 "timeout_secs": params.timeout_secs,
             }));
             let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-            self.metrics_tx.send(crate::metrics::MetricEvent {
-                ts: crate::metrics::unix_ms(),
-                tool: "exec_command",
-                duration_ms: dur,
-                output_chars: 0,
-                param_path_depth: crate::metrics::path_component_count(
-                    param_path.as_deref().unwrap_or(""),
-                ),
-                max_depth: None,
-                result: "error",
-                error_type: Some("timeout".to_string()),
-                session_id: sid,
-                seq: Some(seq),
-                cache_hit: None,
-                cache_write_failure: None,
-                cache_tier: None,
-                exit_code: None,
-                timed_out: true,
-                output_truncated: Some(false),
-                ..Default::default()
-            });
+            self.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("exec_command", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(
+                        param_path.as_deref().unwrap_or(""),
+                    ))
+                    .error_type(Some("timeout".to_string()))
+                    .session_id(sid)
+                    .seq(Some(seq))
+                    .timed_out(true)
+                    .output_truncated(Some(false))
+                    .build(),
+            );
             return Ok(result);
         }
 
@@ -3992,58 +3651,40 @@ impl CodeAnalyzer {
                 span.record("error", true);
                 span.record("error.type", "internal_error");
                 let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-                self.metrics_tx.send(crate::metrics::MetricEvent {
-                    ts: crate::metrics::unix_ms(),
-                    tool: "exec_command",
-                    duration_ms: dur,
-                    output_chars: 0,
-                    param_path_depth: crate::metrics::path_component_count(
-                        param_path.as_deref().unwrap_or(""),
-                    ),
-                    max_depth: None,
-                    result: "error",
-                    error_type: Some("internal_error".to_string()),
-                    session_id: sid.clone(),
-                    seq: Some(seq),
-                    cache_hit: None,
-                    cache_write_failure: None,
-                    cache_tier: None,
-                    exit_code,
-                    timed_out: output.timed_out,
-                    output_truncated: Some(output_truncated),
-                    ..Default::default()
-                });
+                self.metrics_tx.send(
+                    crate::metrics::MetricEventBuilder::new("exec_command", "error", dur)
+                        .param_path_depth(crate::metrics::path_component_count(
+                            param_path.as_deref().unwrap_or(""),
+                        ))
+                        .error_type(Some("internal_error".to_string()))
+                        .session_id(sid.clone())
+                        .seq(Some(seq))
+                        .exit_code(exit_code)
+                        .timed_out(output.timed_out)
+                        .output_truncated(Some(output_truncated))
+                        .build(),
+                );
                 return Ok(err_to_tool_result(e));
             }
         };
 
         result.structured_content = Some(structured);
         let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            ts: crate::metrics::unix_ms(),
-            tool: "exec_command",
-            duration_ms: dur,
-            output_chars: text.len(),
-            param_path_depth: crate::metrics::path_component_count(
-                param_path.as_deref().unwrap_or(""),
-            ),
-            max_depth: None,
-            result: "ok",
-            error_type: None,
-            error_subtype: None,
-            session_id: sid,
-            seq: Some(seq),
-            cache_hit: None,
-            cache_write_failure: None,
-            cache_tier: None,
-            exit_code,
-            timed_out: output.timed_out,
-            output_truncated: Some(output_truncated),
-            language: None,
-            chars_threshold_breach: text.len() > 30_000,
-            file_ext: None,
-            filter_applied: output.filter_applied.clone(),
-        });
+        self.metrics_tx.send(
+            crate::metrics::MetricEventBuilder::new("exec_command", "ok", dur)
+                .output_chars(text.len())
+                .param_path_depth(crate::metrics::path_component_count(
+                    param_path.as_deref().unwrap_or(""),
+                ))
+                .session_id(sid)
+                .seq(Some(seq))
+                .exit_code(exit_code)
+                .timed_out(output.timed_out)
+                .output_truncated(Some(output_truncated))
+                .chars_threshold_breach(text.len() > 30_000)
+                .filter_applied(output.filter_applied.clone())
+                .build(),
+        );
         Ok(result)
     }
 }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -3793,6 +3793,9 @@ impl CodeAnalyzer {
         } else {
             (params.command.clone(), working_dir_path)
         };
+        // Inject --no-stat for git pull if not already present
+        let command = maybe_inject_no_stat(&command);
+        span.record("command", &command);
 
         let param_path = params.working_dir.clone();
 
@@ -3813,6 +3816,28 @@ impl CodeAnalyzer {
         if let Err(e) = validation::validate_heredocs(&command) {
             span.record("error", true);
             span.record("error.type", "invalid_params");
+            let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+            self.metrics_tx.send(crate::metrics::MetricEvent {
+                ts: crate::metrics::unix_ms(),
+                tool: "exec_command",
+                duration_ms: dur,
+                output_chars: 0,
+                param_path_depth: crate::metrics::path_component_count(
+                    param_path.as_deref().unwrap_or(""),
+                ),
+                max_depth: None,
+                result: "error",
+                error_type: Some("invalid_params".to_string()),
+                session_id: sid,
+                seq: Some(seq),
+                cache_hit: None,
+                cache_write_failure: None,
+                cache_tier: None,
+                exit_code: None,
+                timed_out: false,
+                output_truncated: Some(false),
+                ..Default::default()
+            });
             return Ok(err_to_tool_result(e));
         }
 
@@ -3911,10 +3936,10 @@ impl CodeAnalyzer {
             format!("Output:\n{}", output.interleaved)
         };
 
-        // Apply combined output size limit (SIZE_LIMIT = 50k chars). Per-stream caps
+        // Apply combined output size limit (SIZE_LIMIT = 5_000 bytes). Per-stream caps
         // (MAX_STDOUT_BYTES = 30k stdout, MAX_STDERR_BYTES = 10k stderr) already fired in
         // handle_output_persist; this is the safety net for the interleaved assembly which
-        // can still reach up to ~40k chars from per-stream content plus headers and formatting.
+        // can still reach up to ~40k bytes from per-stream content plus headers and formatting.
         let mut combined_truncated = false;
         let truncated_output_text = if output_text.len() > SIZE_LIMIT {
             combined_truncated = true;
@@ -4223,9 +4248,6 @@ async fn run_exec_impl(
     timeout_secs: Option<i64>,
     drain_timeout: std::time::Duration,
 ) -> ShellOutput {
-    // Inject --no-stat for git pull if not already present
-    let command = maybe_inject_no_stat(&command);
-
     let mut cmd = build_exec_command(
         &command,
         working_dir_path.as_ref(),

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -68,6 +68,136 @@ pub struct MetricEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
 }
+/// Fluent builder for MetricEvent. Reduces repetitive struct literal boilerplate.
+#[derive(Debug, Default)]
+pub(crate) struct MetricEventBuilder {
+    ts: u64,
+    tool: &'static str,
+    duration_ms: u64,
+    output_chars: usize,
+    param_path_depth: usize,
+    max_depth: Option<u32>,
+    result: &'static str,
+    error_type: Option<String>,
+    error_subtype: Option<String>,
+    session_id: Option<String>,
+    seq: Option<u32>,
+    cache_hit: Option<bool>,
+    cache_write_failure: Option<bool>,
+    cache_tier: Option<&'static str>,
+    exit_code: Option<i32>,
+    timed_out: bool,
+    output_truncated: Option<bool>,
+    chars_threshold_breach: bool,
+    file_ext: Option<&'static str>,
+    filter_applied: Option<String>,
+    language: Option<String>,
+}
+
+impl MetricEventBuilder {
+    pub fn new(tool: &'static str, result: &'static str, duration_ms: u64) -> Self {
+        Self {
+            ts: unix_ms(),
+            tool,
+            result,
+            duration_ms,
+            ..Self::default()
+        }
+    }
+    pub fn output_chars(mut self, v: usize) -> Self {
+        self.output_chars = v;
+        self
+    }
+    pub fn param_path_depth(mut self, v: usize) -> Self {
+        self.param_path_depth = v;
+        self
+    }
+    pub fn max_depth(mut self, v: Option<u32>) -> Self {
+        self.max_depth = v;
+        self
+    }
+    pub fn error_type(mut self, v: Option<String>) -> Self {
+        self.error_type = v;
+        self
+    }
+    pub fn error_subtype(mut self, v: Option<String>) -> Self {
+        self.error_subtype = v;
+        self
+    }
+    pub fn session_id(mut self, v: Option<String>) -> Self {
+        self.session_id = v;
+        self
+    }
+    pub fn seq(mut self, v: Option<u32>) -> Self {
+        self.seq = v;
+        self
+    }
+    pub fn cache_hit(mut self, v: Option<bool>) -> Self {
+        self.cache_hit = v;
+        self
+    }
+    pub fn cache_write_failure(mut self, v: Option<bool>) -> Self {
+        self.cache_write_failure = v;
+        self
+    }
+    pub fn cache_tier(mut self, v: Option<&'static str>) -> Self {
+        self.cache_tier = v;
+        self
+    }
+    pub fn exit_code(mut self, v: Option<i32>) -> Self {
+        self.exit_code = v;
+        self
+    }
+    pub fn timed_out(mut self, v: bool) -> Self {
+        self.timed_out = v;
+        self
+    }
+    pub fn output_truncated(mut self, v: Option<bool>) -> Self {
+        self.output_truncated = v;
+        self
+    }
+    pub fn chars_threshold_breach(mut self, v: bool) -> Self {
+        self.chars_threshold_breach = v;
+        self
+    }
+    pub fn file_ext(mut self, v: Option<&'static str>) -> Self {
+        self.file_ext = v;
+        self
+    }
+    pub fn filter_applied(mut self, v: Option<String>) -> Self {
+        self.filter_applied = v;
+        self
+    }
+    pub fn language(mut self, v: Option<String>) -> Self {
+        self.language = v;
+        self
+    }
+    pub fn build(self) -> MetricEvent {
+        MetricEvent {
+            ts: self.ts,
+            tool: self.tool,
+            duration_ms: self.duration_ms,
+            output_chars: self.output_chars,
+            param_path_depth: self.param_path_depth,
+            max_depth: self.max_depth,
+            result: self.result,
+            error_type: self.error_type,
+            error_subtype: self.error_subtype,
+            session_id: self.session_id,
+            seq: self.seq,
+            cache_hit: self.cache_hit,
+            cache_write_failure: self.cache_write_failure,
+            cache_tier: self.cache_tier,
+            exit_code: self.exit_code,
+            timed_out: self.timed_out,
+            output_truncated: self.output_truncated,
+            chars_threshold_breach: self.chars_threshold_breach,
+            file_ext: self.file_ext,
+            filter_applied: self.filter_applied,
+            language: self.language,
+        }
+    }
+}
 
 /// Sender half of the metrics channel; cloned and passed to tools for event emission.
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Two commits addressing `exec_command` correctness and metrics construction ergonomics.

### Commit 1: chore(exec): fix SIZE_LIMIT comment, add heredoc metrics, record injected command on span (#1172)

Three surgical fixes to `crates/aptu-coder/src/lib.rs`:

1. **Fix misleading SIZE_LIMIT comment** -- comment said "50k chars" but the constant is `5_000` and `.len()` returns bytes, not Unicode scalar count. Corrected to "5_000 bytes".
2. **Add MetricEvent on heredoc-rejection path** -- the `validate_heredocs` early-return emitted no metric, making validation failures invisible in JSONL metrics. Now emits `result="error"`, `error_type="invalid_params"` matching the timeout pattern.
3. **Record injected command on span** -- `maybe_inject_no_stat` was called inside `run_exec_impl`, after the tracing span had already recorded `params.command`. Moved the call into `exec_command` before `span.record("command", ...)` so the post-injection command appears in traces.

### Commit 2: refactor(metrics): add MetricEventBuilder to reduce MetricEvent construction boilerplate (#1179)

Adds a fluent `MetricEventBuilder` to `crates/aptu-coder/src/metrics.rs`:

- **Builder pattern** -- `MetricEventBuilder::new(tool, result, duration_ms)` followed by optional setters (`.session_id()`, `.cache_hit()`, `.exit_code()`, etc.) and `.build()` produces a `MetricEvent`.
- **Reduces boilerplate in lib.rs** -- replaces verbose struct literals across all seven tool handlers with chained builder calls; net -227 lines in `lib.rs`.
- **No behaviour change** -- `MetricEvent` schema and JSONL output are identical; only construction site syntax changes.

Closes #1172

## Changes

- `crates/aptu-coder/src/lib.rs` -- exec fixes + builder adoption across all tool handlers
- `crates/aptu-coder/src/metrics.rs` -- `MetricEventBuilder` struct and impl

## Test plan

- [ ] Tests pass
- [ ] Linter clean
- [ ] Security scan clean (no findings)
