### PR TITLE
chore(lint): add workspace lints, remove lang feature gates, extract main helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,16 @@ tracing-opentelemetry = "0.33"
 rustls = "0.23"
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false }
 
+[workspace.lints.rust]
+unreachable_pub = "warn"
+
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
 unwrap_used = "deny"
+must_use_candidate = "warn"
+redundant_clone = "warn"
+needless_pass_by_value = "warn"
+large_enum_variant = "warn"
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ unreachable_pub = "warn"
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
 unwrap_used = "deny"
+# Lints below are "warn" until all violations are cleared; promote each to "deny"
+# once zero warnings are confirmed in CI (tracked in issue #1225).
 must_use_candidate = "warn"
 redundant_clone = "warn"
 needless_pass_by_value = "warn"

--- a/crates/aptu-coder-core/Cargo.toml
+++ b/crates/aptu-coder-core/Cargo.toml
@@ -21,23 +21,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["lang-rust", "lang-go", "lang-java", "lang-kotlin", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp", "lang-markdown", "lang-css", "lang-yaml"]
+default = ["schemars"]
 schemars = ["dep:schemars"]
-lang-rust = ["dep:tree-sitter-rust"]
-lang-go = ["dep:tree-sitter-go"]
-lang-cpp = ["dep:tree-sitter-cpp"]
-lang-java = ["dep:tree-sitter-java"]
-lang-kotlin = ["dep:tree-sitter-kotlin-ng"]
-lang-python = ["dep:tree-sitter-python"]
-lang-typescript = ["dep:tree-sitter-typescript"]
-lang-javascript = ["dep:tree-sitter-javascript"]
-lang-tsx = ["dep:tree-sitter-typescript"]
-lang-fortran = ["dep:tree-sitter-fortran"]
-lang-csharp = ["dep:tree-sitter-c-sharp"]
-lang-markdown = ["dep:tree-sitter-md"]
-lang-html = []
-lang-css = ["dep:tree-sitter-css"]
-lang-yaml = ["dep:tree-sitter-yaml"]
 
 [dependencies]
 tree-sitter = { workspace = true }
@@ -54,19 +39,19 @@ tracing = { workspace = true }
 regex = { workspace = true }
 tokio-util = { workspace = true }
 tempfile = { workspace = true }
-tree-sitter-rust = { workspace = true, optional = true }
-tree-sitter-go = { workspace = true, optional = true }
-tree-sitter-cpp = { workspace = true, optional = true }
-tree-sitter-c-sharp = { workspace = true, optional = true }
-tree-sitter-java = { workspace = true, optional = true }
-tree-sitter-kotlin-ng = { workspace = true, optional = true }
-tree-sitter-python = { workspace = true, optional = true }
-tree-sitter-typescript = { workspace = true, optional = true }
-tree-sitter-javascript = { workspace = true, optional = true }
-tree-sitter-fortran = { workspace = true, optional = true }
-tree-sitter-md = { workspace = true, optional = true }
-tree-sitter-css = { workspace = true, optional = true }
-tree-sitter-yaml = { workspace = true, optional = true }
+tree-sitter-rust = { workspace = true }
+tree-sitter-go = { workspace = true }
+tree-sitter-cpp = { workspace = true }
+tree-sitter-c-sharp = { workspace = true }
+tree-sitter-java = { workspace = true }
+tree-sitter-kotlin-ng = { workspace = true }
+tree-sitter-python = { workspace = true }
+tree-sitter-typescript = { workspace = true }
+tree-sitter-javascript = { workspace = true }
+tree-sitter-fortran = { workspace = true }
+tree-sitter-md = { workspace = true }
+tree-sitter-css = { workspace = true }
+tree-sitter-yaml = { workspace = true }
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -1615,7 +1615,6 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::TempDir;
 
-    #[cfg(feature = "lang-rust")]
     #[test]
     fn analyze_str_rust_happy_path() {
         let source = "fn hello() -> i32 { 42 }";
@@ -1623,7 +1622,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "lang-python")]
     #[test]
     fn analyze_str_python_happy_path() {
         let source = "def greet(name):\n    return f'Hello {name}'";
@@ -1631,7 +1629,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "lang-rust")]
     #[test]
     fn analyze_str_rust_by_language_name() {
         let source = "fn hello() -> i32 { 42 }";
@@ -1639,7 +1636,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "lang-python")]
     #[test]
     fn analyze_str_python_by_language_name() {
         let source = "def greet(name):\n    return f'Hello {name}'";
@@ -1647,7 +1643,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "lang-rust")]
     #[test]
     fn analyze_str_rust_mixed_case() {
         let source = "fn hello() -> i32 { 42 }";
@@ -1655,7 +1650,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "lang-python")]
     #[test]
     fn analyze_str_python_mixed_case() {
         let source = "def greet(name):\n    return f'Hello {name}'";
@@ -1671,7 +1665,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "lang-rust")]
     #[test]
     fn test_symbol_focus_callers_pagination_first_page() {
         let temp_dir = TempDir::new().unwrap();
@@ -2002,7 +1995,6 @@ fn caller_c() { target(); }
         );
     }
 
-    #[cfg(feature = "lang-rust")]
     #[test]
     fn test_def_use_focused_analysis() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/aptu-coder-core/src/lang.rs
+++ b/crates/aptu-coder-core/src/lang.rs
@@ -3,69 +3,43 @@
 //! Language detection by file extension.
 //!
 //! Maps file extensions to supported language identifiers.
