### PR TITLE
chore: post-M17 cleanup - remove progress notifications, dedup validators and helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ For richer analysis, use `python scripts/mcp-metrics.py --help`.
 
 ## API verification (critical)
 
-Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. **Read `crates/aptu-coder/src/lib.rs` before adding or modifying any tool** -- it is the authoritative reference for tool handler patterns. Path validation logic lives in `src/validation.rs`; shell detection in `src/shell.rs`; exec output filtering (built-in rules, project-local `.aptu/filters.toml`, `schema_version` enforcement) in `src/filters.rs`. Read the relevant module before touching those subsystems.
+Do not rely on training data for `rmcp`, `schemars`, or `thiserror` APIs. **Post-M17, `crates/aptu-coder/src/lib.rs` is shim-only** (MCP wiring, `#[tool(...)]` decorators, thin forwarding calls). Tool handler logic lives in `crates/aptu-coder/src/tools/<tool>.rs` -- read the relevant handler file before adding or modifying any tool. Path validation logic lives in `src/validation.rs`; shell detection in `src/shell.rs`; exec output filtering (built-in rules, project-local `.aptu/filters.toml`, `schema_version` enforcement) in `src/filters.rs`. Read the relevant module before touching those subsystems.
 
 ## Integration tests
 

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -147,8 +147,6 @@ use filters::{apply_filter, maybe_inject_no_stat};
 use logging::LogEvent;
 use rmcp::handler::server::tool::{ToolRouter, schema_for_type};
 use rmcp::handler::server::wrapper::Parameters;
