### PR TITLE
fix(parser): replace debug_assert with tracing::debug in extract_calls hop cap (#1251)

### DIFF
--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -1817,6 +1817,36 @@ fn caller() {
             "extract must return call entries for source with function calls"
         );
     }
+
+    #[test]
+    fn extract_calls_caps_arg_count_at_sixteen_hops() {
+        // Regression test for #1251: verify deeply nested parenthesized arguments
+        // (20 levels) do not cause a panic. The inner call `g()` is always at 1 hop
+        // from its enclosing call_expression (function identifier is a direct child),
+        // so arg_count is Some(0) -- the cap only fires when the captured node is
+        // deeper in the AST than the direct function child of a call_expression.
+        let src = r#"fn main() { f((((((((((((((((((((g())))))))))))))))))))); }"#;
+        let result = SemanticExtractor::extract(src, "rust", None, None);
+        assert!(
+            result.is_ok(),
+            "extract must succeed even with deeply nested parenthesized arguments"
+        );
+        let output = result.unwrap();
+        let g_calls: Vec<&CallInfo> = output.calls.iter().filter(|c| c.callee == "g").collect();
+        assert_eq!(
+            g_calls.len(),
+            1,
+            "expected exactly one CallInfo with callee 'g', got {}",
+            g_calls.len()
+        );
+        // arg_count is Some(0) because g() has 0 arguments; the >16 hop cap is
+        // a parent-traversal guard on the captured node, not on the call nesting.
+        assert_eq!(
+            g_calls[0].arg_count,
+            Some(0),
+            "g() has 0 arguments, expected Some(0)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/aptu-coder-core/src/parser.rs
+++ b/crates/aptu-coder-core/src/parser.rs
@@ -990,7 +990,6 @@ impl SemanticExtractor {
                     let mut arg_count = None;
                     let mut arg_node = node;
                     let mut hop = 0u32;
-                    let mut cap_hit = false;
                     while let Some(parent) = arg_node.parent() {
                         hop += 1;
                         // Bounded parent traversal: cap at 16 hops to guard against pathological
@@ -999,7 +998,7 @@ impl SemanticExtractor {
                         // leave arg_count as None; the caller is still recorded, just without
                         // argument-count information.
                         if hop > 16 {
-                            cap_hit = true;
+                            tracing::debug!(hop, callee = %call_name, "extract_calls: parent traversal cap reached; arg_count will be None");
                             break;
                         }
                         if parent.kind() == "call_expression" {
@@ -1010,11 +1009,6 @@ impl SemanticExtractor {
                         }
                         arg_node = parent;
                     }
-                    debug_assert!(
-                        !cap_hit,
-                        "extract_calls: parent traversal cap reached (hop > 16)"
-                    );
-
                     calls.push(CallInfo {
                         caller,
                         callee: call_name,
@@ -1798,6 +1792,30 @@ fn main() {
 
         // Assert
         assert!(sites.is_empty(), "expected empty for nonexistent symbol");
+    }
+
+    #[test]
+    fn extract_calls_does_not_panic_on_function_calls() {
+        // Regression test for #1251: debug_assert in extract_calls fired on degenerate
+        // ASTs and killed the server process via panic=abort. Verify extract() succeeds
+        // and returns call info for normal source.
+        let src = r#"
+fn caller() {
+    callee_a();
+    callee_b(1, 2);
+    nested::callee_c();
+}
+"#;
+        let result = SemanticExtractor::extract(src, "rust", None, None);
+        assert!(
+            result.is_ok(),
+            "extract must not panic or error on valid source"
+        );
+        let output = result.unwrap();
+        assert!(
+            !output.calls.is_empty(),
+            "extract must return call entries for source with function calls"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes SIGABRT crash in aptu-coder caused by a debug_assert! that fires on degenerate or malformed ASTs during parent traversal in extract_calls. With panic=abort in the release profile, this assertion kills the entire server process.

## Root Cause

IPS backtrace analysis of 19 identical crash reports all point to extract_calls -> collect_file_analysis -> rayon thread join, with debug_assert firing when parent traversal exceeds 16 hops. The code already implements graceful fallback (cap_hit=true; break; arg_count remains None), so the assertion is redundant and dangerous in production.

## Changes

- Removed debug_assert!(lines 1013-1016) entirely from extract_calls hop cap block
- Added tracing::debug! at the cap site to record hop count and callee name for production observability
- Removed cap_hit variable entirely (it was write-only after assert removal)
- Added regression test: test_extract_calls_does_not_panic_on_function_calls

All 234 tests pass. Clippy clean.

## Test Plan

- [x] Tests pass (see 03-build.json: 234 passed, 0 failed)
- [x] Linter clean (cargo clippy -p aptu-coder-core -- -D warnings)
- [x] Formatter clean (cargo fmt --check)
- [x] Security scan clean (no Critical/High findings)

## Notes

Guard alert: The 16-hop arg_count traversal may be unreachable for well-formed code. The crash could also involve enclosing_function_name's 64-hop traversal. If crashes continue after this fix, a follow-up investigation of that path should be opened.

Closes #1251
