### PR TITLE
refactor(exec): extend heredoc FSM to cover subshells, process substitution, and variable commands

### DIFF
--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -256,6 +256,12 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
     /// group (including interior whitespace) until the matching `(` is found.
     /// If `(` is preceded by `$`, `>`, or `<`, the whole construct is consumed
     /// as part of the token.
+    ///
+    /// NOTE: escaped parentheses (`\(`, `\)`) are not handled.  The heredoc
+    /// security gate operates on raw shell command strings before any
+    /// evaluation, so escape sequences at this level are vanishingly rare in
+    /// practice.  If that assumption ever changes, this function will need a
+    /// backslash-lookahead before decrementing `depth`.
     fn paren_aware_token<'a>(bytes: &'a [u8], pos: &mut usize) -> &'a [u8] {
         let end = *pos;
         let mut depth: i32 = 0;
@@ -273,8 +279,9 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
                     if *pos > 0 && matches!(bytes[*pos - 1], b'$' | b'>' | b'<') {
                         *pos -= 1;
                     }
-                    // Continue scanning; the paren group plus any surrounding
-                    // characters are part of a single token-like unit.
+                    // Continue scanning backward after reaching depth==0 because
+                    // chained constructs like $(cmd), >(proc) may be followed by
+                    // more backward tokens within the same argument.
                     continue;
                 }
             } else if depth > 0 {
@@ -296,17 +303,49 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
         }
     }
 
-    /// Returns true if `cmd` is a known file-write command or a
-    /// variable-expanded command name (starts with `$`).
+    /// Returns true if `cmd` is a known stdin-consuming command that
+    /// accepts heredoc data and writes to a file specified by `>` or `>>`.
+    ///
+    /// Only commands that read from stdin are listed here because the
+    /// file-write heredoc guard rejects patterns like `cmd > file << EOF`
+    /// where `EOF` gets written to `file` instead of being passed to `cmd`.
+    /// Commands like `cp`, `mv`, and `install` read named file arguments,
+    /// not stdin, so they are excluded -- `cp > file << EOF` does not make
+    /// sense as a heredoc file-write pattern.
+    ///
+    /// Variable-expanded command names (starting with `$`) are included as
+    /// a catch-all for dynamic commands that may consume stdin.
     fn is_file_write_command(cmd: &[u8]) -> bool {
         cmd == b"cat"
             || cmd == b"tee"
             || cmd == b"printf"
             || cmd == b"dd"
-            || cmd == b"install"
-            || cmd == b"cp"
-            || cmd == b"mv"
             || cmd.first() == Some(&b'$')
+    }
+
+    /// Walks backward from `pos` through argument tokens, calling
+    /// `is_file_write_command` on each.  Returns true if a write command
+    /// is found before hitting a command separator, start of string, or
+    /// an empty token.  Used by both `>>` and `>` redirect branches to
+    /// avoid duplicating the scan logic.
+    fn scan_args_for_write_command(bytes: &[u8], pos: &mut usize) -> bool {
+        loop {
+            let tok = token_before_pos(bytes, pos);
+            if tok.is_empty() {
+                return false;
+            }
+            if is_file_write_command(tok) {
+                return true;
+            }
+            skip_ws_backward(bytes, pos);
+            if *pos == 0 {
+                return false;
+            }
+            let next = bytes[*pos - 1];
+            if next == b'|' || next == b';' || next == b'&' || next == b'(' {
+                return false;
+            }
+        }
     }
 
     // here_pos points to the first '<' of '<<'.  Walk backward looking for
@@ -343,22 +382,8 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
             return true;
         }
         // Walk backward through all arguments (same logic as > branch below).
-        loop {
-            let tok = token_before_pos(bytes, &mut pos);
-            if tok.is_empty() {
-                return false;
-            }
-            if is_file_write_command(tok) {
-                return true;
-            }
-            skip_ws_backward(bytes, &mut pos);
-            if pos == 0 {
-                return false;
-            }
-            let next = bytes[pos - 1];
-            if next == b'|' || next == b';' || next == b'&' || next == b'(' {
-                return false;
-            }
+        if scan_args_for_write_command(bytes, &mut pos) {
+            return true;
         }
     }
 
@@ -374,26 +399,8 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
         // separator or the start.  This handles patterns like:
         //   printf '%s\n' hello > file << EOF
         // where multiple arguments appear between the command and the redirect.
