### PR TITLE
fix(ci): raise pr-review max-prompt-chars to 200k

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,3 +38,4 @@ jobs:
           fallback-model: 'inception/mercury-2'
           instructions-file: .github/instructions/pr-review.md
           repo-path: ${{ github.workspace }}
+          max-prompt-chars: 200000


### PR DESCRIPTION
Raise `max-prompt-chars` from the default 120,000 to 200,000 in the `pr-review.yml` workflow.

## Problem

PR 1217 dropped 50,537 chars of patches across all 10 changed files because the base context (instructions + metadata + file list) consumed the entire 120k budget before patch assembly began. The `call_graph` and `ast_context` sections were also dropped with `chars=0`, meaning the budget was at zero before the first patch was even considered.

Logged warnings from run [28101571889](https://github.com/clouatre-labs/aptu-coder/actions/runs/28101571889):

```
WARN Dropping patch: prompt budget exceeded  file=crates/aptu-coder/src/tools/analyze_symbol.rs  patch_chars=14160
WARN Dropping patch: prompt budget exceeded  file=crates/aptu-coder/src/tools/server.rs           patch_chars=11090
WARN Dropping patch: prompt budget exceeded  file=crates/aptu-coder/src/tests.rs                  patch_chars=7184
... (7 more files)
warning: review context truncated -- 13 section(s) dropped
```

## Fix

Set `max-prompt-chars: 200000`. The 200k limit is comfortably within the context windows of all configured models (Gemini Flash and Mercury-2) and gives headroom for large cleanup PRs.
