### PR TITLE
fix(exec): reject heredoc file-write patterns in validate_heredocs (#1194)

### DIFF
--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -6,23 +6,66 @@ use rmcp::model::ErrorData;
 
 use crate::error_meta;
 
-/// Scans a shell command string for unclosed heredocs before any process is spawned.
+/// Scans a shell command string for unclosed heredocs and file-write heredoc
+/// patterns before any process is spawned.
 ///
-/// Walks `command` char-by-char, tracking single-quoted and double-quoted regions
-/// (skip `<<` inside either to avoid false positives from awk bitshift, echo
-/// strings, etc.).  For each `<<` or `<<-` token found outside any quoted region,
-/// extracts the delimiter word (strips surrounding single-quotes, double-quotes, or
-/// backslashes to get the bare word) and searches the remainder of the string for
-/// its matching closer on its own line.  For `<<-`, leading tabs are stripped from
-/// each line when searching.
+/// Phase 1 pre-scan: walks the command byte-by-byte with quote tracking.  When a
+/// `<<` token is found outside any quoted region, it scans backward to check for
+/// file-write patterns (cat/tee/redirect + `<<`) and returns an error immediately
+/// if one is detected.
 ///
-/// Returns `Ok(())` if all heredocs are properly closed, or `Err(ErrorData)` with
-/// `INVALID_PARAMS` if any heredoc is missing its closing delimiter.
+/// Phase 2 main scan: continues the existing matching-closer scan (unchanged logic)
+/// with quote state reset to initial values between phases.
+///
+/// Returns `Ok(())` if no file-write patterns or unclosed heredocs are found,
+/// or `Err(ErrorData)` with `INVALID_PARAMS` otherwise.
 ///
 /// This function does NOT spawn any process; it is a pure string scan.
 pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     let bytes = command.as_bytes();
     let len = bytes.len();
+
+    // Phase 1: pre-scan for heredoc file-write patterns (cat/tee/redirect + <<)
+    {
+        let mut i = 0;
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+
+        while i < len {
+            let ch = bytes[i] as char;
+
+            if ch == '\'' && !in_double_quote {
+                in_single_quote = !in_single_quote;
+                i += 1;
+                continue;
+            }
+            if ch == '"' && !in_single_quote {
+                in_double_quote = !in_double_quote;
+                i += 1;
+                continue;
+            }
+            if in_single_quote || in_double_quote {
+                i += 1;
+                continue;
+            }
+
+            // Found `<<` outside quotes -- check for file-write pattern via
+            // backward scan from the first `<`.
+            if ch == '<' && i + 1 < len && bytes[i + 1] == b'<' {
+                if scan_backward_for_file_write(bytes, i) {
+                    return Err(file_write_heredoc_error());
+                }
+                // Skip past `<<` to avoid re-scanning the same token.
+                // Use a simple increment; the main scan loop below handles
+                // the full delimiter parsing.
+                i += 2;
+                continue;
+            }
+            i += 1;
+        }
+    }
+
+    // Phase 2: original heredoc delimiter scan (quote state is fresh)
     let mut i = 0;
     let mut in_single_quote = false;
     let mut in_double_quote = false;
@@ -168,6 +211,100 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     }
 
     Ok(())
