### PR TITLE
chore(release): v0.20.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.4"
+version = "0.20.5"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
# What's Changed

### Security / Reliability

- **`exec`: reject heredoc file-write patterns in `validate_heredocs`** (#1196, closes #1194): Pre-scan phase walks the command byte-by-byte with quote tracking. When a `<<` token is found outside quoted regions, it scans backward to detect file-write patterns (`cat > file`, `tee file`, bare `>` / `>>` redirects) and returns `INVALID_PARAMS` immediately -- before any process is spawned. Users should use `edit_overwrite` for file writes. 11 new integration tests; no false positives on bitshift inside single-quoted awk programs or plain `cat` to stdout.

- **`exec`: extend heredoc FSM to cover subshells, process substitution, and variable commands** (#1199, closes #1198): Extends `scan_backward_for_file_write` in `validation.rs` to handle shell construct classes not covered by the initial fix: subshells (`(cat > file << EOF)`), process substitution (`cat > >(proc) << EOF`), command substitution (`cat > $(echo file) << EOF`), variable commands (`$cmd > file << EOF`), and additional file-write binaries (`printf`, `dd`, `install`, `cp`, `mv`). Adds a `paren_aware_token` inner function and expands the redirect branches to loop backward through all arguments. 7 new integration tests; no new dependencies (avoids supply-chain risk of archived crates like `conch-parser`).

### Features

- **`exec_command`: prefer JSON output flags in tool description** (#1197, closes #1195): Appends one sentence to the `exec_command` tool description instructing models to prefer machine-readable JSON output flags for build, lint, and test commands. Placed in `Tool.description` -- the only surface that reaches every connected model and survives both MCP 2025-11-25 and the 2026-07-28-RC (which removes `InitializeResult.instructions`).

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.20.4...v0.20.5