-#[cfg(test)]
-use rmcp::model::ProgressToken;
 use rmcp::model::{
     CallToolResult, CancelledNotificationParam, CompleteRequestParams, CompleteResult,
     CompletionInfo, Content, ErrorData, Implementation, InitializeRequestParams, InitializeResult,
@@ -258,7 +256,6 @@ impl CodeAnalyzer {
         &self,
         params: &AnalyzeDirectoryParams,
         ct: tokio_util::sync::CancellationToken,
-        progress_token: Option<ProgressToken>,
     ) -> Result<(std::sync::Arc<analyze::AnalysisOutput>, CacheTier), ErrorData> {
         let ctx = crate::tools::AnalyzeDirectoryContext {
             cache: self.cache.clone(),
@@ -267,7 +264,7 @@ impl CodeAnalyzer {
             peer: self.peer.clone(),
             sid: self.session_id.lock().await.clone(),
         };
-        crate::tools::server::handle_overview_mode(&ctx, params, ct, progress_token).await
+        crate::tools::server::handle_overview_mode(&ctx, params, ct).await
     }
 
     /// Delegates to [`tools::server::handle_file_details_mode`].
@@ -285,36 +282,6 @@ impl CodeAnalyzer {
             params,
         )
         .await
-    }
-
-    /// Forwarding shim for tests that call `analyzer.emit_progress(...)` directly.
-    #[cfg(test)]
-    pub(crate) async fn emit_progress(
-        &self,
-        peer: Option<rmcp::Peer<rmcp::RoleServer>>,
-        token: &rmcp::model::ProgressToken,
-        progress: f64,
-        total: f64,
-        message: String,
-    ) {
-        crate::tools::server::emit_progress(peer, token, progress, total, message).await
-    }
-
-    /// Forwarding shim for tests that call `CodeAnalyzer::validate_impl_only` directly.
-    #[cfg(test)]
-    pub(crate) fn validate_impl_only(
-        entries: &[aptu_coder_core::traversal::WalkEntry],
-    ) -> Result<(), rmcp::model::ErrorData> {
-        crate::tools::server::validate_impl_only(entries)
-    }
-
-    /// Forwarding shim for tests that call `CodeAnalyzer::validate_import_lookup` directly.
-    #[cfg(test)]
-    pub(crate) fn validate_import_lookup(
-        import_lookup: Option<bool>,
-        symbol: &str,
-    ) -> Result<(), rmcp::model::ErrorData> {
-        crate::tools::server::validate_import_lookup(import_lookup, symbol)
     }
 
     #[instrument(skip(self, context), fields(gen_ai.system = tracing::field::Empty, gen_ai.operation.name = tracing::field::Empty, gen_ai.tool.name = tracing::field::Empty, error = tracing::field::Empty, error.type = tracing::field::Empty, path = tracing::field::Empty, mcp.session.id = tracing::field::Empty, client.name = tracing::field::Empty, client.version = tracing::field::Empty, mcp.client.session.id = tracing::field::Empty, cache_tier = tracing::field::Empty))]
@@ -367,7 +334,6 @@ impl CodeAnalyzer {
         let ct = context.ct.clone();
         let param_path = params.path.clone();
         let max_depth_val = params.max_depth;
-        let progress_token = context.meta.get_progress_token();
         let ctx = tools::AnalyzeDirectoryContext {
             cache: self.cache.clone(),
             disk_cache: self.disk_cache.clone(),
@@ -385,7 +351,6 @@ impl CodeAnalyzer {
                 param_path,
                 max_depth_val,
                 ct,
-                progress_token,
             },
             &span,
         )
@@ -508,10 +473,8 @@ impl CodeAnalyzer {
             sid: sid.clone(),
             seq,
         };
-        let progress_token = context.meta.get_progress_token();
         let call = tools::AnalyzeSymbolCall {
             ct,
-            progress_token,
             param_path,
             max_depth_val,
             span,

--- a/crates/aptu-coder/src/tests.rs
+++ b/crates/aptu-coder/src/tests.rs
@@ -5,26 +5,6 @@ use crate::tools::exec_command::{build_exec_command, handle_output_persist, stri
 use crate::validation::validate_path_in_dir;
 use aptu_coder_core::traversal;
 use regex::Regex;
-use rmcp::model::NumberOrString;
-
-#[tokio::test]
-async fn test_emit_progress_none_peer_is_noop() {
-    let peer = Arc::new(TokioMutex::new(None));
-    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
-    let analyzer = CodeAnalyzer::new(
-        peer,
-        log_level_filter,
-        rx,
-        crate::metrics::MetricsSender(metrics_tx),
-    );
-    let token = ProgressToken(NumberOrString::String("test".into()));
-    // Should complete without panic
-    analyzer
-        .emit_progress(None, &token, 0.0, 10.0, "test".to_string())
-        .await;
-}
 
 fn make_analyzer() -> CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
@@ -59,7 +39,7 @@ async fn test_validate_impl_only_non_rust_returns_invalid_params() {
     // We use handle_focused_mode which calls validate_impl_only internally.
     let entries: Vec<traversal::WalkEntry> =
         traversal::walk_directory(dir.path(), None).unwrap_or_default();
-    let result = CodeAnalyzer::validate_impl_only(&entries);
+    let result = crate::tools::analyze_symbol::validate_impl_only(&entries);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
@@ -68,7 +48,7 @@ async fn test_validate_impl_only_non_rust_returns_invalid_params() {
 
 #[tokio::test]
 async fn test_no_cache_meta_on_analyze_directory_result() {
-    use aptu_coder_core::types::{AnalyzeDirectoryParams, OutputControlParams, PaginationParams};
+    use aptu_coder_core::types::AnalyzeDirectoryParams;
     use tempfile::TempDir;
 
     let dir = TempDir::new().unwrap();
@@ -80,10 +60,7 @@ async fn test_no_cache_meta_on_analyze_directory_result() {
     }))
     .unwrap();
     let ct = tokio_util::sync::CancellationToken::new();
-    let (arc_output, _cache_hit) = analyzer
-        .handle_overview_mode(&params, ct, None)
-        .await
-        .unwrap();
+    let (arc_output, _cache_hit) = analyzer.handle_overview_mode(&params, ct).await.unwrap();
     // Verify the no_cache_meta shape by constructing it directly and checking the shape
     let meta = no_cache_meta();
     assert_eq!(
@@ -133,10 +110,7 @@ async fn test_handle_overview_mode_no_summary_block() {
     .unwrap();
 
     let ct = tokio_util::sync::CancellationToken::new();
-    let (output, _cache_hit) = analyzer
-        .handle_overview_mode(&params, ct, None)
-        .await
-        .unwrap();
+    let (output, _cache_hit) = analyzer.handle_overview_mode(&params, ct).await.unwrap();
 
     // summary=None with small output: handler uses format_structure (tree), which is
     // already stored in output.formatted from build_analysis_output.
@@ -190,10 +164,7 @@ async fn test_analyze_directory_summary_false_forces_pagination() {
 
     // Act: call the full handler via handle_overview_mode + replicate handler path
     let ct = tokio_util::sync::CancellationToken::new();
-    let (output, _cache_hit) = analyzer
-        .handle_overview_mode(&params, ct, None)
-        .await
-        .unwrap();
+    let (output, _cache_hit) = analyzer.handle_overview_mode(&params, ct).await.unwrap();
 
     // Assert: output is small (confirms SIZE_LIMIT would not trigger auto-summary)
     assert!(
@@ -225,7 +196,7 @@ async fn test_analyze_directory_summary_false_forces_pagination() {
 
 #[tokio::test]
 async fn test_analyze_directory_cache_hit_metrics() {
-    use aptu_coder_core::types::{AnalyzeDirectoryParams, OutputControlParams, PaginationParams};
+    use aptu_coder_core::types::AnalyzeDirectoryParams;
     use tempfile::TempDir;
 
     // Arrange: a temp dir with one file
@@ -239,17 +210,11 @@ async fn test_analyze_directory_cache_hit_metrics() {
 
     // Act: first call (cache miss)
     let ct1 = tokio_util::sync::CancellationToken::new();
-    let (_out1, hit1) = analyzer
-        .handle_overview_mode(&params, ct1, None)
-        .await
-        .unwrap();
+    let (_out1, hit1) = analyzer.handle_overview_mode(&params, ct1).await.unwrap();
 
     // Act: second call (cache hit)
     let ct2 = tokio_util::sync::CancellationToken::new();
-    let (_out2, hit2) = analyzer
-        .handle_overview_mode(&params, ct2, None)
-        .await
-        .unwrap();
+    let (_out2, hit2) = analyzer.handle_overview_mode(&params, ct2).await.unwrap();
 
     // Assert
     assert_eq!(hit1, CacheTier::Miss, "first call must be a cache miss");
@@ -293,7 +258,7 @@ fn test_analyze_symbol_import_lookup_invalid_params() {
     // Arrange: empty symbol with import_lookup=true (violates the guard:
     // symbol must hold the module path when import_lookup=true).
     // Act: call the validate helper directly (same pattern as validate_impl_only).
-    let result = CodeAnalyzer::validate_import_lookup(Some(true), "");
+    let result = crate::tools::analyze_symbol::validate_import_lookup(Some(true), "");
 
     // Assert: INVALID_PARAMS is returned.
     assert!(
@@ -427,7 +392,7 @@ async fn test_analyze_directory_git_ref_filters_changed_files() {
 
 #[tokio::test]
 async fn test_handle_overview_mode_git_ref_filters_via_handler() {
-    use aptu_coder_core::types::{AnalyzeDirectoryParams, OutputControlParams, PaginationParams};
+    use aptu_coder_core::types::AnalyzeDirectoryParams;
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -506,7 +471,7 @@ async fn test_handle_overview_mode_git_ref_filters_via_handler() {
     .unwrap();
     let ct = tokio_util::sync::CancellationToken::new();
     let (arc_output, _cache_hit) = analyzer
-        .handle_overview_mode(&params, ct, None)
+        .handle_overview_mode(&params, ct)
         .await
         .expect("handle_overview_mode with git_ref must succeed");
 
@@ -1906,32 +1871,6 @@ fn test_metric_chars_threshold_breach_no_fire() {
     assert!(
         !event.chars_threshold_breach,
         "chars_threshold_breach should be false for output_chars=5000"
-    );
-}
-
-// ── Progress token gating and watch channel tests ──
-
-/// When no progressToken is present, handle_overview_mode skips all progress
-/// machinery (no peer lock acquisition for progress, no watch channel, no
-/// emit_progress calls) and returns the analysis result directly.
-#[tokio::test]
-async fn test_progress_bypassed_when_no_token() {
-    use tempfile::TempDir;
-
-    let dir = TempDir::new().unwrap();
-    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}").unwrap();
-    let analyzer = make_analyzer();
-    let params: AnalyzeDirectoryParams = serde_json::from_value(serde_json::json!({
-        "path": dir.path().to_str().unwrap(),
-    }))
-    .unwrap();
-    let ct = tokio_util::sync::CancellationToken::new();
-
-    // Act: call with None progress_token -- must complete without error.
-    let result = analyzer.handle_overview_mode(&params, ct, None).await;
-    assert!(
-        result.is_ok(),
-        "handle_overview_mode with None token must succeed"
     );
 }
 

--- a/crates/aptu-coder/src/tools/analyze_directory.rs
+++ b/crates/aptu-coder/src/tools/analyze_directory.rs
@@ -13,12 +13,10 @@ use aptu_coder_core::traversal::{
     WalkEntry, changed_files_from_git_ref, filter_entries_by_git_ref, walk_directory,
 };
 use aptu_coder_core::types::{AnalysisMode, AnalyzeDirectoryParams};
-use rmcp::model::{CallToolResult, Content, ErrorData, ProgressToken};
-use rmcp::{Peer, RoleServer};
+use rmcp::model::{CallToolResult, Content, ErrorData};
 use serde_json::Value;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::watch;
 use tracing::instrument;
 
 use crate::SIZE_LIMIT;
@@ -26,29 +24,6 @@ use crate::tools::common::{
     err_to_tool_result, error_meta, no_cache_meta, summary_cursor_conflict,
 };
 use crate::tools::{AnalyzeDirectoryContext, DirectoryHandlerCall};
-
-/// Emit a progress notification to the MCP client peer.
-async fn emit_progress_notification(
-    peer: Option<Peer<RoleServer>>,
-    token: &ProgressToken,
-    progress: f64,
-    total: f64,
-    message: String,
-) {
-    if let Some(peer) = peer {
-        let notification = rmcp::model::ServerNotification::ProgressNotification(
-            rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
-                progress_token: token.clone(),
-                progress,
-                total: Some(total),
-                message: Some(message),
-            }),
-        );
-        if let Err(e) = peer.send_notification(notification).await {
-            tracing::warn!("Failed to send progress notification: {}", e);
-        }
-    }
-}
 
 /// Core analysis logic for the `analyze_directory` tool (overview mode).
 ///
@@ -59,7 +34,6 @@ pub(crate) async fn handle_overview_mode(
     ctx: &AnalyzeDirectoryContext,
     params: &AnalyzeDirectoryParams,
     ct: tokio_util::sync::CancellationToken,
-    progress_token: Option<ProgressToken>,
 ) -> Result<(Arc<analyze::AnalysisOutput>, CacheTier), ErrorData> {
     let path = Path::new(&params.path);
     let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -163,7 +137,6 @@ pub(crate) async fn handle_overview_mode(
         all_entries
     };
 
-    let total_files = entries.iter().filter(|e| !e.is_dir).count();
     let path_owned = std::path::PathBuf::from(&params.path);
     let counter_clone = counter.clone();
     let ct_clone = ct.clone();
@@ -171,72 +144,6 @@ pub(crate) async fn handle_overview_mode(
     let handle = tokio::task::spawn_blocking(move || {
         analyze::analyze_directory_with_progress(&path_owned, entries, counter_clone, ct_clone)
     });
-
-    // Drive progress notifications while the blocking task runs.
-    if let Some(ref token) = progress_token {
-        let (tx, mut rx) = watch::channel(0usize);
-        let peer = ctx.peer.lock().await.clone();
-        let mut last_progress = 0usize;
-        let mut cancelled = false;
-
-        let counter_notify = counter.clone();
-        let tx_notify = tx.clone();
-        let ct_notify = ct.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                if ct_notify.is_cancelled() {
-                    break;
-                }
-                let current = counter_notify.load(std::sync::atomic::Ordering::Relaxed);
-                if tx_notify.send(current).is_err() {
-                    break;
-                }
-            }
-        });
-
-        loop {
-            tokio::select! {
-                _ = ct.cancelled() => {
-                    cancelled = true;
-                    break;
-                }
-                changed = rx.changed() => {
-                    match changed {
-                        Ok(()) => {
-                            let current = *rx.borrow();
-                            if current != last_progress && total_files > 0 {
-                                emit_progress_notification(
-                                    peer.clone(),
-                                    token,
-                                    current as f64,
-                                    total_files as f64,
-                                    format!("Analyzing {current}/{total_files} files"),
-                                )
-                                .await;
-                                last_progress = current;
-                            }
-                        }
-                        Err(_) => break,
-                    }
-                }
-            }
-            if handle.is_finished() {
-                break;
-            }
-        }
-
-        if !cancelled && total_files > 0 {
-            emit_progress_notification(
-                peer,
-                token,
-                total_files as f64,
-                total_files as f64,
-                format!("Completed analyzing {total_files} files"),
-            )
-            .await;
-        }
-    }
 
     match handle.await {
         Ok(Ok(mut output)) => {
@@ -313,17 +220,15 @@ pub(crate) async fn analyze_directory_handler(
         param_path,
         max_depth_val,
         ct,
-        progress_token,
     } = call;
-    let (arc_output, dir_cache_hit) =
-        match handle_overview_mode(ctx, &params, ct, progress_token).await {
-            Ok(v) => v,
-            Err(e) => {
-                span.record("error", true);
-                span.record("error.type", "internal_error");
-                return Ok(err_to_tool_result(e));
-            }
-        };
+    let (arc_output, dir_cache_hit) = match handle_overview_mode(ctx, &params, ct).await {
+        Ok(v) => v,
+        Err(e) => {
+            span.record("error", true);
+            span.record("error.type", "internal_error");
+            return Ok(err_to_tool_result(e));
+        }
+    };
 
     let mut output = match Arc::try_unwrap(arc_output) {
         Ok(owned) => owned,

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -16,11 +16,10 @@ use aptu_coder_core::traversal::{
     WalkEntry, changed_files_from_git_ref, filter_entries_by_git_ref, walk_directory,
 };
 use aptu_coder_core::types::{AnalyzeSymbolParams, SymbolMatchMode};
-use rmcp::model::{CallToolResult, Content, ErrorData, Meta, ProgressToken};
+use rmcp::model::{CallToolResult, Content, ErrorData, Meta};
 use serde_json::Value;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::watch;
 use tracing::instrument;
 
 use crate::tools::common::{
@@ -34,6 +33,8 @@ use crate::{SIZE_LIMIT, err_to_tool_result_from_pagination};
 /// explicit without coupling to `&self`.
 pub(crate) struct AnalyzeSymbolContext {
     pub(crate) metrics_tx: crate::metrics::MetricsSender,
+    // Retained for log-level notification infrastructure (separate active feature).
+    #[allow(dead_code)]
     pub(crate) peer: Arc<tokio::sync::Mutex<Option<rmcp::Peer<rmcp::RoleServer>>>>,
     pub(crate) call_graph_cache: CallGraphCache,
     pub(crate) disk_cache: Arc<aptu_coder_core::cache::DiskCache>,
@@ -49,7 +50,6 @@ struct FocusedAnalysisParams {
     match_mode: SymbolMatchMode,
     follow_depth: u32,
     max_depth: Option<u32>,
-    use_summary: bool,
     impl_only: Option<bool>,
     def_use: bool,
     parse_timeout_micros: Option<u64>,
@@ -153,208 +153,56 @@ fn paginate_focus_chains(
     Ok((paginated.items, next))
 }
 
-/// Public test wrapper for `emit_progress_notification`.
-#[cfg(test)]
-pub(crate) async fn emit_progress_notification_pub(
-    peer: Option<rmcp::Peer<rmcp::RoleServer>>,
-    token: &ProgressToken,
-    progress: f64,
-    total: f64,
-    message: String,
-) {
-    emit_progress_notification(peer, token, progress, total, message).await;
-}
-
-/// Emit a progress notification to the MCP client peer.
-async fn emit_progress_notification(
-    peer: Option<rmcp::Peer<rmcp::RoleServer>>,
-    token: &ProgressToken,
-    progress: f64,
-    total: f64,
-    message: String,
-) {
-    if let Some(peer) = peer {
-        let notification = rmcp::model::ServerNotification::ProgressNotification(
-            rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
-                progress_token: token.clone(),
-                progress,
-                total: Some(total),
-                message: Some(message),
-            }),
-        );
-        if let Err(e) = peer.send_notification(notification).await {
-            tracing::warn!("Failed to send progress notification: {}", e);
-        }
-    }
-}
-
-/// Poll progress until the analysis task completes.
-#[allow(clippy::cast_precision_loss, clippy::too_many_arguments)]
-async fn poll_progress_until_done(
-    ctx: &AnalyzeSymbolContext,
-    analysis_params: &FocusedAnalysisParams,
-    counter: Arc<std::sync::atomic::AtomicUsize>,
-    ct: tokio_util::sync::CancellationToken,
-    entries: Arc<Vec<WalkEntry>>,
-    total_files: usize,
-    symbol_display: &str,
-    progress_token: Option<ProgressToken>,
-) -> Result<analyze::FocusedAnalysisOutput, ErrorData> {
-    let counter_clone = counter.clone();
-    let ct_clone = ct.clone();
-    let entries_clone = Arc::clone(&entries);
-    let path_owned = analysis_params.path.clone();
-    let symbol_owned = analysis_params.symbol.clone();
-    let match_mode_owned = analysis_params.match_mode.clone();
-    let follow_depth = analysis_params.follow_depth;
-    let max_depth = analysis_params.max_depth;
-    let use_summary = analysis_params.use_summary;
-    let impl_only = analysis_params.impl_only;
-    let def_use = analysis_params.def_use;
-    let parse_timeout_micros = analysis_params.parse_timeout_micros;
-    let handle = tokio::task::spawn_blocking(move || {
-        let params = analyze::FocusedAnalysisConfig {
-            focus: symbol_owned,
-            match_mode: match_mode_owned,
-            follow_depth,
-            max_depth,
-            ast_recursion_limit: None,
-            use_summary,
-            impl_only,
-            def_use,
-            parse_timeout_micros,
-        };
-        analyze::analyze_focused_with_progress_with_entries(
-            &path_owned,
-            &params,
-            &counter_clone,
-            &ct_clone,
-            &entries_clone,
-        )
-    });
-
-    // Gate progress on client-supplied token; skip all machinery when absent.
-    if let Some(ref token) = progress_token {
-        let (tx, mut rx) = watch::channel(0usize);
-        let peer = ctx.peer.lock().await.clone();
-        let mut last_progress = 0usize;
-        let mut cancelled = false;
-
-        // Spawn a notifier that watches the counter and sends on the watch channel.
-        let counter_notify = counter.clone();
-        let tx_notify = tx.clone();
-        let ct_notify = ct.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                if ct_notify.is_cancelled() {
-                    break;
-                }
-                let current = counter_notify.load(std::sync::atomic::Ordering::Relaxed);
-                if tx_notify.send(current).is_err() {
-                    break; // receiver dropped
-                }
-            }
-        });
-
-        loop {
-            tokio::select! {
-                _ = ct.cancelled() => {
-                    cancelled = true;
-                    break;
-                }
-                changed = rx.changed() => {
-                    match changed {
-                        Ok(()) => {
-                            let current = *rx.borrow();
-                            if current != last_progress && total_files > 0 {
-                                emit_progress_notification(
-                                    peer.clone(),
-                                    token,
-                                    current as f64,
-                                    total_files as f64,
-                                    format!(
-                                        "Analyzing {current}/{total_files} files for symbol '{symbol_display}'"
-                                    ),
-                                )
-                                .await;
-                                last_progress = current;
-                            }
-                        }
-                        Err(_) => {
-                            // Sender dropped: analysis complete or notifier exited.
-                            break;
-                        }
-                    }
-                }
-            }
-            if handle.is_finished() {
-                break;
-            }
-        }
-
-        if !cancelled && total_files > 0 {
-            emit_progress_notification(
-                peer.clone(),
-                token,
-                total_files as f64,
-                total_files as f64,
-                format!("Completed analyzing {total_files} files for symbol '{symbol_display}'"),
-            )
-            .await;
-        }
-    }
-
-    match handle.await {
-        Ok(Ok(output)) => Ok(output),
-        Ok(Err(analyze::AnalyzeError::Cancelled)) => Err(ErrorData::new(
-            rmcp::model::ErrorCode::INTERNAL_ERROR,
-            "Analysis cancelled".to_string(),
-            Some(error_meta("transient", true, "analysis was cancelled")),
-        )),
-        Ok(Err(e)) => Err(ErrorData::new(
-            rmcp::model::ErrorCode::INTERNAL_ERROR,
-            format!("Error analyzing symbol: {e}"),
-            Some(error_meta("resource", false, "check symbol name and file")),
-        )),
-        Err(e) => Err(ErrorData::new(
-            rmcp::model::ErrorCode::INTERNAL_ERROR,
-            format!("Task join error: {e}"),
-            Some(error_meta("transient", true, "retry the request")),
-        )),
-    }
-}
-
 /// Run focused analysis with auto-summary retry on SIZE_LIMIT overflow.
-#[allow(clippy::too_many_arguments)]
 async fn run_focused_with_auto_summary(
-    ctx: &AnalyzeSymbolContext,
+    _ctx: &AnalyzeSymbolContext,
     params: &AnalyzeSymbolParams,
     analysis_params: &FocusedAnalysisParams,
     counter: Arc<std::sync::atomic::AtomicUsize>,
     ct: tokio_util::sync::CancellationToken,
     entries: Arc<Vec<WalkEntry>>,
-    total_files: usize,
-    progress_token: Option<ProgressToken>,
 ) -> Result<analyze::FocusedAnalysisOutput, ErrorData> {
     let use_summary_for_task = params.output_control.summary == Some(true);
 
-    let analysis_params_initial = FocusedAnalysisParams {
+    let config_initial = analyze::FocusedAnalysisConfig {
+        focus: analysis_params.symbol.clone(),
+        match_mode: analysis_params.match_mode.clone(),
+        follow_depth: analysis_params.follow_depth,
+        max_depth: analysis_params.max_depth,
+        ast_recursion_limit: None,
         use_summary: use_summary_for_task,
-        ..analysis_params.clone()
+        impl_only: analysis_params.impl_only,
+        def_use: analysis_params.def_use,
+        parse_timeout_micros: analysis_params.parse_timeout_micros,
     };
 
-    let mut output = poll_progress_until_done(
-        ctx,
-        &analysis_params_initial,
-        counter.clone(),
-        ct.clone(),
-        entries.clone(),
-        total_files,
-        &params.symbol,
-        progress_token.clone(),
-    )
-    .await?;
+    let mut output = tokio::task::spawn_blocking({
+        let path = analysis_params.path.clone();
+        let entries = entries.clone();
+        let counter = counter.clone();
+        let ct = ct.clone();
+        let config = config_initial.clone();
+        move || {
+            analyze::analyze_focused_with_progress_with_entries(
+                &path, &config, &counter, &ct, &entries,
+            )
+        }
+    })
+    .await
+    .map_err(|e| {
+        ErrorData::new(
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            format!("analysis task panicked: {e}"),
+            None,
+        )
+    })?
+    .map_err(|e| {
+        ErrorData::new(
+            rmcp::model::ErrorCode::INTERNAL_ERROR,
+            format!("analysis failed: {e}"),
+            None,
+        )
+    })?;
 
     if params.output_control.summary.is_none() && output.formatted.len() > SIZE_LIMIT {
         tracing::debug!(
@@ -362,23 +210,28 @@ async fn run_focused_with_auto_summary(
             message = "output exceeded size limit, retrying with summary"
         );
         let counter2 = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let analysis_params_retry = FocusedAnalysisParams {
+        let config_retry = analyze::FocusedAnalysisConfig {
             use_summary: true,
-            ..analysis_params.clone()
+            ..config_initial
         };
-        let summary_result = poll_progress_until_done(
-            ctx,
-            &analysis_params_retry,
-            counter2,
-            ct,
-            entries,
-            total_files,
-            &params.symbol,
-            progress_token,
-        )
-        .await;
+        let summary_result = tokio::task::spawn_blocking({
+            let path = analysis_params.path.clone();
+            let entries = entries.clone();
+            move || {
+                analyze::analyze_focused_with_progress_with_entries(
+                    &path,
+                    &config_retry,
+                    &counter2,
+                    &ct,
+                    &entries,
+                )
+            }
+        })
+        .await
+        .ok()
+        .and_then(|r| r.ok());
 
-        if let Ok(summary_output) = summary_result {
+        if let Some(summary_output) = summary_result {
             output.formatted = summary_output.formatted;
         } else {
             let estimated_tokens = output.formatted.len() / 4;
@@ -427,7 +280,6 @@ async fn handle_focused_mode(
     ctx: &AnalyzeSymbolContext,
     params: &AnalyzeSymbolParams,
     ct: tokio_util::sync::CancellationToken,
-    progress_token: Option<ProgressToken>,
 ) -> Result<(CacheTier, analyze::FocusedAnalysisOutput), ErrorData> {
     let path = Path::new(&params.path);
     let raw_entries = match walk_directory(path, params.max_depth) {
@@ -541,7 +393,6 @@ async fn handle_focused_mode(
         return Ok((CacheTier::L2Disk, cached));
     }
 
-    let total_files = entries.iter().filter(|e| !e.is_dir).count();
     let counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     let analysis_params = FocusedAnalysisParams {
@@ -550,23 +401,13 @@ async fn handle_focused_mode(
         match_mode: params.match_mode.clone().unwrap_or_default(),
         follow_depth: params.follow_depth.unwrap_or(1),
         max_depth: params.max_depth,
-        use_summary: false,
         impl_only: params.impl_only,
         def_use: params.def_use.unwrap_or(false),
         parse_timeout_micros: None,
     };
 
-    let mut output = run_focused_with_auto_summary(
-        ctx,
-        params,
-        &analysis_params,
-        counter,
-        ct,
-        entries,
-        total_files,
-        progress_token,
-    )
-    .await?;
+    let mut output =
+        run_focused_with_auto_summary(ctx, params, &analysis_params, counter, ct, entries).await?;
 
     if params.impl_only == Some(true) {
         let filter_line = format!(
@@ -895,17 +736,15 @@ async fn handle_call_graph(
     let sid = ctx.sid.clone();
     let seq = ctx.seq;
     let ct = call.ct;
-    let progress_token = call.progress_token;
     let param_path = call.param_path;
     let max_depth_val = call.max_depth_val;
     let t_start = call.t_start;
 
     // Call handler for analysis and progress tracking
-    let (graph_cache_tier, mut output) =
-        match handle_focused_mode(&ctx, &params, ct, progress_token).await {
-            Ok(v) => v,
-            Err(e) => return Ok(err_to_tool_result(e)),
-        };
+    let (graph_cache_tier, mut output) = match handle_focused_mode(&ctx, &params, ct).await {
+        Ok(v) => v,
+        Err(e) => return Ok(err_to_tool_result(e)),
+    };
 
     // Surface cache tier in structuredContent for observability and testing.
     output.cache_tier = Some(graph_cache_tier.as_str().to_owned());

--- a/crates/aptu-coder/src/tools/mod.rs
+++ b/crates/aptu-coder/src/tools/mod.rs
@@ -78,6 +78,8 @@ pub(crate) struct AnalyzeDirectoryContext {
     pub(crate) cache: AnalysisCache,
     pub(crate) disk_cache: Arc<aptu_coder_core::cache::DiskCache>,
     pub(crate) metrics_tx: crate::metrics::MetricsSender,
+    // Retained for log-level notification infrastructure (separate active feature).
+    #[allow(dead_code)]
     pub(crate) peer: Arc<tokio::sync::Mutex<Option<rmcp::Peer<rmcp::RoleServer>>>>,
     pub(crate) sid: Option<String>,
 }
@@ -93,7 +95,6 @@ pub(crate) struct DirectoryHandlerCall {
     pub(crate) param_path: String,
     pub(crate) max_depth_val: Option<u32>,
     pub(crate) ct: tokio_util::sync::CancellationToken,
-    pub(crate) progress_token: Option<rmcp::model::ProgressToken>,
 }
 
 /// Shared handler context passed to extracted `analyze_file` free functions.
@@ -113,7 +114,6 @@ pub(crate) struct AnalyzeFileContext {
 /// `clippy::too_many_arguments` (7 args max).
 pub(crate) struct AnalyzeSymbolCall {
     pub(crate) ct: tokio_util::sync::CancellationToken,
-    pub(crate) progress_token: Option<rmcp::model::ProgressToken>,
     pub(crate) param_path: String,
     pub(crate) max_depth_val: Option<u32>,
     pub(crate) span: tracing::Span,

--- a/crates/aptu-coder/src/tools/server.rs
+++ b/crates/aptu-coder/src/tools/server.rs
@@ -272,7 +272,6 @@ pub(crate) async fn handle_overview_mode(
     ctx: &crate::tools::AnalyzeDirectoryContext,
     params: &aptu_coder_core::types::AnalyzeDirectoryParams,
     ct: tokio_util::sync::CancellationToken,
-    progress_token: Option<rmcp::model::ProgressToken>,
 ) -> Result<
     (
         std::sync::Arc<aptu_coder_core::analyze::AnalysisOutput>,
@@ -280,7 +279,7 @@ pub(crate) async fn handle_overview_mode(
     ),
     rmcp::model::ErrorData,
 > {
-    crate::tools::analyze_directory::handle_overview_mode(ctx, params, ct, progress_token).await
+    crate::tools::analyze_directory::handle_overview_mode(ctx, params, ct).await
 }
 
 /// Delegates to [`crate::tools::analyze_file::handle_file_details_mode`].
@@ -305,45 +304,4 @@ pub(crate) async fn handle_file_details_mode(
         sid,
     };
     crate::tools::analyze_file::handle_file_details_mode(&ctx, params).await
-}
-
-/// Forwarding shim for tests that call `analyzer.emit_progress(...)` directly.
-#[cfg(test)]
-pub(crate) async fn emit_progress(
-    peer: Option<rmcp::Peer<rmcp::RoleServer>>,
-    token: &rmcp::model::ProgressToken,
-    progress: f64,
-    total: f64,
-    message: String,
-) {
-    if let Some(peer) = peer {
-        let notification = rmcp::model::ServerNotification::ProgressNotification(
-            rmcp::model::Notification::new(rmcp::model::ProgressNotificationParam {
-                progress_token: token.clone(),
-                progress,
-                total: Some(total),
-                message: Some(message),
-            }),
-        );
-        if let Err(e) = peer.send_notification(notification).await {
-            tracing::warn!("Failed to send progress notification: {}", e);
-        }
-    }
-}
-
-/// Forwarding shim for tests that call `validate_impl_only` directly.
-#[cfg(test)]
-pub(crate) fn validate_impl_only(
-    entries: &[aptu_coder_core::traversal::WalkEntry],
-) -> Result<(), rmcp::model::ErrorData> {
-    crate::tools::analyze_symbol::validate_impl_only(entries)
-}
-
-/// Forwarding shim for tests that call `validate_import_lookup` directly.
-#[cfg(test)]
-pub(crate) fn validate_import_lookup(
-    import_lookup: Option<bool>,
-    symbol: &str,
-) -> Result<(), rmcp::model::ErrorData> {
-    crate::tools::analyze_symbol::validate_import_lookup(import_lookup, symbol)
 }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -9,6 +9,22 @@ async fn call_exec_command_raw(params: serde_json::Value) -> serde_json::Value {
     call_tool_raw("exec_command", params).await
 }
 
+fn truncate_output(output: &str, max_lines: usize, max_bytes: usize) -> (String, bool) {
+    let lines: Vec<&str> = output.lines().collect();
+
+    let output_to_use = if lines.len() > max_lines {
+        lines[..max_lines].join("\n")
+    } else {
+        output.to_string()
+    };
+
+    if output_to_use.len() > max_bytes {
+        (output_to_use[..max_bytes].to_string(), true)
+    } else {
+        (output_to_use, lines.len() > max_lines)
+    }
+}
+
 #[tokio::test]
 async fn exec_command_happy_path() {
     // Arrange: prepare a simple echo command
@@ -170,23 +186,6 @@ async fn exec_command_output_truncation() {
 
 #[test]
 fn test_truncate_output_by_lines() {
-    // Helper function to test truncation logic
-    fn truncate_output(output: &str, max_lines: usize, max_bytes: usize) -> (String, bool) {
-        let lines: Vec<&str> = output.lines().collect();
-
-        let output_to_use = if lines.len() > max_lines {
-            lines[..max_lines].join("\n")
-        } else {
-            output.to_string()
-        };
-
-        if output_to_use.len() > max_bytes {
-            (output_to_use[..max_bytes].to_string(), true)
-        } else {
-            (output_to_use, lines.len() > max_lines)
-        }
-    }
-
     // Arrange: create output with 2500 lines
     let output = (1..=2500)
         .map(|i| i.to_string())
@@ -204,23 +203,6 @@ fn test_truncate_output_by_lines() {
 
 #[test]
 fn test_truncate_output_by_bytes() {
-    // Helper function to test truncation logic
-    fn truncate_output(output: &str, max_lines: usize, max_bytes: usize) -> (String, bool) {
-        let lines: Vec<&str> = output.lines().collect();
-
-        let output_to_use = if lines.len() > max_lines {
-            lines[..max_lines].join("\n")
-        } else {
-            output.to_string()
-        };
-
-        if output_to_use.len() > max_bytes {
-            (output_to_use[..max_bytes].to_string(), true)
-        } else {
-            (output_to_use, lines.len() > max_lines)
-        }
-    }
-
     // Arrange: create output that exceeds byte limit
     let output = "x".repeat(100 * 1024); // 100KB
 

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -6,25 +6,15 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex as TokioMutex;
 use tracing_subscriber::filter::LevelFilter;
 
+mod common;
+use common::make_test_analyzer;
+
 /// Serializes tests that mutate process-global env vars to prevent parallel pollution.
 /// Returns a `tokio::sync::MutexGuard` that can be held across `.await` points.
 async fn env_var_lock() -> tokio::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<TokioMutex<()>> = OnceLock::new();
     let m = LOCK.get_or_init(|| TokioMutex::new(()));
     m.lock().await
-}
-
-fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
-    let peer = Arc::new(TokioMutex::new(None));
-    let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::logging::LogEvent>();
-    let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
-    aptu_coder::CodeAnalyzer::new(
-        peer,
-        log_level_filter,
-        rx,
-        aptu_coder::metrics::MetricsSender(metrics_tx),
-    )
 }
 
 async fn call_tools_list_with_profile(profile: Option<&str>) -> serde_json::Value {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,7 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 |--------|------|-----------------|
 | **`aptu-coder`** | | |
 | `filters` | `crates/aptu-coder/src/filters.rs` | `exec_command` output filtering: `build_builtin_filter_rules`, `load_filter_table` (built-in + project-local `.aptu/filters.toml`), `apply_filter`, `maybe_inject_no_stat`; `FilterTableConfig` validates `schema_version` on deserialization and falls back to built-in rules on mismatch or parse error |
-| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP tool handlers for `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol`, `edit_overwrite`, `edit_replace`, `exec_command`; exec plumbing (`build_exec_command`, `run_exec_impl`, `handle_output_persist`) |
+| `lib` | `crates/aptu-coder/src/lib.rs` | CodeAnalyzer struct; MCP wiring and thin shims (`#[tool(...)]` decorators, forwarding calls). Post-M17 all tool handler logic lives in `crates/aptu-coder/src/tools/<tool>.rs`. Exec plumbing (`build_exec_command`, `run_exec_impl`, `handle_output_persist`) remains in `lib.rs`. |
 | `logging` | `crates/aptu-coder/src/logging.rs` | MCP logging integration via tracing; McpLoggingLayer bridges events to MCP clients via `notifications/message` |
 | `main` | `crates/aptu-coder/src/main.rs` | MCP server entry point; initializes tracing, OTel providers, metrics channel; stdio transport by default, streamable HTTP when `--port N` is passed |
 | `metrics` | `crates/aptu-coder/src/metrics.rs` | Always-on JSONL metrics: daily-rotating files, `MetricEvent`, `MetricsSender`, `MetricsWriter`; includes `migrate_legacy_metrics_dir` for the `code-analyze-mcp` → `aptu-coder` XDG path migration |
@@ -155,7 +155,7 @@ Two independent telemetry channels run in parallel; neither blocks tool executio
 
 ### W3C Trace Context propagation
 
-The server extracts `traceparent` and `tracestate` from `MCP params._meta` on every tool call and sets them as the span parent context. Tool spans appear as children of the calling agent's distributed trace (goose session, Claude turn). This requires no changes to tool handlers -- context extraction is done at the handler dispatch layer in `lib.rs`.
+The server extracts `traceparent` and `tracestate` from `MCP params._meta` on every tool call and sets them as the span parent context. Tool spans appear as children of the calling agent's distributed trace (goose session, Claude turn). This requires no changes to tool handlers -- context extraction is done at the handler dispatch layer in the `lib.rs` shims before delegating to `tools/<tool>.rs`.
 
 ### Child spans for sub-operations
 


### PR DESCRIPTION
Closes #1217

## Summary

Extends the existing FSM in `scan_backward_for_file_write` (`crates/aptu-coder/src/validation.rs`) to handle the shell construct classes identified in issue #1198, without introducing any new dependency.

## Changes

### `crates/aptu-coder/src/validation.rs`

- Replaced the `TODO` comment (added in #1196) with a doc comment listing supported and unsupported patterns
- Added `paren_aware_token` inner function: walks backward through paren-grouped constructs (`$(...)`, `>(...)`, `<(...)`) to correctly identify file-path tokens that use process or command substitution
- Extended the `>` and `>>` redirect branches to loop backward through all arguments after the redirect operator (not just the first token), covering patterns like `printf '%s\n' hello > file << EOF`
- Expanded `is_file_write_command` to match `printf`, `dd`, `install`, `cp`, `mv` in addition to `cat` and `tee`
- Added variable-command detection: any `$VAR`-prefixed token in command position is treated as a potential file-write command

### `crates/aptu-coder/tests/exec_command.rs`

Seven new integration tests covering the constructs required by the acceptance criteria:

| Test | Pattern | Expected |
|------|---------|----------|
| `test_heredoc_subshell_rejected` | `(cat > file << EOF)` | rejected |
| `test_heredoc_process_substitution_rejected` | `cat > >(proc) << EOF` | rejected |
| `test_heredoc_command_substitution_rejected` | `cat > $(echo file) << EOF` | rejected |
| `test_heredoc_variable_command_rejected` | `$cmd > file << EOF` | rejected |
| `test_heredoc_printf_write_rejected` | `printf '%s\n' hello > file << EOF` | rejected |
| `test_heredoc_pipeline_accepted` | `cat << EOF | grep pattern` | accepted |
| `test_heredoc_quoted_subshell_delimiter_accepted` | `cat << '$(EOF)'` | accepted |

## Testing

```
cargo test -p aptu-coder -- heredoc   # 24 passed, 0 failed
cargo clippy -p aptu-coder -- -D warnings  # clean
cargo fmt --check -p aptu-coder       # clean
```

## No new dependencies

This implementation extends the existing FSM rather than introducing an external shell parser, avoiding the supply-chain risk of archived crates (conch-parser) and scope creep from adding bash to the language registry (tree-sitter-bash).

