### PR TITLE
chore(api): fix unreachable_pub and add must_use annotations

### DIFF
--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -35,6 +35,7 @@ pub enum CacheTier {
 /// the fallback to at least 1.
 ///
 /// This helper centralises all three LRU init sites so the `.max(1)` guard lives in one place.
+#[must_use]
 pub fn parse_cache_capacity(env_key: &str, default: usize) -> usize {
     std::env::var(env_key)
         .ok()
@@ -44,6 +45,7 @@ pub fn parse_cache_capacity(env_key: &str, default: usize) -> usize {
 }
 
 impl CacheTier {
+    #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
             CacheTier::L1Memory => "l1_memory",
@@ -202,6 +204,7 @@ impl CallGraphCache {
     }
 
     /// Look up a cached result by key. Returns `None` on miss or mutex poison.
+    #[must_use]
     pub fn get(&self, key: &CallGraphCacheKey) -> Option<CallGraphCacheValue> {
         lock_or_recover(&self.cache, self.capacity, |guard| guard.get(key).cloned())
     }
@@ -326,6 +329,7 @@ impl AnalysisCache {
     /// Returns the configured file-cache capacity.
     /// Exposed for testing across crate boundaries; not part of the stable API.
     #[doc(hidden)]
+    #[must_use]
     pub fn file_capacity(&self) -> usize {
         self.file_capacity
     }

--- a/crates/aptu-coder-core/src/formatter_defuse.rs
+++ b/crates/aptu-coder-core/src/formatter_defuse.rs
@@ -9,6 +9,7 @@ use crate::formatter::{snippet_one_line, strip_base_path};
 
 /// Format a page of def-use sites for pagination.
 /// Renders a DEF-USE SITES section with WRITES and READS sub-sections.
+#[must_use]
 pub fn format_focused_paginated_defuse(
     paginated_sites: &[crate::types::DefUseSite],
     total: usize,

--- a/crates/aptu-coder-core/src/languages/cpp.rs
+++ b/crates/aptu-coder-core/src/languages/cpp.rs
@@ -52,6 +52,7 @@ pub const DEFUSE_QUERY: &str = r"
 
 /// Extract the function name from a C/C++ `function_definition` node by
 /// walking the declarator chain: declarator -> function_declarator -> declarator -> identifier.
+#[must_use]
 pub fn extract_function_name(node: &Node, source: &str, _lang: &str) -> Option<String> {
     node.child_by_field_name("declarator")
         .and_then(|decl| extract_declarator_name(decl, source))

--- a/crates/aptu-coder-core/src/languages/regex_fallback.rs
+++ b/crates/aptu-coder-core/src/languages/regex_fallback.rs
@@ -130,6 +130,7 @@ pub fn extract_toml(source: &str) -> SemanticAnalysis {
 /// and second delimiter, then delegates to [`SemanticExtractor::extract`] with
 /// `language = "typescript"`. Returns [`Default::default`] when no frontmatter
 /// is found or extraction fails.
+#[must_use]
 pub fn extract_astro(source: &str) -> SemanticAnalysis {
     let block = extract_frontmatter(source);
     let Some(frontmatter) = block else {

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -26,18 +26,23 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod filters;
-pub mod logging;
-pub mod metrics;
-pub mod otel;
-mod shell;
-mod tools;
-mod validation;
+pub(crate) mod logging;
+pub(crate) mod metrics;
+pub(crate) mod otel;
+pub(crate) mod shell;
+pub(crate) mod tools;
+pub(crate) mod validation;
+
+pub use logging::{LogEvent, McpLoggingLayer};
+pub use metrics::{MetricEvent, MetricsSender, MetricsWriter, migrate_legacy_metrics_dir};
+pub use otel::{
+    ClientMetadata, extract_and_set_trace_context, init_log_appender, init_meter, init_otel,
+};
 
 use aptu_coder_core::analyze;
 use aptu_coder_core::{cache, completion, types};
 use validation::validate_path;
 
-use crate::otel::{ClientMetadata, extract_and_set_trace_context};
 use crate::tools::common::{err_to_tool_result, no_cache_meta};
 
 pub const STDIN_MAX_BYTES: usize = 1_048_576;
@@ -68,6 +73,7 @@ pub struct ExecCommandParams {
 
 impl ExecCommandParams {
     /// Creates a new ExecCommandParams with the given command.
+    #[must_use]
     pub fn new(command: String, working_dir: Option<String>) -> Self {
         Self {
             command,
@@ -112,6 +118,7 @@ pub struct ShellOutput {
 
 impl ShellOutput {
     /// Creates a new ShellOutput with the given parameters.
+    #[must_use]
     pub fn new(
         stdout: String,
         stderr: String,
@@ -144,7 +151,7 @@ use aptu_coder_core::types::{
 use filters::CompiledRule;
 #[cfg(test)]
 use filters::{apply_filter, maybe_inject_no_stat};
-use logging::LogEvent;
+
 use rmcp::handler::server::tool::{ToolRouter, schema_for_type};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
 use aptu_coder::{
-    CodeAnalyzer,
-    logging::McpLoggingLayer,
-    metrics::{MetricEvent, MetricsSender, MetricsWriter},
+    CodeAnalyzer, McpLoggingLayer, MetricEvent, MetricsSender, MetricsWriter, init_log_appender,
+    init_meter, init_otel,
 };
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -20,8 +19,6 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-
-use aptu_coder::otel;
 
 /// Authentication middleware that validates Bearer tokens using constant-time comparison.
 ///
@@ -169,13 +166,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Initialize OpenTelemetry (returns None if OTEL_EXPORTER_OTLP_ENDPOINT is unset)
-    let otel_provider = otel::init_otel();
-    let log_provider = otel::init_log_appender();
-    let meter_provider = otel::init_meter();
+    let otel_provider = init_otel();
+    let log_provider = init_log_appender();
+    let meter_provider = init_meter();
 
     // Create shared peer Arc for logging layer
     // Migrate legacy metrics directory if needed
-    if let Err(e) = aptu_coder::metrics::migrate_legacy_metrics_dir() {
+    if let Err(e) = aptu_coder::migrate_legacy_metrics_dir() {
         tracing::warn!("Failed to migrate legacy metrics directory: {e}");
     }
     let peer = Arc::new(TokioMutex::new(None));

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -95,7 +95,8 @@ pub(crate) struct MetricEventBuilder {
 }
 
 impl MetricEventBuilder {
-    pub fn new(tool: &'static str, result: &'static str, duration_ms: u64) -> Self {
+    #[must_use]
+    pub(crate) fn new(tool: &'static str, result: &'static str, duration_ms: u64) -> Self {
         Self {
             ts: unix_ms(),
             tool,
@@ -104,75 +105,93 @@ impl MetricEventBuilder {
             ..Self::default()
         }
     }
-    pub fn output_chars(mut self, v: usize) -> Self {
+    #[must_use]
+    pub(crate) fn output_chars(mut self, v: usize) -> Self {
         self.output_chars = v;
         self
     }
-    pub fn param_path_depth(mut self, v: usize) -> Self {
+    #[must_use]
+    pub(crate) fn param_path_depth(mut self, v: usize) -> Self {
         self.param_path_depth = v;
         self
     }
-    pub fn max_depth(mut self, v: Option<u32>) -> Self {
+    #[must_use]
+    pub(crate) fn max_depth(mut self, v: Option<u32>) -> Self {
         self.max_depth = v;
         self
     }
-    pub fn error_type(mut self, v: Option<String>) -> Self {
+    #[must_use]
+    pub(crate) fn error_type(mut self, v: Option<String>) -> Self {
         self.error_type = v;
         self
     }
-    pub fn error_subtype(mut self, v: Option<String>) -> Self {
+    #[must_use]
+    pub(crate) fn error_subtype(mut self, v: Option<String>) -> Self {
         self.error_subtype = v;
         self
     }
-    pub fn session_id(mut self, v: Option<String>) -> Self {
+    #[must_use]
+    pub(crate) fn session_id(mut self, v: Option<String>) -> Self {
         self.session_id = v;
         self
     }
-    pub fn seq(mut self, v: Option<u32>) -> Self {
+    #[must_use]
+    pub(crate) fn seq(mut self, v: Option<u32>) -> Self {
         self.seq = v;
         self
     }
-    pub fn cache_hit(mut self, v: Option<bool>) -> Self {
+    #[must_use]
+    pub(crate) fn cache_hit(mut self, v: Option<bool>) -> Self {
         self.cache_hit = v;
         self
     }
-    pub fn cache_write_failure(mut self, v: Option<bool>) -> Self {
+    #[must_use]
+    pub(crate) fn cache_write_failure(mut self, v: Option<bool>) -> Self {
         self.cache_write_failure = v;
         self
     }
-    pub fn cache_tier(mut self, v: Option<&'static str>) -> Self {
+    #[must_use]
+    pub(crate) fn cache_tier(mut self, v: Option<&'static str>) -> Self {
         self.cache_tier = v;
         self
     }
-    pub fn exit_code(mut self, v: Option<i32>) -> Self {
+    #[must_use]
+    pub(crate) fn exit_code(mut self, v: Option<i32>) -> Self {
         self.exit_code = v;
         self
     }
-    pub fn timed_out(mut self, v: bool) -> Self {
+    #[must_use]
+    pub(crate) fn timed_out(mut self, v: bool) -> Self {
         self.timed_out = v;
         self
     }
-    pub fn output_truncated(mut self, v: Option<bool>) -> Self {
+    #[must_use]
+    pub(crate) fn output_truncated(mut self, v: Option<bool>) -> Self {
         self.output_truncated = v;
         self
     }
-    pub fn chars_threshold_breach(mut self, v: bool) -> Self {
+    #[must_use]
+    pub(crate) fn chars_threshold_breach(mut self, v: bool) -> Self {
         self.chars_threshold_breach = v;
         self
     }
-    pub fn file_ext(mut self, v: Option<&'static str>) -> Self {
+    #[must_use]
+    pub(crate) fn file_ext(mut self, v: Option<&'static str>) -> Self {
         self.file_ext = v;
         self
     }
-    pub fn filter_applied(mut self, v: Option<String>) -> Self {
+    #[must_use]
+    pub(crate) fn filter_applied(mut self, v: Option<String>) -> Self {
         self.filter_applied = v;
         self
     }
-    pub fn language(mut self, v: Option<String>) -> Self {
+    #[must_use]
+    pub(crate) fn language(mut self, v: Option<String>) -> Self {
         self.language = v;
         self
     }
-    pub fn build(self) -> MetricEvent {
+    #[must_use]
+    pub(crate) fn build(self) -> MetricEvent {
         MetricEvent {
             ts: self.ts,
             tool: self.tool,
@@ -425,7 +444,7 @@ impl MetricsWriter {
 
 /// Returns the current UNIX timestamp in milliseconds.
 #[must_use]
-pub fn unix_ms() -> u64 {
+pub(crate) fn unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -436,7 +455,7 @@ pub fn unix_ms() -> u64 {
 
 /// Counts the number of path segments in a file path.
 #[must_use]
-pub fn path_component_count(path: &str) -> usize {
+pub(crate) fn path_component_count(path: &str) -> usize {
     Path::new(path).components().count()
 }
 
@@ -446,7 +465,7 @@ pub fn path_component_count(path: &str) -> usize {
 /// - Returns `Some("other")` for paths that have an extension but it is not in the known set.
 /// - Returns `None` for paths with no extension or an empty extension.
 #[must_use]
-pub fn path_file_ext(path: &str) -> Option<&'static str> {
+pub(crate) fn path_file_ext(path: &str) -> Option<&'static str> {
     let ext_os = Path::new(path).extension()?;
     let ext_str = ext_os.to_str()?;
     if ext_str.is_empty() {
@@ -468,7 +487,7 @@ pub fn path_file_ext(path: &str) -> Option<&'static str> {
 /// - Returns `Some("Rust")` for paths with a recognized extension.
 /// - Returns `None` for paths with no extension or an unrecognized extension.
 #[must_use]
-pub fn path_language(path: &str) -> Option<String> {
+pub(crate) fn path_language(path: &str) -> Option<String> {
     let ext_os = Path::new(path).extension()?;
     let ext_str = ext_os.to_str()?;
     if ext_str.is_empty() {
@@ -566,7 +585,7 @@ fn date_to_days_since_epoch(y: u32, m: u32, d: u32) -> u32 {
 
 /// Returns the current UTC date as a string in YYYY-MM-DD format.
 #[must_use]
-pub fn current_date_str() -> String {
+pub(crate) fn current_date_str() -> String {
     let days = u32::try_from(unix_ms() / 86_400_000).unwrap_or(u32::MAX);
     let z = days + 719_468;
     let era = z / 146_097;

--- a/crates/aptu-coder/src/tools/mod.rs
+++ b/crates/aptu-coder/src/tools/mod.rs
@@ -41,15 +41,15 @@
 //!     moved into this module. They are the framework glue that ties all
 //!     tools together and must live in the crate root.
 
-pub mod analyze_directory;
-pub mod analyze_file;
-pub mod analyze_module;
-pub mod analyze_symbol;
-pub mod common;
-pub mod edit_overwrite;
-pub mod edit_replace;
-pub mod exec_command;
-pub mod server;
+pub(crate) mod analyze_directory;
+pub(crate) mod analyze_file;
+pub(crate) mod analyze_module;
+pub(crate) mod analyze_symbol;
+pub(crate) mod common;
+pub(crate) mod edit_overwrite;
+pub(crate) mod edit_replace;
+pub(crate) mod exec_command;
+pub(crate) mod server;
 
 pub(crate) use analyze_module::AnalyzeModuleContext;
 pub(crate) use analyze_symbol::AnalyzeSymbolContext;

--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -10,13 +10,13 @@ use tracing_subscriber::filter::LevelFilter;
 pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::logging::LogEvent>();
+    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::LogEvent>();
     let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
     aptu_coder::CodeAnalyzer::new(
         peer,
         log_level_filter,
         rx,
-        aptu_coder::metrics::MetricsSender(metrics_tx),
+        aptu_coder::MetricsSender(metrics_tx),
     )
 }
 

--- a/crates/aptu-coder/tests/integration_tests.rs
+++ b/crates/aptu-coder/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use aptu_coder::logging::LogEvent;
+use aptu_coder::LogEvent;
 use common::call_tool_raw;
 use rmcp::model::{CallToolResult, Content, LoggingLevel, Meta};
 

--- a/crates/aptu-coder/tests/logging_layer_tests.rs
+++ b/crates/aptu-coder/tests/logging_layer_tests.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 aptu-coder contributors
 // SPDX-License-Identifier: Apache-2.0
-use aptu_coder::logging::{LogEvent, McpLoggingLayer};
+use aptu_coder::{LogEvent, McpLoggingLayer};
 use rmcp::model::LoggingLevel;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;

--- a/crates/aptu-coder/tests/otel_tests.rs
+++ b/crates/aptu-coder/tests/otel_tests.rs
@@ -4,7 +4,9 @@
 use serial_test::serial;
 use std::env;
 
-use aptu_coder::otel::{ClientMetadata, extract_and_set_trace_context};
+use aptu_coder::{
+    ClientMetadata, extract_and_set_trace_context, init_log_appender, init_meter, init_otel,
+};
 
 #[test]
 #[serial]
@@ -15,7 +17,7 @@ fn test_init_otel_no_env_var_returns_none() {
     }
 
     // Act: call init_otel with no env var
-    let result = aptu_coder::otel::init_otel();
+    let result = init_otel();
 
     // Assert: should return None (graceful noop when env var unset)
     assert!(
@@ -36,7 +38,7 @@ fn test_init_otel_invalid_url_returns_none() {
     }
 
     // Act: call init_otel with invalid endpoint
-    let result = aptu_coder::otel::init_otel();
+    let result = init_otel();
 
     // Assert: opentelemetry-otlp 0.32+ uses lazy connection, so init_otel returns Some(provider)
     // even with an invalid URL. The actual connection failure occurs at export time, not init time.
@@ -61,7 +63,7 @@ fn test_noop_layer_composition_no_panic() {
     }
 
     // Act: call init_otel (returns None) and verify no panic on layer composition
-    let otel_provider = aptu_coder::otel::init_otel();
+    let otel_provider = init_otel();
     assert!(
         otel_provider.is_none(),
         "init_otel should return None when env var unset"
@@ -87,7 +89,7 @@ fn test_log_appender_no_env_var_returns_none() {
     }
 
     // Act: call init_log_appender with no env var
-    let result = aptu_coder::otel::init_log_appender();
+    let result = init_log_appender();
 
     // Assert: should return None (graceful noop when env var unset)
     assert!(
@@ -141,7 +143,7 @@ fn test_metrics_histogram_no_env_var() {
     }
 
     // Act: call init_meter with no env var
-    let result = aptu_coder::otel::init_meter();
+    let result = init_meter();
 
     // Assert: should return None (graceful noop when env var unset)
     assert!(


### PR DESCRIPTION
## Summary

Fixes #1223.

Four targeted fixes to the public API surface:

- **F4/F6:** Change 9 `pub mod` to `pub(crate) mod` in `tools/mod.rs`; change 19 MetricEventBuilder methods and 6 utility functions from `pub` to `pub(crate)` in `metrics.rs`
- **F11:** Add `#[must_use]` to 2 constructor functions in `lib.rs` and 7 functions in `aptu-coder-core`
- **F14:** Change `pub mod logging/metrics/otel` to `pub(crate)` in `lib.rs`; add 6 `pub use` re-exports for all external consumers; update `main.rs` and 4 integration test files to use flat re-exported paths

## Test plan

- `cargo clippy -- -W unreachable_pub -W clippy::must_use_candidate`: 0 warnings
- `cargo test`: all pass
- `cargo fmt --check`: clean

Closes #1223
