### PR TITLE
feat(metrics): add 'received' event at top of each tool handler, guard OTEL histogram (#1177)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -562,8 +562,11 @@ impl CodeAnalyzer {
     /// Emit a "received" metric event for the given tool name.
     /// Increments the session call sequence, locks the session ID, and sends
     /// the metric event via the channel. Returns the (seq, sid) pair for use
-    /// by the caller in exit metrics, preserving strict seq monotonicity.
+    /// by the caller in exit metrics, preserving per-call seq uniqueness.
     async fn emit_received_metric(&self, tool: &'static str) -> (u32, Option<String>) {
+        // Relaxed: per-session monotonic counter; unique allocation is all that is
+        // needed. No cross-thread happens-before required. Contrast:
+        // GLOBAL_SESSION_COUNTER uses SeqCst for cross-session uniqueness.
         let seq = self
             .session_call_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -1478,6 +1478,19 @@ impl CodeAnalyzer {
         let mut params = params.0;
         // Apply max_depth default: 3. Pass 0 for unlimited depth.
         params.max_depth = params.max_depth.or(Some(3));
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "analyze_directory",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -1504,7 +1517,6 @@ impl CodeAnalyzer {
             }
         };
         let ct = context.ct.clone();
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let max_depth_val = params.max_depth;
         let seq = self
@@ -1698,6 +1710,19 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "analyze_file",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -1723,7 +1748,6 @@ impl CodeAnalyzer {
                 return Ok(err_to_tool_result(e));
             }
         };
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
             .session_call_seq
@@ -1998,6 +2022,19 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "analyze_symbol",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2024,7 +2061,6 @@ impl CodeAnalyzer {
             }
         };
         let ct = context.ct.clone();
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let max_depth_val = params.follow_depth;
         let seq = self
@@ -2462,6 +2498,19 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "analyze_module",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2487,7 +2536,6 @@ impl CodeAnalyzer {
                 return Ok(err_to_tool_result(e));
             }
         };
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
             .session_call_seq
@@ -2806,6 +2854,19 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "edit_overwrite",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2850,7 +2911,6 @@ impl CodeAnalyzer {
                 }
             }
         };
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
             .session_call_seq
@@ -3118,6 +3178,19 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
+        let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "edit_replace",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -3162,7 +3235,6 @@ impl CodeAnalyzer {
                 }
             }
         };
-        let t_start = std::time::Instant::now();
         let param_path = params.path.clone();
         let seq = self
             .session_call_seq
@@ -3655,6 +3727,18 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let t_start = std::time::Instant::now();
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool: "exec_command",
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -559,6 +559,26 @@ impl CodeAnalyzer {
         }
     }
 
+    /// Emit a "received" metric event for the given tool name.
+    /// Increments the session call sequence, locks the session ID, and sends
+    /// the metric event via the channel. Returns the (seq, sid) pair for use
+    /// by the caller in exit metrics, preserving strict seq monotonicity.
+    async fn emit_received_metric(&self, tool: &'static str) -> (u32, Option<String>) {
+        let seq = self
+            .session_call_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let sid = self.session_id.lock().await.clone();
+        self.metrics_tx.send(crate::metrics::MetricEvent {
+            tool,
+            result: "received",
+            session_id: sid.clone(),
+            seq: Some(seq),
+            duration_ms: 0,
+            ..Default::default()
+        });
+        (seq, sid)
+    }
+
     /// Private helper: Extract analysis logic for overview mode (`analyze_directory`).
     /// Returns the complete analysis output and a cache_hit bool after spawning and monitoring progress.
     /// Cancels the blocking task when `ct` is triggered; returns an error on cancellation.
