### PR TITLE
chore(release): v0.20.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.3"
+version = "0.20.4"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version to v0.20.4 and tag the release.

## What's Changed

### Bug Fixes

- **`filters`: tighten `maybe_inject_no_stat` word-boundary check** (#1178, closes #1171): Two confirmed false positives fixed. `"gitpull some-arg"` matched `starts_with("git")` and had `--no-stat` injected into an unrelated binary; fixed by requiring a trailing space (`"git "`). `"git log upstream/pull/123"` matched `contains("pull")` via the path component and had its diffstat silently suppressed; fixed by checking the second whitespace token rather than a substring.

### Features

- **`metrics`: `received` event at top of each tool handler, guard OTEL histogram** (#1181, closes #1177): Emits a zero-cost `result="received"` `MetricEvent` at the absolute top of all seven tool handlers, before validation or execution. This distinguishes rmcp dispatch failures (no `received` entry) from handler aborts (no `ok`/`error` entry). A guard in `record_otel_metrics` skips histogram recording for `duration_ms=0` events to prevent pollution.

### Maintenance

- **`exec`: remove redundant `child.wait()` in no-timeout branch, add exit_code test** (#1180, closes #1173): The no-timeout branch called `child.wait()` twice; the first call caches the exit status in `FusedChild::Done` so the second was redundant and misleading. Captured `exit_status` from the first await and reused it. Removed `test_exec_exit_1_no_timeout` (covered by existing tests in `exec_command.rs`).

- **`exec`: fix `SIZE_LIMIT` comment, add heredoc metrics, record injected command on span** (#1179, closes #1172): Corrected a stale `SIZE_LIMIT` comment, added JSONL metric emission for heredoc rejection events, and records the injected shell command on the active tracing span for better observability.

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.20.3...v0.20.4