+}
+
+fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
+    /// Checks whether the token before `pos` (walked backward to preceding
+    /// whitespace or start-of-string) is returned as a byte slice.
+    fn token_before_pos<'a>(bytes: &'a [u8], pos: &mut usize) -> &'a [u8] {
+        let end = *pos;
+        while *pos > 0 && !(bytes[*pos - 1] as char).is_ascii_whitespace() {
+            *pos -= 1;
+        }
+        &bytes[*pos..end]
+    }
+
+    /// Skips whitespace scanning backward from `pos`.
+    fn skip_ws_backward(bytes: &[u8], pos: &mut usize) {
+        while *pos > 0 && (bytes[*pos - 1] as char).is_ascii_whitespace() {
+            *pos -= 1;
+        }
+    }
+
+    // here_pos points to the first '<' of '<<'.  Walk backward looking for
+    // a file-write pattern (cat/tee/redirect + >? file + <<).
+
+    let mut pos = here_pos;
+
+    // Skip whitespace between << and the preceding word
+    skip_ws_backward(bytes, &mut pos);
+    if pos == 0 {
+        return false;
+    }
+
+    // Find the file path token immediately before <<
+    let file_token = token_before_pos(bytes, &mut pos);
+    if file_token.is_empty() {
+        return false;
+    }
+
+    // Skip whitespace before the file token
+    skip_ws_backward(bytes, &mut pos);
+    if pos == 0 {
+        return false;
+    }
+
+    // Check for >> or > redirect operator before the file token
+    if pos >= 2 && bytes[pos - 1] == b'>' && bytes[pos - 2] == b'>' {
+        // >> append-redirect operator
+        pos -= 2;
+        skip_ws_backward(bytes, &mut pos);
+        if pos == 0 {
+            // Bare >> file << EOF -- no command before redirect
+            return true;
+        }
+        let cmd = token_before_pos(bytes, &mut pos);
+        return cmd == b"cat" || cmd == b"tee";
+    }
+
+    if bytes[pos - 1] == b'>' {
+        // > write-redirect operator
+        pos -= 1;
+        skip_ws_backward(bytes, &mut pos);
+        if pos == 0 {
+            // Bare > file << EOF -- no command before redirect
+            return true;
+        }
+        let cmd = token_before_pos(bytes, &mut pos);
+        return cmd == b"cat" || cmd == b"tee";
+    }
+
+    // No redirect operator -- check for tee command (tee file << EOF)
+    let cmd = token_before_pos(bytes, &mut pos);
+    if cmd == b"tee" {
+        return true;
+    }
+
+    // Check if the previous token is a flag (starts with '-') for
+    // patterns like `tee -a file << EOF`
+    if cmd.len() > 1 && cmd[0] == b'-' {
+        skip_ws_backward(bytes, &mut pos);
+        if pos == 0 {
+            return false;
+        }
+        let prev_cmd = token_before_pos(bytes, &mut pos);
+        return prev_cmd == b"tee";
+    }
+
+    false
+}
+
+fn file_write_heredoc_error() -> ErrorData {
+    ErrorData::new(
+        rmcp::model::ErrorCode::INVALID_PARAMS,
+        "heredoc file-write pattern detected (cat/tee/redirect + <<) -- use edit_overwrite to write files instead of shell heredocs".to_string(),
+        Some(error_meta("validation", false, "use edit_overwrite to write files")),
+    )
 }
 
 fn missing_heredoc_error() -> ErrorData {

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -32,6 +32,9 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     // process substitution, variable-expanded command names).  Obfuscated or
     // deeply nested constructs may not be caught.  For a stricter guarantee,
     // replace this phase with a full shell AST parser.
+    //
+    // TODO: migrate to a proper shell lexer/AST parser if parsing complexity
+    // grows beyond the patterns enumerated above.
     {
         let mut i = 0;
         let mut in_single_quote = false;
@@ -613,5 +616,39 @@ mod tests {
                 "file extension should be txt, path has trailing separator"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit tests for scan_backward_for_file_write edge cases.
+    // The inner helpers (token_before_pos, skip_ws_backward) are tested
+    // indirectly via scan_backward_for_file_write with targeted inputs.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn scan_backward_empty_input_not_file_write() {
+        // here_pos == 0: nothing before <<, must not panic and must return false.
+        assert!(!scan_backward_for_file_write(b"", 0));
+    }
+
+    #[test]
+    fn scan_backward_only_whitespace_before_heredoc_not_file_write() {
+        // All whitespace before <<: "   <<"
+        // token_before_pos returns an empty slice, skip_ws_backward leaves pos==0.
+        let cmd = b"   <<";
+        assert!(!scan_backward_for_file_write(cmd, 3));
+    }
+
+    #[test]
+    fn scan_backward_leading_whitespace_file_token_then_redirect() {
+        // "  cat > file <<" -- whitespace at start of string, cat before redirect.
+        let cmd = b"  cat > file <<";
+        assert!(scan_backward_for_file_write(cmd, 13));
+    }
+
+    #[test]
+    fn scan_backward_file_token_only_no_redirect_no_tee_not_file_write() {
+        // "somecmd file <<" -- neither cat/tee nor a redirect; must return false.
+        let cmd = b"somecmd file <<";
+        assert!(!scan_backward_for_file_write(cmd, 13));
     }
 }

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -26,6 +26,12 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     let len = bytes.len();
 
     // Phase 1: pre-scan for heredoc file-write patterns (cat/tee/redirect + <<)
+    //
+    // This is a heuristic scanner: it handles the common patterns above but
+    // does not cover every possible shell construct (e.g. subshell grouping,
+    // process substitution, variable-expanded command names).  Obfuscated or
+    // deeply nested constructs may not be caught.  For a stricter guarantee,
+    // replace this phase with a full shell AST parser.
     {
         let mut i = 0;
         let mut in_single_quote = false;

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -33,8 +33,8 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     // deeply nested constructs may not be caught.  For a stricter guarantee,
     // replace this phase with a full shell AST parser.
     //
-    // TODO: migrate to a proper shell lexer/AST parser if parsing complexity
-    // grows beyond the patterns enumerated above.
+    // TODO(#1198): migrate to a proper shell lexer/AST parser if parsing
+    // complexity grows beyond the patterns enumerated above.
     {
         let mut i = 0;
         let mut in_single_quote = false;

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1097,3 +1097,110 @@ async fn test_drain_timeout_background_pipe_holder() {
         .await
         .expect("test timed out");
 }
+
+// ---------------------------------------------------------------------------
+// Heredoc file-write rejection tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_heredoc_cat_redirect_write_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat > /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_cat_append_write_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat >> /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_tee_write_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "tee /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_tee_append_flag_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "tee -a /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_bare_redirect_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": ">> /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_cat_redirect_in_quotes_accepted() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo 'cat > file <<EOF'"
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected isError=false: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_cat_stdout_accepted() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected isError=false: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_awk_bitshift_accepted() {
+    // The awk command should execute (exit code 2 from awk syntax),
+    // NOT be rejected by pre-spawn validation.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "awk '{print 1 << 2}'"
+    }))
+    .await;
+    // awk syntax error on macOS produces exit code 2, so isError=true,
+    // but the important thing is that the command *ran* at all (not
+    // rejected by pre-spawn heredoc validation).  Verify by checking
+    // the output contains the awk error message.
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("awk:"),
+        "expected awk to run (not be rejected by pre-scan): {resp}"
+    );
+}

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1163,6 +1163,45 @@ async fn test_heredoc_bare_redirect_rejected() {
 }
 
 #[tokio::test]