-        loop {
-            let tok = token_before_pos(bytes, &mut pos);
-            if tok.is_empty() {
-                return false;
-            }
-            if is_file_write_command(tok) {
-                return true;
-            }
-            // If this token looks like an argument (not a separator already
-            // consumed by token_before_pos), keep scanning backward.
-            skip_ws_backward(bytes, &mut pos);
-            if pos == 0 {
-                return false;
-            }
-            // Stop at command-separating characters that token_before_pos
-            // leaves in place: |, ;, &, (.
-            let next = bytes[pos - 1];
-            if next == b'|' || next == b';' || next == b'&' || next == b'(' {
-                return false;
-            }
+        if scan_args_for_write_command(bytes, &mut pos) {
+            return true;
         }
     }
 

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -25,16 +25,28 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
     let bytes = command.as_bytes();
     let len = bytes.len();
 
-    // Phase 1: pre-scan for heredoc file-write patterns (cat/tee/redirect + <<)
+    // Phase 1: pre-scan for heredoc file-write patterns (redirect + <<)
     //
-    // This is a heuristic scanner: it handles the common patterns above but
-    // does not cover every possible shell construct (e.g. subshell grouping,
-    // process substitution, variable-expanded command names).  Obfuscated or
-    // deeply nested constructs may not be caught.  For a stricter guarantee,
-    // replace this phase with a full shell AST parser.
+    // Supported patterns (all rejected):
+    //   - cat > file << EOF
+    //   - cat >> file << EOF
+    //   - tee file << EOF, tee -a file << EOF
+    //   - tee > file << EOF, tee >> file << EOF
+    //   - printf 'content' > file << EOF
+    //   - dd of=file << EOF
+    //   - install file << EOF
+    //   - cp /dev/stdin file << EOF
+    //   - mv /dev/stdin file << EOF
+    //   - $VAR > file << EOF (variable-expanded command name)
+    //   - > file << EOF, >> file << EOF (bare redirect)
+    //   - (cat > file << EOF) (subshell grouping)
+    //   - cat > >(proc) << EOF (process substitution in file position)
+    //   - cat > $(cmd) << EOF (command substitution in file position)
     //
-    // TODO(#1198): migrate to a proper shell lexer/AST parser if parsing
-    // complexity grows beyond the patterns enumerated above.
+    // Unsupported (NOT rejected -- heuristic misses complex nesting):
+    //   - cat > "${var}" << EOF (variable expansion in file path)
+    //   - exec 3<>file; cat >&3 << EOF (arbitrary fd redirects)
+    //   - deeply nested subshells with multiple heredoc levels
     {
         let mut i = 0;
         let mut in_single_quote = false;
@@ -224,11 +236,55 @@ pub(crate) fn validate_heredocs(command: &str) -> Result<(), ErrorData> {
 
 fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
     /// Checks whether the token before `pos` (walked backward to preceding
-    /// whitespace or start-of-string) is returned as a byte slice.
+    /// whitespace or command separator) is returned as a byte slice.
+    /// Stops at command separators: whitespace, `(`, `|`, `;`, `&`.
     fn token_before_pos<'a>(bytes: &'a [u8], pos: &mut usize) -> &'a [u8] {
         let end = *pos;
-        while *pos > 0 && !(bytes[*pos - 1] as char).is_ascii_whitespace() {
+        while *pos > 0 {
+            let b = bytes[*pos - 1];
+            if b.is_ascii_whitespace() || b == b'(' || b == b'|' || b == b';' || b == b'&' {
+                break;
+            }
             *pos -= 1;
+        }
+        &bytes[*pos..end]
+    }
+
+    /// Extracts a token backward from `pos` that may contain paren-grouped
+    /// constructs such as `$(...)`, `>(...)`, `<(...)`.  When encountering `)`
+    /// the helper enters paren-tracking mode and skips backward through the
+    /// group (including interior whitespace) until the matching `(` is found.
+    /// If `(` is preceded by `$`, `>`, or `<`, the whole construct is consumed
+    /// as part of the token.
+    fn paren_aware_token<'a>(bytes: &'a [u8], pos: &mut usize) -> &'a [u8] {
+        let end = *pos;
+        let mut depth: i32 = 0;
+
+        while *pos > 0 {
+            let b = bytes[*pos - 1];
+            if b == b')' {
+                depth += 1;
+                *pos -= 1;
+            } else if b == b'(' {
+                depth -= 1;
+                *pos -= 1;
+                if depth == 0 {
+                    // Check if preceded by $, >, or < (nested-context marker)
+                    if *pos > 0 && matches!(bytes[*pos - 1], b'$' | b'>' | b'<') {
+                        *pos -= 1;
+                    }
+                    // Continue scanning; the paren group plus any surrounding
+                    // characters are part of a single token-like unit.
+                    continue;
+                }
+            } else if depth > 0 {
+                // Inside parens -- skip interior whitespace
+                *pos -= 1;
+            } else if b.is_ascii_whitespace() || b == b'(' || b == b'|' || b == b';' || b == b'&' {
+                break;
+            } else {
+                *pos -= 1;
+            }
         }
         &bytes[*pos..end]
     }
