### PR TITLE
chore: add .github/aptu.yml to enable aptu triage and review

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -1,0 +1,6 @@
+version: 1
+triage:
+  enabled: true
+review:
+  enabled: true
+  instructions-file: .github/instructions/pr-review.md


### PR DESCRIPTION
Add `.github/aptu.yml` to opt this repository into aptu automated issue triage and PR review via the aptu-github-app webhook.

The worker dispatches only when this file is present with `enabled: true` -- no file means no dispatch.