### PR TITLE
feat(tools): scaffold tools/ submodule and document extraction pattern (#1187)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -30,6 +30,7 @@ pub mod logging;
 pub mod metrics;
 pub mod otel;
 mod shell;
+mod tools;
 mod validation;
 
 use aptu_coder_core::analyze;

--- a/crates/aptu-coder/src/tools/mod.rs
+++ b/crates/aptu-coder/src/tools/mod.rs
@@ -1,0 +1,42 @@
+//! Extraction pattern for milestone 17 (lib.rs decomposition).
+//!
+//! This module will contain extracted tool handler logic as free functions,
+//! keeping the `#[tool(...)]`-decorated methods in `lib.rs` as thin shims.
+//! The pattern ensures a smooth, incremental decomposition with no single
+//! large-bang refactor.
+//!
+//! Pattern rules
+//! -------------
+//!
+//! (a) **Extracted handlers are free functions, not methods.** Each handler
+//!     is a plain `pub(crate) fn` in this module, not an `impl CodeAnalyzer`
+//!     method. This breaks the coupling to `&self` and makes the function
+//!     testable in isolation.
+//!
+//! (b) **Explicit parameters instead of `&self`.** State that the handler
+//!     needs (e.g., `config: &Config`, `state: &HandlerState`) is passed
+//!     explicitly as function parameters. The shim in `lib.rs` extracts
+//!     values from `&self` before calling the extracted function.
+//!
+//! (c) **`#[tool(...)]`-decorated method and `#[instrument(...)]` decorator
+//!     remain in `lib.rs` as thin shims.** The `#[tool(..)]` attribute
+//!     macro and the outer `#[instrument(..)]` stay on the small stub in
+//!     `lib.rs`. The stub validates parameters, extracts state, and
+//!     delegates to the free function here.
+//!
+//! (d) **The extracted free function also carries `#[instrument(skip(...))]`
+//!     on its own signature.** This preserves distributed tracing context
+//!     after the call leaves the `lib.rs` shim. Use `skip` for large
+//!     internal types whose fields are not useful trace attributes.
+//!
+//! (e) **`edit_failure_counts` stays in `CodeAnalyzer` and is passed by
+//!     reference to extracted edit handlers.** The concurrent failure-tracking
+//!     map is not moved into `tools/`; it remains an `Arc<Mutex<...>>` field
+//!     on `CodeAnalyzer`. Extracted edit handlers receive `&edit_failure_counts`
+//!     as a parameter.
+//!
+//! (f) **`#[tool_router]` and `#[tool_handler]` impl blocks remain in
+//!     `lib.rs` permanently.** The `#[tool_router]` impl on `CodeAnalyzer`
+//!     and the `#[tool_handler]` impl for `ServerHandler` must not be
+//!     moved into this module. They are the framework glue that ties all
+//!     tools together and must live in the crate root.


### PR DESCRIPTION
## Summary

Scaffold the tools/ submodule for milestone 17 (lib.rs decomposition). This PR adds `mod tools;` to lib.rs between `mod shell;` and `mod validation;` and creates crates/aptu-coder/src/tools/mod.rs with the extraction pattern documented as a module-level comment covering all 6 pattern rules.

No logic is moved; lib.rs LOC is unchanged. This is Shard 0 of milestone 17.

## Changes

- crates/aptu-coder/src/lib.rs (1 line added: mod tools;)
- crates/aptu-coder/src/tools/mod.rs (new file with extraction pattern documentation)

## Test plan

- [x] Tests pass (667 tests passed)
- [x] Linter clean (cargo clippy -- -D warnings)
- [x] Formatter clean (cargo fmt --check)
- [x] Security scan clean (no findings)

## Acceptance Criteria

- [x] mod tools; inserted between mod shell; and mod validation; with no #[allow(...)] on the line
- [x] tools/mod.rs exists and contains doc comment covering all 6 extraction pattern points
- [x] No logic moved from lib.rs in this PR
- [x] No public API changes
- [x] All tests pass

Closes #1187
