### PR TITLE
chore(types): remove dead API types and peer field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aptu-coder"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -73,12 +73,12 @@ pub use pagination::{CursorData, PaginationError};
 pub use parser::ParserError;
 pub use traversal::{TraversalError, WalkEntry};
 pub use types::{
-    AnalysisMode, AnalysisResult, AnalyzeDirectoryParams, AnalyzeFileField, AnalyzeFileParams,
-    AnalyzeModuleParams, AnalyzeSymbolParams, CallChain, CallEdge, CallInfo, ClassInfo, DefUseKind,
-    DefUseSite, EditOverwriteOutput, EditOverwriteParams, EditReplaceOutput, EditReplaceParams,
-    FileInfo, FilterRule, FocusedAnalysisData, FunctionInfo, ImplTraitInfo, ImportInfo,
-    ModuleFunctionInfo, ModuleImportInfo, ModuleInfo, OutputControlParams, PaginationParams,
-    ReferenceInfo, ReferenceType, SemanticAnalysis, SymbolMatchMode,
+    AnalysisMode, AnalyzeDirectoryParams, AnalyzeFileField, AnalyzeFileParams, AnalyzeModuleParams,
+    AnalyzeSymbolParams, CallEdge, CallInfo, ClassInfo, DefUseKind, DefUseSite,
+    EditOverwriteOutput, EditOverwriteParams, EditReplaceOutput, EditReplaceParams, FileInfo,
+    FilterRule, FunctionInfo, ImplTraitInfo, ImportInfo, ModuleFunctionInfo, ModuleImportInfo,
+    ModuleInfo, OutputControlParams, PaginationParams, ReferenceInfo, ReferenceType,
+    SemanticAnalysis, SymbolMatchMode,
 };
 
 /// Captures from a custom tree-sitter query.

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -253,28 +253,6 @@ pub struct AnalyzeSymbolParams {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct AnalysisResult {
-    pub path: String,
-    pub mode: AnalysisMode,
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::schema_helpers::integer_schema")
-    )]
-    pub import_count: usize,
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::schema_helpers::option_integer_schema")
-    )]
-    pub main_line: Option<usize>,
-    pub files: Vec<FileInfo>,
-    pub functions: Vec<FunctionInfo>,
-    pub classes: Vec<ClassInfo>,
-    pub references: Vec<ReferenceInfo>,
-}
-
-#[non_exhaustive]
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct FileInfo {
@@ -447,28 +425,6 @@ pub enum AnalysisMode {
     SymbolFocus,
     /// Fast function and import index for a single file (analyze_module fast path).
     ModuleOnly,
-}
-
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct CallChain {
-    pub chain: Vec<CallInfo>,
-    #[cfg_attr(
-        feature = "schemars",
-        schemars(schema_with = "crate::schema_helpers::integer_schema")
-    )]
-    pub depth: u32,
-}
-
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct FocusedAnalysisData {
-    pub symbol: String,
-    pub definition: Option<FunctionInfo>,
-    pub call_chains: Vec<CallChain>,
-    pub references: Vec<ReferenceInfo>,
 }
 
 #[non_exhaustive]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.21", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.22", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -467,7 +467,6 @@ impl CodeAnalyzer {
         let max_depth_val = params.follow_depth;
         let ctx = tools::AnalyzeSymbolContext {
             metrics_tx: self.metrics_tx.clone(),
-            peer: self.peer.clone(),
             call_graph_cache: self.call_graph_cache.clone(),
             disk_cache: self.disk_cache.clone(),
             sid: sid.clone(),

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -33,9 +33,6 @@ use crate::{SIZE_LIMIT, err_to_tool_result_from_pagination};
 /// explicit without coupling to `&self`.
 pub(crate) struct AnalyzeSymbolContext {
     pub(crate) metrics_tx: crate::metrics::MetricsSender,
-    // Retained for log-level notification infrastructure (separate active feature).
-    #[allow(dead_code)]
-    pub(crate) peer: Arc<tokio::sync::Mutex<Option<rmcp::Peer<rmcp::RoleServer>>>>,
     pub(crate) call_graph_cache: CallGraphCache,
     pub(crate) disk_cache: Arc<aptu_coder_core::cache::DiskCache>,
     pub(crate) sid: Option<String>,


### PR DESCRIPTION
## Summary

Removes dead public API types and a dead struct field identified in the structural refactor audit, and bumps the workspace version to `0.22.0` to satisfy semver checks for the breaking public API removal.

## Changes

### F3: Dead public API types

Deleted three types with zero usages across the codebase:
- `AnalysisResult` -- defined in `types.rs`, re-exported from `lib.rs`, never called
- `FocusedAnalysisData` -- same
- `CallChain` -- same (distinct from `InternalCallChain` in `graph.rs`, which is actively used)

### F10: Dead `peer` field

Removed the `peer` field from `AnalyzeSymbolContext` in `tools/analyze_symbol.rs` (was suppressed with `#[allow(dead_code)]`) and its corresponding construction site in `lib.rs`. The `disk_cache` field in the same struct is untouched -- it is actively used at lines 388 and 432.

### Version bump

Bumped workspace version `0.21.0` -> `0.22.0` and updated the `aptu-coder-core` dependency pin in `crates/aptu-coder/Cargo.toml` from `"0.21"` to `"0.22"`. Required because removing public items is a breaking change under pre-1.0 semver, and `cargo semver-checks` enforces this in CI.

## Test plan

- [x] Tests pass (101 passed; 1 pre-existing unrelated failure in metrics, not caused by this change)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Security scan clean (no findings)
- [x] `cargo semver-checks` satisfied by version bump

## Files changed

- `crates/aptu-coder-core/src/types.rs`
- `crates/aptu-coder-core/src/lib.rs`
- `crates/aptu-coder/src/tools/analyze_symbol.rs`
- `crates/aptu-coder/src/lib.rs`
- `Cargo.toml` (workspace version bump)
- `crates/aptu-coder/Cargo.toml` (dependency version pin update)

Closes #1222