+//!
+//! All languages are unconditionally compiled in.  The historical `lang-*` Cargo feature
+//! gates have been removed; every registered extension is always available at runtime.
+//! This simplifies the build matrix and guarantees that callers never get a feature-gate
+//! error for a language that "should" be supported.
 
 const EXTENSION_MAP: &[(&str, &str)] = &[
-    #[cfg(feature = "lang-cpp")]
     ("c", "c"),
-    #[cfg(feature = "lang-cpp")]
     ("cc", "cpp"),
-    #[cfg(feature = "lang-javascript")]
     ("cjs", "javascript"),
-    #[cfg(feature = "lang-cpp")]
     ("cpp", "cpp"),
-    #[cfg(feature = "lang-cpp")]
     ("cxx", "cpp"),
-    #[cfg(feature = "lang-fortran")]
     ("f", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("f03", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("f08", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("f77", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("f90", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("f95", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("for", "fortran"),
-    #[cfg(feature = "lang-fortran")]
     ("ftn", "fortran"),
-    #[cfg(feature = "lang-cpp")]
     ("h", "cpp"),
-    #[cfg(feature = "lang-csharp")]
     ("cs", "csharp"),
-    #[cfg(feature = "lang-cpp")]
     ("hpp", "cpp"),
-    #[cfg(feature = "lang-cpp")]
     ("hxx", "cpp"),
-    #[cfg(feature = "lang-javascript")]
     ("js", "javascript"),
-    #[cfg(feature = "lang-javascript")]
     ("mjs", "javascript"),
-    #[cfg(feature = "lang-go")]
     ("go", "go"),
-    #[cfg(feature = "lang-java")]
     ("java", "java"),
-    #[cfg(feature = "lang-kotlin")]
     ("kt", "kotlin"),
-    #[cfg(feature = "lang-kotlin")]
     ("kts", "kotlin"),
-    #[cfg(feature = "lang-python")]
     ("py", "python"),
-    #[cfg(feature = "lang-rust")]
     ("rs", "rust"),
-    #[cfg(feature = "lang-typescript")]
     ("ts", "typescript"),
-    #[cfg(feature = "lang-tsx")]
     ("tsx", "tsx"),
-    #[cfg(feature = "lang-html")]
     ("html", "html"),
-    #[cfg(feature = "lang-html")]
     ("htm", "html"),
-    #[cfg(feature = "lang-markdown")]
     ("md", "markdown"),
-    #[cfg(feature = "lang-markdown")]
     ("mdx", "markdown"),
     ("astro", "astro"),
     ("css", "css"),
@@ -98,40 +72,26 @@ pub fn supported_extensions() -> Vec<&'static str> {
     EXTENSION_MAP.iter().map(|(ext, _)| *ext).collect()
 }
 
-/// Returns a static slice of all supported language names based on compiled features.
+/// Returns a static slice of all supported language names.
 ///
-/// The returned slice contains language identifiers like `"rust"`, `"python"`, `"go"`, etc.,
-/// depending on which language features are enabled at compile time.
+/// All languages are unconditionally compiled in; the historical `lang-*` feature
+/// gates have been removed.
 #[must_use]
 pub fn supported_languages() -> &'static [&'static str] {
     &[
-        #[cfg(feature = "lang-rust")]
         "rust",
-        #[cfg(feature = "lang-go")]
         "go",
-        #[cfg(feature = "lang-java")]
         "java",
-        #[cfg(feature = "lang-kotlin")]
         "kotlin",
-        #[cfg(feature = "lang-python")]
         "python",
-        #[cfg(feature = "lang-typescript")]
         "typescript",
-        #[cfg(feature = "lang-tsx")]
         "tsx",
-        #[cfg(feature = "lang-javascript")]
         "javascript",
-        #[cfg(feature = "lang-fortran")]
         "fortran",
-        #[cfg(feature = "lang-cpp")]
         "c",
-        #[cfg(feature = "lang-cpp")]
         "cpp",
-        #[cfg(feature = "lang-csharp")]
         "csharp",
-        #[cfg(feature = "lang-html")]
         "html",
-        #[cfg(feature = "lang-markdown")]
         "markdown",
     ]
 }
@@ -142,37 +102,21 @@ mod tests {
 
     #[test]
     fn test_language_for_extension_happy_path() {
-        #[cfg(feature = "lang-rust")]
         assert_eq!(language_for_extension("rs"), Some("rust"));
-        #[cfg(feature = "lang-python")]
         assert_eq!(language_for_extension("py"), Some("python"));
-        #[cfg(feature = "lang-go")]
         assert_eq!(language_for_extension("go"), Some("go"));
-        #[cfg(feature = "lang-java")]
         assert_eq!(language_for_extension("java"), Some("java"));
-        #[cfg(feature = "lang-typescript")]
         assert_eq!(language_for_extension("ts"), Some("typescript"));
-        #[cfg(feature = "lang-tsx")]
         assert_eq!(language_for_extension("tsx"), Some("tsx"));
-        #[cfg(feature = "lang-fortran")]
         assert_eq!(language_for_extension("f90"), Some("fortran"));
-        #[cfg(feature = "lang-fortran")]
         assert_eq!(language_for_extension("for"), Some("fortran"));
-        #[cfg(feature = "lang-fortran")]
         assert_eq!(language_for_extension("ftn"), Some("fortran"));
-        #[cfg(feature = "lang-cpp")]
         assert_eq!(language_for_extension("c"), Some("c"));
-        #[cfg(feature = "lang-cpp")]
         assert_eq!(language_for_extension("cpp"), Some("cpp"));
-        #[cfg(feature = "lang-cpp")]
         assert_eq!(language_for_extension("h"), Some("cpp"));
-        #[cfg(feature = "lang-cpp")]
         assert_eq!(language_for_extension("hpp"), Some("cpp"));
-        #[cfg(feature = "lang-cpp")]
         assert_eq!(language_for_extension("cc"), Some("cpp"));
-        #[cfg(feature = "lang-kotlin")]
         assert_eq!(language_for_extension("kt"), Some("kotlin"));
-        #[cfg(feature = "lang-kotlin")]
         assert_eq!(language_for_extension("kts"), Some("kotlin"));
     }
 
@@ -199,12 +143,9 @@ mod tests {
     fn test_language_for_extension_edge_case() {
         assert_eq!(language_for_extension("unknown"), None);
         assert_eq!(language_for_extension(""), None);
-        #[cfg(feature = "lang-rust")]
         assert_eq!(language_for_extension("RS"), Some("rust"));
         // Uppercase Fortran extensions resolved via eq_ignore_ascii_case
-        #[cfg(feature = "lang-fortran")]
         assert_eq!(language_for_extension("F90"), Some("fortran"));
-        #[cfg(feature = "lang-fortran")]
         assert_eq!(language_for_extension("FOR"), Some("fortran"));
     }
 }

--- a/crates/aptu-coder-core/src/languages/cpp.rs
+++ b/crates/aptu-coder-core/src/languages/cpp.rs
@@ -155,7 +155,7 @@ fn extract_declarator_name(node: Node, source: &str) -> Option<String> {
     }
 }
 
-#[cfg(all(test, feature = "lang-cpp"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;

--- a/crates/aptu-coder-core/src/languages/csharp.rs
+++ b/crates/aptu-coder-core/src/languages/csharp.rs
@@ -187,7 +187,7 @@ pub fn find_method_for_receiver(
         .and_then(|n| get_node_text(&n, source))
 }
 
-#[cfg(all(test, feature = "lang-csharp"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;

--- a/crates/aptu-coder-core/src/languages/css.rs
+++ b/crates/aptu-coder-core/src/languages/css.rs
@@ -22,7 +22,7 @@ pub const IMPORT_QUERY: &str = r"
 /// Tree-sitter call query for CSS (empty -- no call sites in CSS).
 pub const CALL_QUERY: &str = "";
 
-#[cfg(all(test, feature = "lang-css"))]
+#[cfg(test)]
 mod tests {
     use tree_sitter::{Parser, StreamingIterator};
 

--- a/crates/aptu-coder-core/src/languages/fortran.rs
+++ b/crates/aptu-coder-core/src/languages/fortran.rs
@@ -140,7 +140,7 @@ pub fn find_method_for_receiver(
         .and_then(|n| get_node_text(&n, source))
 }
 
-#[cfg(all(test, feature = "lang-fortran"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use tree_sitter::Parser;

--- a/crates/aptu-coder-core/src/languages/go.rs
+++ b/crates/aptu-coder-core/src/languages/go.rs
@@ -176,7 +176,7 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
-#[cfg(all(test, feature = "lang-go"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;

--- a/crates/aptu-coder-core/src/languages/java.rs
+++ b/crates/aptu-coder-core/src/languages/java.rs
@@ -163,7 +163,7 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
-#[cfg(all(test, feature = "lang-java"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;

--- a/crates/aptu-coder-core/src/languages/javascript.rs
+++ b/crates/aptu-coder-core/src/languages/javascript.rs
@@ -146,7 +146,7 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
-#[cfg(all(test, feature = "lang-javascript"))]
+#[cfg(test)]
 mod tests {
     use crate::DefUseKind;
     use crate::parser::SemanticExtractor;

--- a/crates/aptu-coder-core/src/languages/kotlin.rs
+++ b/crates/aptu-coder-core/src/languages/kotlin.rs
@@ -163,7 +163,7 @@ pub fn find_method_for_receiver(
         .and_then(|n| get_node_text(&n, source))
 }
 
-#[cfg(all(test, feature = "lang-kotlin"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use tree_sitter::{Parser, StreamingIterator};

--- a/crates/aptu-coder-core/src/languages/markdown.rs
+++ b/crates/aptu-coder-core/src/languages/markdown.rs
@@ -18,7 +18,7 @@ pub const ELEMENT_QUERY: &str = r"
 /// Tree-sitter call query for Markdown (empty -- no call sites in Markdown).
 pub const CALL_QUERY: &str = "";
 
-#[cfg(all(test, feature = "lang-markdown"))]
+#[cfg(test)]
 mod tests {
     use tree_sitter::{Parser, StreamingIterator};
 

--- a/crates/aptu-coder-core/src/languages/mod.rs
+++ b/crates/aptu-coder-core/src/languages/mod.rs
@@ -7,34 +7,20 @@
 //! available language handlers are enabled): Astro, C/C++, C#, CSS, Fortran, Go,
 //! HTML, Java, JavaScript, JSON, Kotlin, Markdown, Python, Rust, TOML, TSX, TypeScript, YAML.
 
-#[cfg(feature = "lang-cpp")]
 pub mod cpp;
-#[cfg(feature = "lang-csharp")]
 pub mod csharp;
-#[cfg(feature = "lang-css")]
 pub mod css;
-#[cfg(feature = "lang-fortran")]
 pub mod fortran;
-#[cfg(feature = "lang-go")]
 pub mod go;
-#[cfg(feature = "lang-html")]
 pub mod html;
-#[cfg(feature = "lang-java")]
 pub mod java;
-#[cfg(feature = "lang-javascript")]
 pub mod javascript;
-#[cfg(feature = "lang-kotlin")]
 pub mod kotlin;
-#[cfg(feature = "lang-markdown")]
 pub mod markdown;
-#[cfg(feature = "lang-python")]
 pub mod python;
 pub mod regex_fallback;
-#[cfg(feature = "lang-rust")]
 pub mod rust;
-#[cfg(any(feature = "lang-typescript", feature = "lang-tsx"))]
 pub mod typescript;
-#[cfg(feature = "lang-yaml")]
 pub mod yaml;
 
 use tree_sitter::{Language, Node};
@@ -85,7 +71,6 @@ pub struct LanguageInfo {
 #[allow(clippy::too_many_lines)] // exhaustive match over all supported languages; splitting harms readability
 pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
     match lang_name {
-        #[cfg(feature = "lang-rust")]
         "rust" => Some(LanguageInfo {
             name: "rust",
             language: tree_sitter_rust::LANGUAGE.into(),
@@ -101,7 +86,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(rust::find_receiver_type),
             extract_inheritance: Some(rust::extract_inheritance),
         }),
-        #[cfg(feature = "lang-python")]
         "python" => Some(LanguageInfo {
             name: "python",
             language: tree_sitter_python::LANGUAGE.into(),
@@ -117,7 +101,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: Some(python::extract_inheritance),
         }),
-        #[cfg(feature = "lang-typescript")]
         "typescript" => Some(LanguageInfo {
             name: "typescript",
             language: tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
@@ -133,7 +116,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: Some(typescript::extract_inheritance),
         }),
-        #[cfg(feature = "lang-tsx")]
         "tsx" => Some(LanguageInfo {
             name: "tsx",
             language: tree_sitter_typescript::LANGUAGE_TSX.into(),
@@ -149,7 +131,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: Some(typescript::extract_inheritance),
         }),
-        #[cfg(feature = "lang-go")]
         "go" => Some(LanguageInfo {
             name: "go",
             language: tree_sitter_go::LANGUAGE.into(),
@@ -165,7 +146,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(go::find_receiver_type),
             extract_inheritance: Some(go::extract_inheritance),
         }),
-        #[cfg(feature = "lang-cpp")]
         "c" | "cpp" => Some(LanguageInfo {
             name: if lang_name == "c" { "c" } else { "cpp" },
             language: tree_sitter_cpp::LANGUAGE.into(),
@@ -181,7 +161,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: Some(cpp::extract_inheritance),
         }),
-        #[cfg(feature = "lang-java")]
         "java" => Some(LanguageInfo {
             name: "java",
             language: tree_sitter_java::LANGUAGE.into(),
@@ -197,7 +176,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(java::find_receiver_type),
             extract_inheritance: Some(java::extract_inheritance),
         }),
-        #[cfg(feature = "lang-kotlin")]
         "kotlin" => Some(LanguageInfo {
             name: "kotlin",
             language: tree_sitter_kotlin_ng::LANGUAGE.into(),
@@ -213,7 +191,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(kotlin::find_receiver_type),
             extract_inheritance: Some(kotlin::extract_inheritance),
         }),
-        #[cfg(feature = "lang-fortran")]
         "fortran" => Some(LanguageInfo {
             name: "fortran",
             language: tree_sitter_fortran::LANGUAGE.into(),
@@ -229,7 +206,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(fortran::find_receiver_type),
             extract_inheritance: Some(fortran::extract_inheritance),
         }),
-        #[cfg(feature = "lang-csharp")]
         "csharp" => Some(LanguageInfo {
             name: "csharp",
             language: tree_sitter_c_sharp::LANGUAGE.into(),
@@ -245,7 +221,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: Some(csharp::find_receiver_type),
             extract_inheritance: Some(csharp::extract_inheritance),
         }),
-        #[cfg(feature = "lang-javascript")]
         "javascript" => Some(LanguageInfo {
             name: "javascript",
             language: tree_sitter_javascript::LANGUAGE.into(),
@@ -270,9 +245,7 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
         // skipping the file.
         // TODO: implement once tree-sitter-html ^0.25 ships.
         //       Track releases: https://github.com/tree-sitter/tree-sitter-html/releases
-        #[cfg(feature = "lang-html")]
         "html" => None,
-        #[cfg(feature = "lang-markdown")]
         "markdown" => Some(LanguageInfo {
             name: "markdown",
             language: tree_sitter_md::LANGUAGE.into(),
@@ -288,7 +261,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: None,
         }),
-        #[cfg(feature = "lang-css")]
         "css" => Some(LanguageInfo {
             name: "css",
             language: tree_sitter_css::LANGUAGE.into(),
@@ -304,7 +276,6 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
             find_receiver_type: None,
             extract_inheritance: None,
         }),
-        #[cfg(feature = "lang-yaml")]
         "yaml" => Some(LanguageInfo {
             name: "yaml",
             language: tree_sitter_yaml::LANGUAGE.into(),
@@ -330,31 +301,18 @@ pub fn get_language_info(lang_name: &str) -> Option<LanguageInfo> {
 #[must_use]
 pub fn get_ts_language(lang_name: &str) -> Option<Language> {
     match lang_name {
-        #[cfg(feature = "lang-rust")]
         "rust" => Some(tree_sitter_rust::LANGUAGE.into()),
-        #[cfg(feature = "lang-python")]
         "python" => Some(tree_sitter_python::LANGUAGE.into()),
-        #[cfg(feature = "lang-typescript")]
         "typescript" => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
-        #[cfg(feature = "lang-tsx")]
         "tsx" => Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
-        #[cfg(feature = "lang-go")]
         "go" => Some(tree_sitter_go::LANGUAGE.into()),
-        #[cfg(feature = "lang-cpp")]
         "c" | "cpp" => Some(tree_sitter_cpp::LANGUAGE.into()),
-        #[cfg(feature = "lang-java")]
         "java" => Some(tree_sitter_java::LANGUAGE.into()),
-        #[cfg(feature = "lang-kotlin")]
         "kotlin" => Some(tree_sitter_kotlin_ng::LANGUAGE.into()),
-        #[cfg(feature = "lang-fortran")]
         "fortran" => Some(tree_sitter_fortran::LANGUAGE.into()),
-        #[cfg(feature = "lang-csharp")]
         "csharp" => Some(tree_sitter_c_sharp::LANGUAGE.into()),
-        #[cfg(feature = "lang-javascript")]
         "javascript" => Some(tree_sitter_javascript::LANGUAGE.into()),
-        #[cfg(feature = "lang-css")]
         "css" => Some(tree_sitter_css::LANGUAGE.into()),
-        #[cfg(feature = "lang-yaml")]
         "yaml" => Some(tree_sitter_yaml::LANGUAGE.into()),
         _ => None,
     }
@@ -367,9 +325,7 @@ pub fn get_ts_language(lang_name: &str) -> Option<Language> {
 #[must_use]
 pub fn try_regex_fallback(source: &str, language: &str) -> Option<crate::types::SemanticAnalysis> {
     match language {
-        #[cfg(not(feature = "lang-css"))]
         "css" => Some(regex_fallback::extract_css(source)),
-        #[cfg(not(feature = "lang-yaml"))]
         "yaml" => Some(regex_fallback::extract_yaml(source)),
         "json" => Some(regex_fallback::extract_json(source)),
         "toml" => Some(regex_fallback::extract_toml(source)),

--- a/crates/aptu-coder-core/src/languages/python.rs
+++ b/crates/aptu-coder-core/src/languages/python.rs
@@ -67,7 +67,7 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
-#[cfg(all(test, feature = "lang-python"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;

--- a/crates/aptu-coder-core/src/languages/regex_fallback.rs
+++ b/crates/aptu-coder-core/src/languages/regex_fallback.rs
@@ -220,7 +220,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "lang-typescript")]
     #[test]
     fn test_regex_fallback_astro_basic() {
         // Arrange: Astro file with TypeScript frontmatter

--- a/crates/aptu-coder-core/src/languages/rust.rs
+++ b/crates/aptu-coder-core/src/languages/rust.rs
@@ -122,7 +122,7 @@ pub fn extract_inheritance(_node: &Node, _source: &str) -> Vec<String> {
     Vec::new()
 }
 
-#[cfg(all(test, feature = "lang-rust"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::parser::SemanticExtractor;

--- a/crates/aptu-coder-core/src/languages/typescript.rs
+++ b/crates/aptu-coder-core/src/languages/typescript.rs
@@ -96,7 +96,7 @@ pub fn extract_inheritance(node: &Node, source: &str) -> Vec<String> {
     inherits
 }
 
-#[cfg(all(test, any(feature = "lang-typescript", feature = "lang-tsx")))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::DefUseKind;
@@ -111,7 +111,6 @@ mod tests {
         parser.parse(src, None).expect("Failed to parse TypeScript")
     }
 
-    #[cfg(feature = "lang-tsx")]
     fn parse_tsx(src: &str) -> tree_sitter::Tree {
         let mut parser = Parser::new();
         parser
@@ -216,7 +215,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "lang-tsx")]
     #[test]
     fn test_tsx_element_query_with_jsx() {
         // Arrange -- a TSX functional component parsed with the TSX grammar

--- a/crates/aptu-coder-core/src/languages/yaml.rs
+++ b/crates/aptu-coder-core/src/languages/yaml.rs
@@ -15,7 +15,7 @@ pub const ELEMENT_QUERY: &str = r"
 /// Tree-sitter call query for YAML (empty -- no call sites in YAML).
 pub const CALL_QUERY: &str = "";
 
-#[cfg(all(test, feature = "lang-yaml"))]
+#[cfg(test)]
 mod tests {
     use tree_sitter::{Parser, StreamingIterator};
 

--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -1578,11 +1578,10 @@ pub(crate) fn execute_query_impl(
     Ok(captures)
 }
 
-// Language-feature-gated tests (require lang-rust); see also tests_unsupported below
-#[cfg(all(test, feature = "lang-rust"))]
+#[cfg(test)]
+// Tests for parser functionality
 mod tests {
     use super::*;
-    use std::path::Path;
 
     #[test]
     fn test_ast_recursion_limit_zero_is_unlimited() {
@@ -1802,8 +1801,8 @@ fn main() {
     }
 }
 
-// Language-feature-gated tests for Python
-#[cfg(all(test, feature = "lang-python"))]
+#[cfg(test)]
+// Tests for Python language parsing
 mod tests_python {
     use super::*;
 

--- a/crates/aptu-coder-core/tests/integration_tests.rs
+++ b/crates/aptu-coder-core/tests/integration_tests.rs
@@ -436,7 +436,6 @@ fn test_semantic_analysis_empty_file() {
     assert!(!output.formatted.contains("R:"));
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -469,7 +468,6 @@ class MyClass:
     assert_eq!(output.semantic.classes[0].name, "MyClass");
 }
 
-#[cfg(feature = "lang-javascript")]
 #[test]
 fn test_javascript_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -499,7 +497,6 @@ import {x} from 'module';
     assert!(output.semantic.imports.len() >= 1);
 }
 
-#[cfg(feature = "lang-javascript")]
 #[test]
 fn test_javascript_commonjs_require() {
     let temp_dir = TempDir::new().unwrap();
@@ -534,7 +531,6 @@ const path = require('path');
     );
 }
 
-#[cfg(feature = "lang-typescript")]
 #[test]
 fn test_typescript_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -591,7 +587,6 @@ class MyClass {
     assert!(class_names.contains(&"MyClass"));
 }
 
-#[cfg(feature = "lang-go")]
 #[test]
 fn test_go_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -632,7 +627,6 @@ type MyInterface interface {
     assert!(class_names.contains(&"MyInterface"));
 }
 
-#[cfg(feature = "lang-java")]
 #[test]
 fn test_java_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -1413,7 +1407,6 @@ fn test_format_summary_sibling_dir_prefix() {
 
 // Reference extraction tests for Python, Java, and TypeScript
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_reference_extraction_happy_path() {
     let temp_dir = TempDir::new().unwrap();
@@ -1465,7 +1458,6 @@ def process(items: list[User]) -> None:
     }
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_reference_extraction_edge_case() {
     let temp_dir = TempDir::new().unwrap();
@@ -1517,6 +1509,7 @@ def handle(data: list[dict[Result, Data]]) -> None:
 
 // Import extraction tests
 
+#[allow(dead_code)]
 struct ImportTestCase {
     lang: &'static str,
     ext: &'static str,
@@ -1524,12 +1517,6 @@ struct ImportTestCase {
     expected_modules: Vec<&'static str>,
 }
 
-#[cfg(any(
-    feature = "lang-python",
-    feature = "lang-go",
-    feature = "lang-java",
-    feature = "lang-typescript"
-))]
 #[test]
 fn test_import_extraction_happy_path() {
     let test_cases = vec![
@@ -1630,12 +1617,6 @@ export function hello(): void {
     }
 }
 
-#[cfg(any(
-    feature = "lang-python",
-    feature = "lang-go",
-    feature = "lang-java",
-    feature = "lang-typescript"
-))]
 #[test]
 fn test_import_extraction_no_imports() {
     let test_cases = vec![
@@ -1892,7 +1873,6 @@ fn test_single_page_no_cursor() {
 
 // Inheritance extraction tests
 
-#[cfg(feature = "lang-java")]
 #[test]
 fn test_java_inheritance_extraction() {
     let temp_dir = TempDir::new().unwrap();
@@ -1945,7 +1925,6 @@ public class Dog extends Animal implements Comparable {
     );
 }
 
-#[cfg(feature = "lang-typescript")]
 #[test]
 fn test_typescript_inheritance_extraction() {
     let temp_dir = TempDir::new().unwrap();
@@ -1997,7 +1976,6 @@ class Dog extends Animal implements Movable {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_inheritance_extraction() {
     let temp_dir = TempDir::new().unwrap();
@@ -2033,7 +2011,6 @@ class Dog(Animal):
     );
 }
 
-#[cfg(feature = "lang-go")]
 #[test]
 fn test_go_inheritance_extraction() {
     let temp_dir = TempDir::new().unwrap();
@@ -3343,7 +3320,6 @@ fn test_overview_force_true_with_cursor_no_guard() {
 
 // Python wildcard import resolution tests
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_wildcard_import_parser_clean_module_field() {
     let temp_dir = TempDir::new().unwrap();
@@ -3367,7 +3343,6 @@ fn test_python_wildcard_import_parser_clean_module_field() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_wildcard_import_relative_resolution() {
     let temp_dir = TempDir::new().unwrap();
@@ -3406,7 +3381,6 @@ fn test_python_wildcard_import_relative_resolution() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_wildcard_import_with_all() {
     let temp_dir = TempDir::new().unwrap();
@@ -3455,7 +3429,6 @@ fn test_python_wildcard_import_with_all() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_wildcard_import_target_not_found() {
     let temp_dir = TempDir::new().unwrap();
@@ -3483,7 +3456,6 @@ fn test_python_wildcard_import_target_not_found() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_named_import_from_statement() {
     let temp_dir = TempDir::new().unwrap();
@@ -3548,7 +3520,6 @@ fn test_analyze_module_dir_guard_rejects_symlink_to_directory() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_aliased_import_from_statement() {
     let temp_dir = TempDir::new().unwrap();
@@ -3605,7 +3576,6 @@ fn test_analyze_directory_verbose_no_summary() {
     );
 }
 
-#[cfg(feature = "lang-fortran")]
 #[test]
 fn test_fortran_parse_and_extract() {
     let temp_dir = TempDir::new().unwrap();
@@ -3656,7 +3626,6 @@ END MODULE math_utils
     );
 }
 
-#[cfg(feature = "lang-fortran")]
 #[test]
 fn test_fortran_edge_case_fixed_form() {
     // Fixed-form layout with columns 1-5 blank, statement starting col 7.
@@ -3786,7 +3755,6 @@ fn test_format_summary_max_depth_zero_unchanged() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_analyze_symbol_python_callees() {
     let dir = TempDir::new().unwrap();
@@ -3805,7 +3773,6 @@ fn test_analyze_symbol_python_callees() {
     );
 }
 
-#[cfg(feature = "lang-go")]
 #[test]
 fn test_analyze_symbol_go_callees() {
     let dir = TempDir::new().unwrap();
@@ -3823,7 +3790,6 @@ fn test_analyze_symbol_go_callees() {
     );
 }
 
-#[cfg(feature = "lang-typescript")]
 #[test]
 fn test_analyze_symbol_typescript_callees() {
     let dir = TempDir::new().unwrap();
@@ -3841,7 +3807,6 @@ fn test_analyze_symbol_typescript_callees() {
     );
 }
 
-#[cfg(feature = "lang-fortran")]
 #[test]
 fn test_analyze_symbol_fortran_callees() {
     let dir = TempDir::new().unwrap();
@@ -3876,7 +3841,6 @@ fn test_analyze_symbol_rust_method_item_callees() {
     );
 }
 
-#[cfg(feature = "lang-java")]
 #[test]
 fn test_analyze_symbol_java_callees() {
     let dir = TempDir::new().unwrap();
@@ -3953,7 +3917,6 @@ fn test_analyze_symbol_no_callees_no_transition_cursor() {
     );
 }
 
-#[cfg(feature = "lang-rust")]
 #[test]
 fn test_execute_query_valid_rust() {
     // Arrange: source with a function
@@ -4000,7 +3963,6 @@ fn test_execute_query_malformed_query() {
     );
 }
 
-#[cfg(feature = "lang-csharp")]
 #[test]
 fn test_csharp_parse_and_extract() {
     // Arrange
@@ -4033,7 +3995,6 @@ namespace Demo {
     assert_eq!(fa.function_count, 3);
 }
 
-#[cfg(feature = "lang-csharp")]
 #[test]
 fn test_csharp_inheritance_extraction() {
     // Arrange
@@ -4076,7 +4037,6 @@ class Dog : Base, IRun {
     );
 }
 
-#[cfg(feature = "lang-csharp")]
 #[test]
 fn test_csharp_struct_and_enum_extraction() {
     // Arrange
@@ -4108,7 +4068,6 @@ public enum Direction { North, South, East, West }
     );
 }
 
-#[cfg(feature = "lang-csharp")]
 #[test]
 fn test_analyze_symbol_csharp_callees() {
     // Arrange
@@ -4131,7 +4090,6 @@ fn test_analyze_symbol_csharp_callees() {
     );
 }
 
-#[cfg(feature = "lang-tsx")]
 #[test]
 fn test_integration_tsx_analyze_file() {
     // Arrange
@@ -4187,7 +4145,6 @@ export default Button;
 }
 
 // C files share the lang-cpp feature flag; C and C++ use the same tree-sitter grammar
-#[cfg(feature = "lang-cpp")]
 #[test]
 fn test_integration_c_analyze_file() {
     // Arrange
@@ -4239,7 +4196,6 @@ int add(int a, int b) {
     );
 }
 
-#[cfg(feature = "lang-cpp")]
 #[test]
 fn test_integration_cpp_analyze_file() {
     // Arrange
@@ -4416,7 +4372,6 @@ fn test_symlink_file_skipped_in_analyze_directory() {
 fn test_large_file_skipped_no_panic() {
     use aptu_coder_core::analyze::{MAX_FILE_SIZE_BYTES, analyze_directory};
     use std::fs::File;
-    use std::io::Write;
 
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();
@@ -4427,7 +4382,7 @@ fn test_large_file_skipped_no_panic() {
 
     // Create a sparse file exceeding MAX_FILE_SIZE_BYTES without writing data
     let large_file = root.join("large.rs");
-    let mut file = File::create(&large_file).unwrap();
+    let file = File::create(&large_file).unwrap();
     file.set_len(MAX_FILE_SIZE_BYTES + 1).unwrap();
     drop(file);
 
@@ -4449,7 +4404,6 @@ fn test_large_file_skipped_no_panic() {
 
 // Test additions for attribute/decorator line reporting
 
-#[cfg(feature = "lang-rust")]
 #[test]
 fn test_rust_function_attribute_line_reported() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4469,7 +4423,6 @@ fn test_rust_function_attribute_line_reported() {
     );
 }
 
-#[cfg(feature = "lang-rust")]
 #[test]
 fn test_rust_function_no_attribute_unchanged() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4486,7 +4439,6 @@ fn test_rust_function_no_attribute_unchanged() {
     );
 }
 
-#[cfg(feature = "lang-rust")]
 #[test]
 fn test_rust_function_multiple_stacked_attributes() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4503,7 +4455,6 @@ fn test_rust_function_multiple_stacked_attributes() {
     );
 }
 
-#[cfg(feature = "lang-rust")]
 #[test]
 fn test_rust_impl_method_attribute_line_reported() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4523,7 +4474,6 @@ fn test_rust_impl_method_attribute_line_reported() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_decorated_function_reports_decorator_line() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4540,7 +4490,6 @@ fn test_python_decorated_function_reports_decorator_line() {
     );
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_python_plain_function_reports_def_line() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4594,7 +4543,6 @@ use std::io;
     assert_eq!(result.language, "rust");
 }
 
-#[cfg(feature = "lang-python")]
 #[test]
 fn test_extract_module_info_python() {
     use aptu_coder_core::parser::SemanticExtractor;
@@ -4627,7 +4575,6 @@ def farewell():
     assert_eq!(result.language, "python");
 }
 
-#[cfg(feature = "lang-typescript")]
 #[test]
 fn test_extract_module_info_typescript() {
     use aptu_coder_core::parser::SemanticExtractor;

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.22", features = ["schemars", "lang-rust", "lang-go", "lang-java", "lang-python", "lang-typescript", "lang-tsx", "lang-fortran", "lang-javascript", "lang-cpp", "lang-csharp"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.22", features = ["schemars"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -121,32 +121,27 @@ fn parse_port(s: &str) -> Result<u16, String> {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    aws_lc_rs::default_provider()
-        .install_default()
-        .expect("failed to install rustls CryptoProvider");
-
+/// Parse CLI arguments and resolve the optional HTTP port.
+///
+/// Returns `Ok(None)` when the server should run in stdio mode (no `--port`),
+/// `Ok(Some(port))` when an HTTP port was specified, or `Err(msg)` on invalid
+/// input.  Prints the package version and returns `Ok(None)` when `--version`
+/// is passed; the caller is responsible for exiting after printing.
+fn parse_cli_args() -> Result<Option<u16>, String> {
     let mut port: Option<u16> = None;
     let mut args = std::env::args();
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--version" => {
                 println!("{}", env!("CARGO_PKG_VERSION"));
-                return Ok(());
+                return Ok(None);
             }
             "--port" => match args.next() {
                 Some(val) => match parse_port(&val) {
                     Ok(p) => port = Some(p),
-                    Err(msg) => {
-                        eprintln!("error: --port {msg}");
-                        std::process::exit(1);
-                    }
+                    Err(msg) => return Err(format!("--port {msg}")),
                 },
-                None => {
-                    eprintln!("error: --port requires a value");
-                    std::process::exit(1);
-                }
+                None => return Err("--port requires a value".to_string()),
             },
             _ => {}
         }
@@ -158,37 +153,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     {
         match parse_port(&val) {
             Ok(p) => port = Some(p),
-            Err(msg) => {
-                eprintln!("error: APTU_CODER_PORT {msg}");
-                std::process::exit(1);
-            }
+            Err(msg) => return Err(format!("APTU_CODER_PORT {msg}")),
         }
     }
 
-    // Initialize OpenTelemetry (returns None if OTEL_EXPORTER_OTLP_ENDPOINT is unset)
-    let otel_provider = init_otel();
-    let log_provider = init_log_appender();
-    let meter_provider = init_meter();
+    Ok(port)
+}
 
-    // Create shared peer Arc for logging layer
-    // Migrate legacy metrics directory if needed
-    if let Err(e) = aptu_coder::migrate_legacy_metrics_dir() {
-        tracing::warn!("Failed to migrate legacy metrics directory: {e}");
-    }
-    let peer = Arc::new(TokioMutex::new(None));
-
-    // Create shared level filter for dynamic control (std::sync::Mutex for Copy type)
-    let log_level_filter = Arc::new(Mutex::new(LevelFilter::WARN));
-
-    // Create unbounded channel for log events
-    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
-
-    // Create MCP logging layer with event sender
-    let mcp_logging_layer = McpLoggingLayer::new(event_tx, log_level_filter.clone());
-
-    // Build layered subscriber: fmt + MCP logging + optional OTel tracing + optional log bridge.
-    // tracing_subscriber accepts Option<impl Layer>; None is a no-op, so all combinations
-    // collapse to a single linear chain without branching.
+/// Install the global tracing subscriber with optional OpenTelemetry layers.
+///
+/// Builds a layered subscriber: stderr fmt layer + MCP logging layer + optional
+/// OTel tracing layer + optional OTel log bridge.  OTel layers are no-ops when
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` is unset.  Callers retain the original
+/// providers so they can be shut down after the service exits.
+fn setup_tracing(
+    mcp_logging_layer: McpLoggingLayer,
+    otel_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    log_provider: Option<opentelemetry_sdk::logs::SdkLoggerProvider>,
+) {
     use opentelemetry::trace::TracerProvider as _;
 
     let otel_trace_layer = otel_provider
@@ -205,6 +187,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(otel_trace_layer)
         .with(otel_log_layer)
         .init();
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
+    let port = match parse_cli_args() {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        }
+    };
+
+    // Initialize OpenTelemetry (returns None if OTEL_EXPORTER_OTLP_ENDPOINT is unset)
+    let otel_provider = init_otel();
+    let log_provider = init_log_appender();
+    let meter_provider = init_meter();
+
+    // Migrate legacy metrics directory if needed
+    if let Err(e) = aptu_coder::migrate_legacy_metrics_dir() {
+        tracing::warn!("Failed to migrate legacy metrics directory: {e}");
+    }
+
+    // Create shared peer Arc for logging layer
+    let peer = Arc::new(TokioMutex::new(None));
+
+    // Create shared level filter for dynamic control (std::sync::Mutex for Copy type)
+    let log_level_filter = Arc::new(Mutex::new(LevelFilter::WARN));
+
+    // Create unbounded channel for log events
+    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Create MCP logging layer with event sender
+    let mcp_logging_layer = McpLoggingLayer::new(event_tx, log_level_filter.clone());
+
+    // Install global tracing subscriber with optional OTel layers
+    setup_tracing(
+        mcp_logging_layer,
+        otel_provider.clone(),
+        log_provider.clone(),
+    );
 
     // Create metrics channel and spawn writer
     let (metrics_tx, metrics_rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
@@ -230,7 +256,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(log_prov) = log_provider
         && let Err(e) = log_prov.shutdown()
     {
-        tracing::warn!("Failed to shutdown OpenTelemetry log provider: {e}");
+        tracing::warn!("Failed to shutdown OpenTelemetry meter provider: {e}");
     }
 
     if let Some(meter_prov) = meter_provider


### PR DESCRIPTION
## Summary

Implements three items from issue #1225: workspace lint hygiene (F12), language feature flag unification (F13), and `main()` refactor (F15).

> **Merge order:** This PR must land **after** #1223. The lints added here will deny violations that #1223 fixes; merging in reverse order breaks CI.

## F12: Workspace lints

Added to `[workspace.lints.rust]`:
- `unreachable_pub = "warn"` (rustc lint; placed in the rust table, not clippy)

Added to `[workspace.lints.clippy]`:
- `must_use_candidate = "warn"`
- `redundant_clone = "warn"`
- `needless_pass_by_value = "warn"`
- `large_enum_variant = "warn"`

All new lints are at `"warn"` level (not `"deny"`) so they do not block CI before violations from prior work are fully cleared.

## F13: Remove lang-* feature gates

Policy chosen: **remove all feature gates unconditionally** (simpler build matrix, no partial language support confusion).

- Removed all `#[cfg(feature = "lang-*")]` attributes from `lang.rs`, `languages/mod.rs`, `languages/typescript.rs`, `languages/regex_fallback.rs`, and `analyze.rs` test functions
- Made all `tree-sitter-*` dependencies non-optional in `crates/aptu-coder-core/Cargo.toml`
- Removed the `[features]` `lang-*` entries from `crates/aptu-coder-core/Cargo.toml`
- Removed `lang-*` from the `features` list on the `aptu-coder-core` dep in `crates/aptu-coder/Cargo.toml`
- Added a policy comment at the top of `lang.rs` documenting the unconditional approach
- `schemars` feature and all `#[cfg(feature = "schemars")]` guards are untouched

## F15: Extract helpers from `main()`

- `parse_cli_args() -> Result<Option<u16>, String>`: handles `--version`, `--port`, and `APTU_CODER_PORT` env var. Replaces `process::exit(1)` calls with `Err(msg)` returns; caller in `main()` handles the exit.
- `setup_tracing(mcp_logging_layer, otel_provider, log_provider)`: installs the global tracing subscriber (stderr fmt + MCP logging + optional OTel layers). Callers retain the original providers for shutdown.
- Service dispatch and OTel provider shutdown remain in `main()`.

Closes #1225