+async fn test_heredoc_bare_single_redirect_rejected() {
+    // Bare > file << EOF with no command before the redirect operator.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "> /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for bare > redirect: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_tee_append_redirect_rejected() {
+    // tee >> file << EOF -- tee with an explicit append redirect operator.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "tee >> /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for tee >> redirect: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_tee_single_redirect_rejected() {
+    // tee > file << EOF -- tee with an explicit write redirect operator.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "tee > /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for tee > redirect: {resp}"
+    );
+}
+
+#[tokio::test]
 async fn test_heredoc_cat_redirect_in_quotes_accepted() {
     let resp = call_exec_command_raw(serde_json::json!({
         "command": "echo 'cat > file <<EOF'"


### PR DESCRIPTION
## Summary

Reject heredoc file-write patterns in `validate_heredocs` before spawning any process. File writes via heredocs (cat > file, tee file, bare redirects) are unsafe and prone to race conditions and unintended behavior; users should use `edit_overwrite` instead.

Implements a pre-scan phase that walks the command byte-by-byte with quote tracking. When a `<<` token is found outside quoted regions, it scans backward to detect file-write patterns and returns INVALID_PARAMS immediately if detected. The existing heredoc structure validation continues unchanged as Phase 2.

Fixes #1194.

## Changes

- crates/aptu-coder/src/validation.rs
- crates/aptu-coder/src/lib.rs
- crates/aptu-coder/tests/exec_command.rs

## Test plan

- [x] Tests pass: 50 tests passed (11 new heredoc file-write tests)
- [x] Linter clean: cargo clippy -- -D warnings passed
- [x] Formatter clean: cargo fmt --check passed
- [x] Security scan clean: aptu scan-security found 0 issues

New tests cover:
- cat > file rejected
- cat >> file rejected
- tee file rejected
- tee -a file rejected (tee with flags)
- bare >> file rejected
- bare > file rejected
- tee >> file rejected
- tee > file rejected
- cat > file inside single-quoted string accepted (no false positive)
- plain cat to stdout accepted (no regression)
- bitshift inside single-quoted awk program accepted (non-regression)

Closes #1194
