### PR TITLE
chore(release): bump version to 0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
Bump workspace version `0.22.1` -> `0.22.2` to cut a patch release for the cross-process file locking fix landed in #1255.

Closes #1254

## Changes

- `Cargo.toml`: version `0.22.1` -> `0.22.2`
- `Cargo.lock`: updated crate versions accordingly