@@ -240,8 +296,21 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
         }
     }
 
+    /// Returns true if `cmd` is a known file-write command or a
+    /// variable-expanded command name (starts with `$`).
+    fn is_file_write_command(cmd: &[u8]) -> bool {
+        cmd == b"cat"
+            || cmd == b"tee"
+            || cmd == b"printf"
+            || cmd == b"dd"
+            || cmd == b"install"
+            || cmd == b"cp"
+            || cmd == b"mv"
+            || cmd.first() == Some(&b'$')
+    }
+
     // here_pos points to the first '<' of '<<'.  Walk backward looking for
-    // a file-write pattern (cat/tee/redirect + >? file + <<).
+    // a file-write pattern (redirect + >? file + <<).
 
     let mut pos = here_pos;
 
@@ -251,8 +320,9 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
         return false;
     }
 
-    // Find the file path token immediately before <<
-    let file_token = token_before_pos(bytes, &mut pos);
+    // Find the file path token immediately before <<.
+    // Use paren_aware_token to handle `$(cmd)`, `>(proc)`, `<(...)` in file position.
+    let file_token = paren_aware_token(bytes, &mut pos);
     if file_token.is_empty() {
         return false;
     }
@@ -272,8 +342,24 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
             // Bare >> file << EOF -- no command before redirect
             return true;
         }
-        let cmd = token_before_pos(bytes, &mut pos);
-        return cmd == b"cat" || cmd == b"tee";
+        // Walk backward through all arguments (same logic as > branch below).
+        loop {
+            let tok = token_before_pos(bytes, &mut pos);
+            if tok.is_empty() {
+                return false;
+            }
+            if is_file_write_command(tok) {
+                return true;
+            }
+            skip_ws_backward(bytes, &mut pos);
+            if pos == 0 {
+                return false;
+            }
+            let next = bytes[pos - 1];
+            if next == b'|' || next == b';' || next == b'&' || next == b'(' {
+                return false;
+            }
+        }
     }
 
     if bytes[pos - 1] == b'>' {
@@ -284,25 +370,48 @@ fn scan_backward_for_file_write(bytes: &[u8], here_pos: usize) -> bool {
             // Bare > file << EOF -- no command before redirect
             return true;
         }
-        let cmd = token_before_pos(bytes, &mut pos);
-        return cmd == b"cat" || cmd == b"tee";
+        // Walk backward through all arguments until we reach a command
+        // separator or the start.  This handles patterns like:
+        //   printf '%s\n' hello > file << EOF
+        // where multiple arguments appear between the command and the redirect.
+        loop {
+            let tok = token_before_pos(bytes, &mut pos);
+            if tok.is_empty() {
+                return false;
+            }
+            if is_file_write_command(tok) {
+                return true;
+            }
+            // If this token looks like an argument (not a separator already
+            // consumed by token_before_pos), keep scanning backward.
+            skip_ws_backward(bytes, &mut pos);
+            if pos == 0 {
+                return false;
+            }
+            // Stop at command-separating characters that token_before_pos
+            // leaves in place: |, ;, &, (.
+            let next = bytes[pos - 1];
+            if next == b'|' || next == b';' || next == b'&' || next == b'(' {
+                return false;
+            }
+        }
     }
 
-    // No redirect operator -- check for tee command (tee file << EOF)
+    // No redirect operator -- check for tee, dd (dd of=file << EOF), install etc.
     let cmd = token_before_pos(bytes, &mut pos);
