### PR TITLE
refactor(exec): remove redundant child.wait() in no-timeout branch, add exit_code test (#1173)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -4184,14 +4184,14 @@ async fn run_with_timeout(
         _ => {
             // No user timeout: wait for child exit first, then drain buffered output
             // with a short grace period (drain_timeout) for background subprocesses.
-            child.wait().await.ok();
+            let exit_status = child.wait().await.ok();
             let drain_result = tokio::time::timeout(drain_timeout, drain_task).await;
 
             let drain_truncated = drain_result.is_err();
             if drain_truncated {
                 drain_abort.abort();
             }
-            let exit_code = child.wait().await.ok().and_then(|s| s.code());
+            let exit_code = exit_status.and_then(|s| s.code());
             let ocerr = if drain_truncated {
                 Some("post-exit drain timeout: background process held pipes".to_string())
             } else {

--- a/crates/aptu-coder/tests/exec_timeout.rs
+++ b/crates/aptu-coder/tests/exec_timeout.rs
@@ -6,6 +6,25 @@ mod common;
 use common::call_tool_raw;
 use std::time::Duration;
 
+/// No-timeout branch: "exit 1" must return exit_code == 1.
+#[tokio::test]
+async fn test_exec_exit_1_no_timeout() {
+    let fut = async {
+        let resp = call_tool_raw("exec_command", serde_json::json!({"command": "exit 1"})).await;
+
+        let sc = &resp["result"]["structuredContent"];
+        assert_eq!(
+            sc["exit_code"].as_i64(),
+            Some(1),
+            "expected exit_code=1 for 'exit 1': {sc}"
+        );
+    };
+
+    tokio::time::timeout(Duration::from_secs(10), fut)
+        .await
+        .expect("exec exit 1 test did not complete within 10s");
+}
+
 /// Regression test: the user-timeout path (timeout_secs = 30) must
 /// not hang indefinitely when the child process holds stdout open (e.g. a
 /// macOS login shell profile that blocks).

--- a/crates/aptu-coder/tests/exec_timeout.rs
+++ b/crates/aptu-coder/tests/exec_timeout.rs
@@ -6,25 +6,6 @@ mod common;
 use common::call_tool_raw;
 use std::time::Duration;
 
-/// No-timeout branch: "exit 1" must return exit_code == 1.
-#[tokio::test]
-async fn test_exec_exit_1_no_timeout() {
-    let fut = async {
-        let resp = call_tool_raw("exec_command", serde_json::json!({"command": "exit 1"})).await;
-
-        let sc = &resp["result"]["structuredContent"];
-        assert_eq!(
-            sc["exit_code"].as_i64(),
-            Some(1),
-            "expected exit_code=1 for 'exit 1': {sc}"
-        );
-    };
-
-    tokio::time::timeout(Duration::from_secs(10), fut)
-        .await
-        .expect("exec exit 1 test did not complete within 10s");
-}
-
 /// Regression test: the user-timeout path (timeout_secs = 30) must
 /// not hang indefinitely when the child process holds stdout open (e.g. a
 /// macOS login shell profile that blocks).


### PR DESCRIPTION
## Summary

Remove the redundant `child.wait()` call in the no-timeout branch of `run_with_timeout` in `crates/aptu-coder/src/lib.rs`.

### Background

tokio v1 guarantees that `Child::wait()` is idempotent after the first call (the exit status is cached in `FusedChild::Done`). The no-timeout branch was calling `child.wait()` twice: once to ensure the process is reaped, and again to extract the exit code. The second call was redundant and misleading.

### Changes

- **`crates/aptu-coder/src/lib.rs`**: Capture `exit_status` from the first `child.wait().await` in the no-timeout branch. Reuse `exit_status` for exit code extraction. Remove the second `child.wait()` call.
- **`crates/aptu-coder/tests/exec_timeout.rs`**: Remove `test_exec_exit_1_no_timeout` -- redundant; the no-timeout path is already covered by `test_timeout_not_fires_for_immediate_command_without_timeout_secs` and non-zero exit code propagation by `test_exec_exit_code_42` in `exec_command.rs`.

The `abort_handle` / `drain_abort` pattern and `unbounded_channel` are unchanged.

Closes #1173

## Test plan

- [ ] Tests pass
- [ ] Linter clean
- [ ] Security scan clean