@@ -1479,18 +1499,7 @@ impl CodeAnalyzer {
         // Apply max_depth default: 3. Pass 0 for unlimited depth.
         params.max_depth = params.max_depth.or(Some(3));
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "analyze_directory",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("analyze_directory").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -1519,10 +1528,6 @@ impl CodeAnalyzer {
         let ct = context.ct.clone();
         let param_path = params.path.clone();
         let max_depth_val = params.max_depth;
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Call handler for analysis and progress tracking
         let progress_token = context.meta.get_progress_token();
@@ -1711,18 +1716,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "analyze_file",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("analyze_file").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -1749,10 +1743,6 @@ impl CodeAnalyzer {
             }
         };
         let param_path = params.path.clone();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Check if path is a directory (not allowed for analyze_file)
         if std::path::Path::new(&params.path).is_dir() {
@@ -2023,18 +2013,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "analyze_symbol",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("analyze_symbol").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2063,10 +2042,6 @@ impl CodeAnalyzer {
         let ct = context.ct.clone();
         let param_path = params.path.clone();
         let max_depth_val = params.follow_depth;
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Check if path is a file (not allowed for analyze_symbol)
         if std::path::Path::new(&params.path).is_file() {
@@ -2499,18 +2474,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "analyze_module",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("analyze_module").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2537,10 +2501,6 @@ impl CodeAnalyzer {
             }
         };
         let param_path = params.path.clone();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Issue 340: Guard against directory paths
         if std::fs::metadata(&params.path)
@@ -2855,18 +2815,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "edit_overwrite",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("edit_overwrite").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -2912,10 +2861,6 @@ impl CodeAnalyzer {
             }
         };
         let param_path = params.path.clone();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Guard against directory paths
         if std::fs::metadata(&resolved_path)
@@ -3179,18 +3124,7 @@ impl CodeAnalyzer {
     ) -> Result<CallToolResult, ErrorData> {
         let params = params.0;
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "edit_replace",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("edit_replace").await;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
         let client_name = self.client_name.lock().await.clone();
@@ -3236,10 +3170,6 @@ impl CodeAnalyzer {
             }
         };
         let param_path = params.path.clone();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Guard against directory paths
         if std::fs::metadata(&resolved_path)
@@ -3727,18 +3657,7 @@ impl CodeAnalyzer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let t_start = std::time::Instant::now();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
-        self.metrics_tx.send(crate::metrics::MetricEvent {
-            tool: "exec_command",
-            result: "received",
-            session_id: sid.clone(),
-            seq: Some(seq),
-            duration_ms: 0,
-            ..Default::default()
-        });
+        let (seq, sid) = self.emit_received_metric("exec_command").await;
         let params = params.0;
         // Extract W3C Trace Context from request _meta if present
         let session_id = self.session_id.lock().await.clone();
@@ -3873,10 +3792,6 @@ impl CodeAnalyzer {
         };
 
         let param_path = params.working_dir.clone();
-        let seq = self
-            .session_call_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let sid = self.session_id.lock().await.clone();
 
         // Validate stdin size cap (1 MB)
         if let Some(ref stdin_content) = params.stdin

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -1094,6 +1094,10 @@ mod tests {
 ///
 /// Instruments are initialized once via OnceLock to avoid rebuilding them on every call.
 fn record_otel_metrics(event: &MetricEvent) {
+    // Skip OTEL recording for "received" events (duration_ms=0 would pollute latency histograms)
+    if event.result == "received" {
+        return;
+    }
     use opentelemetry::metrics::{Counter, Histogram};
     use opentelemetry::{KeyValue, global};
     use std::sync::OnceLock;


### PR DESCRIPTION
## Summary

Add a `result="received"` `MetricEvent` at the very top of each of the seven tool handlers in `crates/aptu-coder/src/lib.rs`, before any validation or execution. Also add an early-return guard in `record_otel_metrics` in `crates/aptu-coder/src/metrics.rs` to prevent `duration_ms=0` events from polluting the latency histogram.

### Motivation

On 2026-06-22, three parallel sub-agent sessions each produced `-32603: request timeout after PT300S` from the MCP client, with zero JSONL metric entries for the failing `tool_call_id`s. This confirmed the failures occurred in the rmcp dispatch layer before any handler was entered. With `result="received"` in place, a single metrics lookup can definitively distinguish:

| `received` present? | `ok`/`error` present? | Meaning |
|---|---|---|
| No | No | Handler never entered -- rmcp dispatch or pipe layer |
| Yes | No | Handler entered but aborted (not possible with current code) |
| Yes | Yes | Handler completed normally |

### Changes

- **`crates/aptu-coder/src/lib.rs`**: For each of the 7 `#[tool]`-annotated handlers (`analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command`):
  - Move `let t_start = std::time::Instant::now()` to the absolute top of the handler body (before trace context and validation). `exec_command` already had `t_start` at the top.
  - Immediately after `t_start`, fetch `seq` and `sid`, then emit `MetricEvent { result: "received", duration_ms: 0, ..Default::default() }`.
- **`crates/aptu-coder/src/metrics.rs`**: Add `if event.result == "received" { return; }` guard at the top of `record_otel_metrics` to skip histogram recording for zero-duration events.

### No schema change

`result` is already a free-form `&'static str` field in `MetricEvent`. The `"received"` value requires no schema update.

Closes #1177

## Test plan

- `cargo test -p aptu-coder` -- 213 passed, 0 failed
- `cargo clippy -- -D warnings` -- clean
- `cargo fmt --check` -- clean
- `cargo deny check advisories licenses` -- clean