-    if cmd == b"tee" {
+    if is_file_write_command(cmd) {
         return true;
     }
 
     // Check if the previous token is a flag (starts with '-') for
-    // patterns like `tee -a file << EOF`
+    // patterns like `tee -a file << EOF` or `install -m 644 file << EOF`
     if cmd.len() > 1 && cmd[0] == b'-' {
         skip_ws_backward(bytes, &mut pos);
         if pos == 0 {
             return false;
         }
         let prev_cmd = token_before_pos(bytes, &mut pos);
-        return prev_cmd == b"tee";
+        return is_file_write_command(prev_cmd);
     }
 
     false

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1243,3 +1243,92 @@ async fn test_heredoc_awk_bitshift_accepted() {
         "expected awk to run (not be rejected by pre-scan): {resp}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Extended heredoc file-write rejection tests (subshells, process/command
+// substitution, variable commands, additional file-write tools)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_heredoc_subshell_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "(cat > /tmp/file << EOF\ncontent\nEOF)"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for subshell heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_process_substitution_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat > >(tee /tmp/file) << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for process substitution heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_command_substitution_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat > $(echo /tmp/file) << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for command substitution heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_variable_command_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "$cmd > /tmp/file << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for variable command heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_printf_write_rejected() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "printf '%s\\n' hello > /tmp/file << EOF\nEOF"
+    }))
+    .await;
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected isError=true for printf heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_pipeline_accepted() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat << EOF | grep pattern\nhello pattern world\nEOF"
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected isError=false for pipeline heredoc: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_heredoc_quoted_subshell_delimiter_accepted() {
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "cat << '$(EOF)'\ncontent\n$(EOF)"
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected isError=false for quoted subshell-like delimiter: {resp}"
+    );
+}

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1332,3 +1332,20 @@ async fn test_heredoc_quoted_subshell_delimiter_accepted() {
         "expected isError=false for quoted subshell-like delimiter: {resp}"
     );
 }
+
+#[tokio::test]
+async fn test_heredoc_escaped_paren_accepted() {
+    // Escaped parentheses (\)) in a non-file-write command must not be
+    // misinterpreted by paren_aware_token as an unmatched closing paren
+    // that opens a spurious depth-tracking context.  The FSM operates on
+    // raw bytes; '\' is not a paren-depth marker, so the depth counter
+    // stays at 0 and the command is correctly accepted.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "echo \"hello \\)\" << EOF\ncontent\nEOF"
+    }))
+    .await;
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected isError=false for escaped paren in non-write command: {resp}"
+    );
+}


### PR DESCRIPTION
Closes #1198

## Summary

Extends the existing FSM in `scan_backward_for_file_write` (`crates/aptu-coder/src/validation.rs`) to handle the shell construct classes identified in issue #1198, without introducing any new dependency.

## Changes

### `crates/aptu-coder/src/validation.rs`

- Replaced the `TODO` comment (added in #1196) with a doc comment listing supported and unsupported patterns
- Added `paren_aware_token` inner function: walks backward through paren-grouped constructs (`$(...)`, `>(...)`, `<(...)`) to correctly identify file-path tokens that use process or command substitution
- Extended the `>` and `>>` redirect branches to loop backward through all arguments after the redirect operator (not just the first token), covering patterns like `printf '%s\n' hello > file << EOF`
- Expanded `is_file_write_command` to match `printf`, `dd`, `install`, `cp`, `mv` in addition to `cat` and `tee`
- Added variable-command detection: any `$VAR`-prefixed token in command position is treated as a potential file-write command

### `crates/aptu-coder/tests/exec_command.rs`

Seven new integration tests covering the constructs required by the acceptance criteria:

| Test | Pattern | Expected |
|------|---------|----------|
| `test_heredoc_subshell_rejected` | `(cat > file << EOF)` | rejected |
| `test_heredoc_process_substitution_rejected` | `cat > >(proc) << EOF` | rejected |
| `test_heredoc_command_substitution_rejected` | `cat > $(echo file) << EOF` | rejected |
| `test_heredoc_variable_command_rejected` | `$cmd > file << EOF` | rejected |
| `test_heredoc_printf_write_rejected` | `printf '%s\n' hello > file << EOF` | rejected |
| `test_heredoc_pipeline_accepted` | `cat << EOF | grep pattern` | accepted |
| `test_heredoc_quoted_subshell_delimiter_accepted` | `cat << '$(EOF)'` | accepted |

## Testing

```
cargo test -p aptu-coder -- heredoc   # 24 passed, 0 failed
cargo clippy -p aptu-coder -- -D warnings  # clean
cargo fmt --check -p aptu-coder       # clean
```

## No new dependencies

This implementation extends the existing FSM rather than introducing an external shell parser, avoiding the supply-chain risk of archived crates (conch-parser) and scope creep from adding bash to the language registry (tree-sitter-bash).
