### PR TITLE
fix(lib): tighten crate public API -- demote internal tool helpers to pub(crate)

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -33,15 +33,13 @@ mod shell;
 mod tools;
 mod validation;
 
-pub use tools::common::{
-    ClientMetadata, err_to_tool_result, error_meta, extract_and_set_trace_context, no_cache_meta,
-    summary_cursor_conflict,
-};
-
 use aptu_coder_core::analyze;
 use aptu_coder_core::{cache, completion, types};
 use shell::resolve_shell;
 use validation::validate_path;
+
+use crate::otel::{ClientMetadata, extract_and_set_trace_context};
+use crate::tools::common::{err_to_tool_result, no_cache_meta};
 
 pub const STDIN_MAX_BYTES: usize = 1_048_576;
 

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -21,7 +21,7 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-mod otel;
+use aptu_coder::otel;
 
 /// Authentication middleware that validates Bearer tokens using constant-time comparison.
 ///

--- a/crates/aptu-coder/src/otel.rs
+++ b/crates/aptu-coder/src/otel.rs
@@ -9,6 +9,93 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::warn;
 
+/// Session and client metadata recorded as span attributes on every tool call.
+#[allow(dead_code)]
+pub struct ClientMetadata {
+    pub session_id: Option<String>,
+    pub client_name: Option<String>,
+    pub client_version: Option<String>,
+}
+
+#[allow(dead_code)]
+/// Extract W3C Trace Context from MCP request _meta field and set as parent span context.
+///
+/// Attempts to extract traceparent and tracestate from the request's _meta field.
+/// If successful, calls `set_parent` on the current tracing span so the OTel layer
+/// re-parents it to the caller's trace. This must be called after the `#[instrument]`
+/// span has been entered (i.e., inside the function body) for `set_parent` to take effect.
+/// If extraction fails or _meta is absent, silently proceeds with root context (no panic).
+pub fn extract_and_set_trace_context(
+    meta: Option<&rmcp::model::Meta>,
+    client_meta: ClientMetadata,
+) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let span = tracing::Span::current();
+
+    // Record session and client attributes
+    if let Some(sid) = client_meta.session_id {
+        span.record("mcp.session.id", &sid);
+    }
+    if let Some(cn) = client_meta.client_name {
+        span.record("client.name", &cn);
+    }
+    if let Some(cv) = client_meta.client_version {
+        span.record("client.version", &cv);
+    }
+
+    // Extract agent-session-id from _meta if present (opportunistic; silent no-op if absent)
+    if let Some(asi_str) = meta.and_then(|m| m.0.get("agent-session-id").and_then(|v| v.as_str())) {
+        span.record("mcp.client.session.id", asi_str);
+    }
+
+    let Some(meta) = meta else { return };
+
+    let mut propagation_map = std::collections::HashMap::new();
+
+    // Extract traceparent if present
+    if let Some(traceparent) = meta.0.get("traceparent")
+        && let Some(tp_str) = traceparent.as_str()
+    {
+        propagation_map.insert("traceparent".to_string(), tp_str.to_string());
+    }
+
+    // Extract tracestate if present
+    if let Some(tracestate) = meta.0.get("tracestate")
+        && let Some(ts_str) = tracestate.as_str()
+    {
+        propagation_map.insert("tracestate".to_string(), ts_str.to_string());
+    }
+
+    // Only attempt extraction if we have at least traceparent
+    if propagation_map.is_empty() {
+        return;
+    }
+
+    // Extract context via the globally registered propagator (TraceContextPropagator by default)
+    let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&ExtractMap(&propagation_map))
+    });
+
+    // Re-parent the current tracing span (already entered via #[instrument]) to the
+    // extracted OTel context. set_parent is a no-op if the OTel layer is not installed.
+    let _ = span.set_parent(parent_cx);
+}
+
+/// Helper struct for W3C Trace Context extraction from HashMap
+#[allow(dead_code)]
+struct ExtractMap<'a>(&'a std::collections::HashMap<String, String>);
+
+impl<'a> opentelemetry::propagation::Extractor for ExtractMap<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|s| s.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
 /// Builds the standard service resource attached to all three signal providers.
 fn service_resource() -> Resource {
     Resource::builder()

--- a/crates/aptu-coder/src/otel.rs
+++ b/crates/aptu-coder/src/otel.rs
@@ -10,14 +10,12 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::warn;
 
 /// Session and client metadata recorded as span attributes on every tool call.
-#[allow(dead_code)]
 pub struct ClientMetadata {
     pub session_id: Option<String>,
     pub client_name: Option<String>,
     pub client_version: Option<String>,
 }
 
-#[allow(dead_code)]
 /// Extract W3C Trace Context from MCP request _meta field and set as parent span context.
 ///
 /// Attempts to extract traceparent and tracestate from the request's _meta field.
@@ -83,7 +81,6 @@ pub fn extract_and_set_trace_context(
 }
 
 /// Helper struct for W3C Trace Context extraction from HashMap
-#[allow(dead_code)]
 struct ExtractMap<'a>(&'a std::collections::HashMap<String, String>);
 
 impl<'a> opentelemetry::propagation::Extractor for ExtractMap<'a> {

--- a/crates/aptu-coder/src/tests.rs
+++ b/crates/aptu-coder/src/tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use super::*;
+use crate::tools::common::summary_cursor_conflict;
 use crate::tools::exec_command::{build_exec_command, handle_output_persist, strip_cd_prefix};
 use crate::validation::validate_path_in_dir;
 use aptu_coder_core::traversal;

--- a/crates/aptu-coder/src/tools/analyze_directory.rs
+++ b/crates/aptu-coder/src/tools/analyze_directory.rs
@@ -21,8 +21,11 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::instrument;
 
+use crate::SIZE_LIMIT;
+use crate::tools::common::{
+    err_to_tool_result, error_meta, no_cache_meta, summary_cursor_conflict,
+};
 use crate::tools::{AnalyzeDirectoryContext, DirectoryHandlerCall};
-use crate::{SIZE_LIMIT, err_to_tool_result, error_meta, no_cache_meta};
 
 /// Emit a progress notification to the MCP client peer.
 async fn emit_progress_notification(
@@ -327,7 +330,7 @@ pub(crate) async fn analyze_directory_handler(
         Err(arc) => (*arc).clone(),
     };
 
-    if crate::summary_cursor_conflict(
+    if summary_cursor_conflict(
         params.output_control.summary,
         params.pagination.cursor.as_deref(),
     ) {

--- a/crates/aptu-coder/src/tools/analyze_file.rs
+++ b/crates/aptu-coder/src/tools/analyze_file.rs
@@ -16,8 +16,11 @@ use serde_json::Value;
 use std::sync::Arc;
 use tracing::instrument;
 
+use crate::SIZE_LIMIT;
 use crate::tools::AnalyzeFileContext;
-use crate::{SIZE_LIMIT, err_to_tool_result, error_meta, no_cache_meta};
+use crate::tools::common::{
+    err_to_tool_result, error_meta, no_cache_meta, summary_cursor_conflict,
+};
 
 /// Core analysis logic for the `analyze_file` tool (file details mode).
 ///
@@ -160,7 +163,7 @@ pub(crate) async fn analyze_file_handler(
         )));
     }
 
-    if crate::summary_cursor_conflict(
+    if summary_cursor_conflict(
         params.output_control.summary,
         params.pagination.cursor.as_deref(),
     ) {

--- a/crates/aptu-coder/src/tools/analyze_module.rs
+++ b/crates/aptu-coder/src/tools/analyze_module.rs
@@ -13,7 +13,7 @@ use rmcp::model::{CallToolResult, Content, ErrorData, Meta};
 use std::sync::Arc;
 use tracing::instrument;
 
-use crate::{err_to_tool_result, error_meta, no_cache_meta};
+use crate::tools::common::{err_to_tool_result, error_meta, no_cache_meta};
 
 /// Shared handler context passed to extracted `analyze_module` free functions.
 ///

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -23,10 +23,10 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::instrument;
 
-use crate::{
-    SIZE_LIMIT, err_to_tool_result, err_to_tool_result_from_pagination, error_meta, no_cache_meta,
-    summary_cursor_conflict,
+use crate::tools::common::{
+    err_to_tool_result, error_meta, no_cache_meta, summary_cursor_conflict,
 };
+use crate::{SIZE_LIMIT, err_to_tool_result_from_pagination};
 
 /// Shared handler context passed to extracted `analyze_symbol` free functions.
 ///

--- a/crates/aptu-coder/src/tools/common.rs
+++ b/crates/aptu-coder/src/tools/common.rs
@@ -2,100 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared helpers used by two or more tool handler modules.
 //!
-//! Items here are `pub(crate)` and re-exported from `lib.rs` at the crate root
-//! so that integration tests can access them via `aptu_coder::` paths.
+//! All items here are `pub(crate)`. OTel-specific types (`ClientMetadata`,
+//! `extract_and_set_trace_context`) live in `crate::otel` where they are `pub`.
 
 use rmcp::model::{CallToolResult, Content, ErrorData, Meta};
 
 /// Returns `true` when `summary=true` and a `cursor` are both provided, which is an invalid
 /// combination since summary mode and pagination are mutually exclusive.
 #[must_use]
-pub fn summary_cursor_conflict(summary: Option<bool>, cursor: Option<&str>) -> bool {
+pub(crate) fn summary_cursor_conflict(summary: Option<bool>, cursor: Option<&str>) -> bool {
     summary == Some(true) && cursor.is_some()
-}
-
-/// Session and client metadata recorded as span attributes on every tool call.
-pub struct ClientMetadata {
-    pub session_id: Option<String>,
-    pub client_name: Option<String>,
-    pub client_version: Option<String>,
-}
-
-/// Extract W3C Trace Context from MCP request _meta field and set as parent span context.
-///
-/// Attempts to extract traceparent and tracestate from the request's _meta field.
-/// If successful, calls `set_parent` on the current tracing span so the OTel layer
-/// re-parents it to the caller's trace. This must be called after the `#[instrument]`
-/// span has been entered (i.e., inside the function body) for `set_parent` to take effect.
-/// If extraction fails or _meta is absent, silently proceeds with root context (no panic).
-pub fn extract_and_set_trace_context(
-    meta: Option<&rmcp::model::Meta>,
-    client_meta: ClientMetadata,
-) {
-    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-
-    let span = tracing::Span::current();
-
-    // Record session and client attributes
-    if let Some(sid) = client_meta.session_id {
-        span.record("mcp.session.id", &sid);
-    }
-    if let Some(cn) = client_meta.client_name {
-        span.record("client.name", &cn);
-    }
-    if let Some(cv) = client_meta.client_version {
-        span.record("client.version", &cv);
-    }
-
-    // Extract agent-session-id from _meta if present (opportunistic; silent no-op if absent)
-    if let Some(asi_str) = meta.and_then(|m| m.0.get("agent-session-id").and_then(|v| v.as_str())) {
-        span.record("mcp.client.session.id", asi_str);
-    }
-
-    let Some(meta) = meta else { return };
-
-    let mut propagation_map = std::collections::HashMap::new();
-
-    // Extract traceparent if present
-    if let Some(traceparent) = meta.0.get("traceparent")
-        && let Some(tp_str) = traceparent.as_str()
-    {
-        propagation_map.insert("traceparent".to_string(), tp_str.to_string());
-    }
-
-    // Extract tracestate if present
-    if let Some(tracestate) = meta.0.get("tracestate")
-        && let Some(ts_str) = tracestate.as_str()
-    {
-        propagation_map.insert("tracestate".to_string(), ts_str.to_string());
-    }
-
-    // Only attempt extraction if we have at least traceparent
-    if propagation_map.is_empty() {
-        return;
-    }
-
-    // Extract context via the globally registered propagator (TraceContextPropagator by default)
-    let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
-        propagator.extract(&ExtractMap(&propagation_map))
-    });
-
-    // Re-parent the current tracing span (already entered via #[instrument]) to the
-    // extracted OTel context. set_parent is a no-op if the OTel layer is not installed.
-    let _ = span.set_parent(parent_cx);
-}
-
-/// Helper struct for W3C Trace Context extraction from HashMap
-struct ExtractMap<'a>(&'a std::collections::HashMap<String, String>);
-
-impl<'a> opentelemetry::propagation::Extractor for ExtractMap<'a> {
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).map(|s| s.as_str())
-    }
-
-    fn keys(&self) -> Vec<&str> {
-        self.0.keys().map(|k| k.as_str()).collect()
-    }
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -107,7 +23,7 @@ struct ErrorMeta {
 }
 
 #[must_use]
-pub fn error_meta(
+pub(crate) fn error_meta(
     category: &'static str,
     is_retryable: bool,
     suggested_action: &'static str,
@@ -121,7 +37,7 @@ pub fn error_meta(
 }
 
 #[must_use]
-pub fn err_to_tool_result(e: ErrorData) -> CallToolResult {
+pub(crate) fn err_to_tool_result(e: ErrorData) -> CallToolResult {
     let mut result =
         CallToolResult::error(vec![Content::text(e.message)]).with_meta(Some(no_cache_meta()));
     if let Some(data) = e.data {
@@ -130,7 +46,7 @@ pub fn err_to_tool_result(e: ErrorData) -> CallToolResult {
     result
 }
 
-pub fn no_cache_meta() -> Meta {
+pub(crate) fn no_cache_meta() -> Meta {
     let mut m = serde_json::Map::new();
     m.insert(
         "cache_hint".to_string(),

--- a/crates/aptu-coder/src/tools/edit_overwrite.rs
+++ b/crates/aptu-coder/src/tools/edit_overwrite.rs
@@ -8,11 +8,9 @@ use aptu_coder_core::types::{EditOverwriteOutput, EditOverwriteParams};
 use rmcp::model::{CallToolResult, Content, ErrorData};
 use tracing::instrument;
 
-use crate::{
-    err_to_tool_result, error_meta, no_cache_meta,
-    tools::EditHandlerContext,
-    validation::{validate_path, validate_path_in_dir},
-};
+use crate::tools::EditHandlerContext;
+use crate::tools::common::{err_to_tool_result, error_meta, no_cache_meta};
+use crate::validation::{validate_path, validate_path_in_dir};
 
 #[instrument(skip(params, ctx, span, t_start), fields(path = %params.path))]
 pub(crate) async fn edit_overwrite(

--- a/crates/aptu-coder/src/tools/edit_replace.rs
+++ b/crates/aptu-coder/src/tools/edit_replace.rs
@@ -11,11 +11,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tracing::instrument;
 
-use crate::{
-    err_to_tool_result, error_meta, no_cache_meta,
-    tools::EditHandlerContext,
-    validation::{validate_path, validate_path_in_dir},
-};
+use crate::tools::EditHandlerContext;
+use crate::tools::common::{err_to_tool_result, error_meta, no_cache_meta};
+use crate::validation::{validate_path, validate_path_in_dir};
 
 /// Number of consecutive not_found or ambiguous edit_replace failures on the same
 /// (session_id, canonical_path) pair before returning a stale-context directive error.

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -15,11 +15,11 @@ use tracing::instrument;
 
 use crate::filters::{CompiledRule, apply_filter, maybe_inject_no_stat};
 use crate::metrics::MetricsSender;
+use crate::otel::{ClientMetadata, extract_and_set_trace_context};
 use crate::shell::resolve_shell;
+use crate::tools::common::{err_to_tool_result, error_meta, no_cache_meta};
 use crate::{
-    ClientMetadata, ExecCommandParams, SIZE_LIMIT, STDIN_MAX_BYTES, ShellOutput,
-    err_to_tool_result, error_meta, extract_and_set_trace_context, no_cache_meta, validate_path,
-    validation,
+    ExecCommandParams, SIZE_LIMIT, STDIN_MAX_BYTES, ShellOutput, validate_path, validation,
 };
 
 /// Default drain timeout in milliseconds for post-exit pipe drain (500ms).

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -4,7 +4,7 @@
 
 use rmcp::model::ErrorData;
 
-use crate::error_meta;
+use crate::tools::common::error_meta;
 
 /// Scans a shell command string for unclosed heredocs and file-write heredoc
 /// patterns before any process is spawned.

--- a/crates/aptu-coder/tests/otel_tests.rs
+++ b/crates/aptu-coder/tests/otel_tests.rs
@@ -4,6 +4,8 @@
 use serial_test::serial;
 use std::env;
 
+use aptu_coder::otel::{ClientMetadata, extract_and_set_trace_context};
+
 #[test]
 #[serial]
 fn test_init_otel_no_env_var_returns_none() {
@@ -106,9 +108,9 @@ fn test_traceparent_malformed_no_panic() {
     let meta = rmcp::model::Meta(meta_map);
 
     // Act: call the real extraction function -- must not panic regardless of input
-    aptu_coder::extract_and_set_trace_context(
+    extract_and_set_trace_context(
         Some(&meta),
-        aptu_coder::ClientMetadata {
+        ClientMetadata {
             session_id: None,
             client_name: None,
             client_version: None,
@@ -120,9 +122,9 @@ fn test_traceparent_malformed_no_panic() {
 #[serial]
 fn test_traceparent_missing_meta_no_panic() {
     // Act: None meta must be handled silently
-    aptu_coder::extract_and_set_trace_context(
+    extract_and_set_trace_context(
         None,
-        aptu_coder::ClientMetadata {
+        ClientMetadata {
             session_id: None,
             client_name: None,
             client_version: None,


### PR DESCRIPTION
Closes #1210

## Summary

Demotes six internal tool helpers from `pub` to `pub(crate)` in `tools/common.rs` and removes the corresponding `pub use` re-export block from `lib.rs`. Moves `ClientMetadata` and `extract_and_set_trace_context` into the existing `pub mod otel` where they semantically belong, giving integration tests a stable import path via `aptu_coder::otel`.

Removes three stale `#[allow(dead_code)]` suppressors carried over from the old `tools/common.rs` location. Fixes the underlying clippy warning by replacing `mod otel` in `main.rs` with `use aptu_coder::otel` so the binary shares the library module and all pub symbols are reachable across all compilation targets.

## Changes

- `crates/aptu-coder/src/otel.rs`: add `ClientMetadata`, `extract_and_set_trace_context`, `ExtractMap` (moved from `tools/common.rs`); remove stale `#[allow(dead_code)]` suppressors
- `crates/aptu-coder/src/tools/common.rs`: remove the two moved symbols; update doc comment
- `crates/aptu-coder/src/lib.rs`: remove `pub use tools::common::{...}` block; import `ClientMetadata` and `extract_and_set_trace_context` from `crate::otel`
- `crates/aptu-coder/src/tools/exec_command.rs`: import `ClientMetadata` and `extract_and_set_trace_context` from `crate::otel`
- `crates/aptu-coder/src/validation.rs`: import `error_meta` from `crate::tools::common`
- `crates/aptu-coder/src/tests.rs`: import `summary_cursor_conflict` from `crate::tools::common`
- `crates/aptu-coder/tests/otel_tests.rs`: update import to `aptu_coder::otel::{ClientMetadata, extract_and_set_trace_context}`
- `crates/aptu-coder/src/main.rs`: replace `mod otel` with `use aptu_coder::otel` so the binary reuses the library module

## Test plan

- [x] Tests pass
- [x] Linter clean
- [x] Security scan clean
