### PR TITLE
perf(core): eliminate allocations in OTEL telemetry, BFS traversal, and cache

### DIFF
--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -115,7 +115,7 @@ where
         Err(poisoned) => {
             // SAFETY: 100 is a non-zero literal
             let cache_size = NonZeroUsize::new(capacity)
-                .unwrap_or_else(|| unsafe { NonZeroUsize::new_unchecked(100) });
+                .unwrap_or_else(|| NonZeroUsize::new(100).expect("100 is non-zero"));
             let new_cache = LruCache::new(cache_size);
             let mut guard = poisoned.into_inner();
             *guard = new_cache;
@@ -195,8 +195,7 @@ impl CallGraphCache {
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
-        // SAFETY: capacity is >= 1 due to .max(1) applied above
-        let cache_size = unsafe { NonZeroUsize::new_unchecked(capacity) };
+        let cache_size = NonZeroUsize::new(capacity).expect("capacity is non-zero after .max(1)");
         Self {
             capacity,
             cache: Arc::new(Mutex::new(LruCache::new(cache_size))),
@@ -242,10 +241,10 @@ impl AnalysisCache {
     pub fn new(capacity: usize) -> Self {
         let file_capacity = capacity.max(1);
         let dir_capacity = parse_cache_capacity("APTU_CODER_DIR_CACHE_CAPACITY", 20);
-        // SAFETY: file_capacity is >= 1 due to .max(1) applied above
-        let cache_size = unsafe { NonZeroUsize::new_unchecked(file_capacity) };
-        // SAFETY: dir_capacity is >= 1 due to parse_cache_capacity's .max(1) guarantee
-        let dir_cache_size = unsafe { NonZeroUsize::new_unchecked(dir_capacity) };
+        let cache_size =
+            NonZeroUsize::new(file_capacity).expect("file_capacity is non-zero after .max(1)");
+        let dir_cache_size =
+            NonZeroUsize::new(dir_capacity).expect("dir_capacity is non-zero after .max(1)");
         Self {
             file_capacity,
             dir_capacity,

--- a/crates/aptu-coder-core/src/graph.rs
+++ b/crates/aptu-coder-core/src/graph.rs
@@ -8,6 +8,7 @@
 use crate::types::{CallEdge, ImplTraitInfo, SemanticAnalysis, SymbolMatchMode};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, instrument};
 
@@ -415,9 +416,9 @@ impl CallGraph {
 
         let mut chains = Vec::new();
         let mut visited = HashSet::new();
-        let mut queue = VecDeque::new();
-        queue.push_back((symbol.to_string(), 0));
-        visited.insert(symbol.to_string());
+        let mut queue: VecDeque<(Arc<str>, u32)> = VecDeque::new();
+        queue.push_back((Arc::from(symbol), 0));
+        visited.insert(Arc::from(symbol));
 
         while let Some((current, depth)) = queue.pop_front() {
             if depth > follow_depth {
@@ -427,7 +428,7 @@ impl CallGraph {
             // Child span for graph traversal at this depth level
             let _traverse_span = tracing::info_span!("graph.traverse", depth = depth).entered();
 
-            if let Some(neighbors) = graph_map.get(&current) {
+            if let Some(neighbors) = graph_map.get(current.as_ref()) {
                 for edge in neighbors {
                     let path = &edge.path;
                     let line = edge.line;
@@ -442,7 +443,7 @@ impl CallGraph {
                     // For outgoing chains the order is already focus-first.
                     let mut chain = {
                         let mut v = Vec::with_capacity(follow_depth as usize + 2);
-                        v.push((current.clone(), path.clone(), line));
+                        v.push((current.to_string(), path.clone(), line));
                         v
                     };
                     let mut chain_node = neighbor.clone();
@@ -486,9 +487,9 @@ impl CallGraph {
 
                     chains.push(InternalCallChain { chain });
 
-                    if !visited.contains(neighbor) && depth < follow_depth {
-                        visited.insert(neighbor.clone());
-                        queue.push_back((neighbor.clone(), depth + 1));
+                    if !visited.contains(neighbor.as_str()) && depth < follow_depth {
+                        visited.insert(Arc::from(neighbor.as_str()));
+                        queue.push_back((Arc::from(neighbor.as_str()), depth + 1));
                     }
                 }
             }

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -1290,7 +1290,7 @@ fn record_otel_metrics(event: &MetricEvent) {
 
     let error_type = event.error_type.as_deref().unwrap_or("success");
     let attributes = [
-        KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
+        KeyValue::new("gen_ai.tool.name", event.tool),
         KeyValue::new("error.type", error_type.to_string()),
         KeyValue::new("mcp.method.name", "tools/call"),
         KeyValue::new("mcp.protocol.version", "2025-11-25"),
@@ -1305,16 +1305,13 @@ fn record_otel_metrics(event: &MetricEvent) {
         cache_hits_counter.add(
             1,
             &[
-                KeyValue::new("gen_ai.tool.name", event.tool.to_string()),
-                KeyValue::new("cache_tier", tier.to_string()),
+                KeyValue::new("gen_ai.tool.name", event.tool),
+                KeyValue::new("cache_tier", tier),
             ],
         );
     }
 
     if event.cache_write_failure == Some(true) {
-        cache_write_failures_counter.add(
-            1,
-            &[KeyValue::new("gen_ai.tool.name", event.tool.to_string())],
-        );
+        cache_write_failures_counter.add(1, &[KeyValue::new("gen_ai.tool.name", event.tool)]);
     }
 }


### PR DESCRIPTION
## Summary

Performance improvements across metrics, graph analysis, and cache subsystems. Eliminates heap allocations in OTEL telemetry path, reduces clone overhead in BFS traversal, and removes unsafe blocks from cache initialization.

## Changes

- crates/aptu-coder/src/metrics.rs
- crates/aptu-coder-core/src/graph.rs
- crates/aptu-coder-core/src/cache.rs

## Details

**F7 (metrics.rs):** Removed 4 `.to_string()` calls on `&'static str` values in `record_otel_metrics()`: 3x `event.tool` and 1x `tier`. These values pass directly to `KeyValue::new()` via `Into<Value>` without heap allocation. Kept `error_type.to_string()` since `error_type` is `&str` and opentelemetry 0.32.0 has no `From<&str>` impl for `Value`.

**F8 (graph.rs):** Replaced internal BFS queue from `VecDeque<(String, u32)>` to `VecDeque<(Arc<str>, u32)>` and visited set from `HashSet<String>` to `HashSet<Arc<str>>`. Reduces clone overhead during graph traversal; Arc refcount bumps are cheaper than String clones. Function signature and `InternalCallChain` return type unchanged.

**F9 (cache.rs):** Replaced 4 production `unsafe { NonZeroUsize::new_unchecked() }` blocks with safe `.new().expect()` equivalents: line 118 (fallback capacity), line 199 (CallGraphCache), and lines 246-248 (AnalysisCache file and dir capacities). All inputs are guaranteed non-zero by `.max(1)` guards or constants, so panics are unreachable.

## Test plan

- [x] Tests pass: 670 passed, 0 failed (see 03-build.json)
- [x] Linter clean: cargo clippy -- -D warnings
- [x] Formatter clean: cargo fmt --check
- [x] Security scan clean: no findings

Closes #1224
