### PR TITLE
fix(logging): remove log-consumer task that closes transport

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -167,7 +167,7 @@ use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use tokio::sync::{Mutex as TokioMutex, RwLock, mpsc};
+use tokio::sync::{Mutex as TokioMutex, RwLock};
 use tracing::instrument;
 use tracing_subscriber::filter::LevelFilter;
 
@@ -204,7 +204,6 @@ pub struct CodeAnalyzer {
     disk_cache: std::sync::Arc<cache::DiskCache>,
     peer: Arc<TokioMutex<Option<Peer<RoleServer>>>>,
     log_level_filter: Arc<Mutex<LevelFilter>>,
-    event_rx: Arc<TokioMutex<Option<mpsc::UnboundedReceiver<LogEvent>>>>,
     metrics_tx: crate::metrics::MetricsSender,
     session_call_seq: Arc<std::sync::atomic::AtomicU32>,
     session_id: Arc<TokioMutex<Option<String>>>,
@@ -238,10 +237,9 @@ impl CodeAnalyzer {
     pub fn new(
         peer: Arc<TokioMutex<Option<Peer<RoleServer>>>>,
         log_level_filter: Arc<Mutex<LevelFilter>>,
-        event_rx: mpsc::UnboundedReceiver<LogEvent>,
         metrics_tx: crate::metrics::MetricsSender,
     ) -> Self {
-        crate::tools::server::build_analyzer(peer, log_level_filter, event_rx, metrics_tx)
+        crate::tools::server::build_analyzer(peer, log_level_filter, metrics_tx)
     }
 
     /// Emit a "received" metric event for the given tool name.
@@ -775,7 +773,6 @@ impl ServerHandler for CodeAnalyzer {
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {
         crate::tools::server::on_initialized_impl(
             self.peer.clone(),
-            self.event_rx.clone(),
             self.session_id.clone(),
             self.session_call_seq.clone(),
             self.session_profile.clone(),

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -219,8 +219,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create shared level filter for dynamic control (std::sync::Mutex for Copy type)
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::WARN));
 
-    // Create unbounded channel for log events
-    let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    // Create unbounded channel for log events; receiver is intentionally dropped --
+    // the log-consumer task was removed in fix(logging) and the capability is no
+    // longer advertised. The sender (held by McpLoggingLayer) silently discards
+    // events when the receiver is gone.
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
 
     // Create MCP logging layer with event sender
     let mcp_logging_layer = McpLoggingLayer::new(event_tx, log_level_filter.clone());
@@ -236,7 +239,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (metrics_tx, metrics_rx) = tokio::sync::mpsc::unbounded_channel::<MetricEvent>();
     tokio::spawn(MetricsWriter::new(metrics_rx, None).run());
 
-    let analyzer = CodeAnalyzer::new(peer, log_level_filter, event_rx, MetricsSender(metrics_tx));
+    let analyzer = CodeAnalyzer::new(peer, log_level_filter, MetricsSender(metrics_tx));
 
     if let Some(p) = port {
         run_http(analyzer, p).await?;

--- a/crates/aptu-coder/src/tests.rs
+++ b/crates/aptu-coder/src/tests.rs
@@ -9,12 +9,10 @@ use regex::Regex;
 fn make_analyzer() -> CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
     CodeAnalyzer::new(
         peer,
         log_level_filter,
-        rx,
         crate::metrics::MetricsSender(metrics_tx),
     )
 }
@@ -95,12 +93,10 @@ async fn test_handle_overview_mode_no_summary_block() {
 
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
     let analyzer = CodeAnalyzer::new(
         peer,
         log_level_filter,
-        rx,
         crate::metrics::MetricsSender(metrics_tx),
     );
 
@@ -147,12 +143,10 @@ async fn test_analyze_directory_summary_false_forces_pagination() {
 
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
     let analyzer = CodeAnalyzer::new(
         peer,
         log_level_filter,
-        rx,
         crate::metrics::MetricsSender(metrics_tx),
     );
 

--- a/crates/aptu-coder/src/tools/server.rs
+++ b/crates/aptu-coder/src/tools/server.rs
@@ -8,18 +8,16 @@
 //! `lib.rs`. This module contains the extracted bodies called by thin shims.
 
 use crate::filters::load_filter_table;
-use crate::logging::LogEvent;
 use crate::shell::resolve_shell;
 use aptu_coder_core::cache::{AnalysisCache, CallGraphCache};
 use rmcp::handler::server::tool::ToolRouter;
-use rmcp::model::{LoggingMessageNotificationParam, Notification, ServerNotification};
 use rmcp::{Peer, RoleServer};
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use tokio::sync::{Mutex as TokioMutex, RwLock, mpsc};
-use tracing::{instrument, warn};
+use tokio::sync::{Mutex as TokioMutex, RwLock};
+use tracing::instrument;
 use tracing_subscriber::filter::LevelFilter;
 
 /// Builds a fully initialized `CodeAnalyzer`.
@@ -29,7 +27,6 @@ use tracing_subscriber::filter::LevelFilter;
 pub(crate) fn build_analyzer(
     peer: Arc<TokioMutex<Option<Peer<RoleServer>>>>,
     log_level_filter: Arc<Mutex<LevelFilter>>,
-    event_rx: mpsc::UnboundedReceiver<LogEvent>,
     metrics_tx: crate::metrics::MetricsSender,
 ) -> crate::CodeAnalyzer {
     let file_cap: usize = std::env::var("APTU_CODER_FILE_CACHE_CAPACITY")
@@ -108,7 +105,6 @@ pub(crate) fn build_analyzer(
         disk_cache,
         peer,
         log_level_filter,
-        event_rx: Arc::new(TokioMutex::new(Some(event_rx))),
         metrics_tx,
         session_call_seq: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         session_id: Arc::new(TokioMutex::new(None)),
@@ -130,10 +126,9 @@ pub(crate) fn build_analyzer(
 /// Handles the `on_initialized` server lifecycle event.
 ///
 /// Contains the logic previously in `ServerHandler::on_initialized`.
-#[instrument(skip(peer, event_rx, tool_router))]
+#[instrument(skip(peer, tool_router))]
 pub(crate) async fn on_initialized_impl(
     peer: Arc<TokioMutex<Option<Peer<RoleServer>>>>,
-    event_rx: Arc<TokioMutex<Option<mpsc::UnboundedReceiver<LogEvent>>>>,
     session_id: Arc<TokioMutex<Option<String>>>,
     session_call_seq: Arc<std::sync::atomic::AtomicU32>,
     session_profile: Arc<std::sync::OnceLock<String>>,
@@ -191,44 +186,6 @@ pub(crate) async fn on_initialized_impl(
 
         router.bind_peer_notifier(context_peer);
     }
-
-    // Spawn consumer task to drain log events from channel with batching.
-    let peer_clone = peer.clone();
-    let event_rx_clone = event_rx.clone();
-
-    tokio::spawn(async move {
-        let rx = {
-            let mut rx_lock = event_rx_clone.lock().await;
-            rx_lock.take()
-        };
-
-        if let Some(mut receiver) = rx {
-            let mut buffer = Vec::with_capacity(64);
-            loop {
-                receiver.recv_many(&mut buffer, 64).await;
-
-                if buffer.is_empty() {
-                    break;
-                }
-
-                let peer_lock = peer_clone.lock().await;
-                if let Some(peer_ref) = peer_lock.as_ref() {
-                    for log_event in buffer.drain(..) {
-                        let notification = ServerNotification::LoggingMessageNotification(
-                            Notification::new(LoggingMessageNotificationParam {
-                                level: log_event.level,
-                                logger: Some(log_event.logger),
-                                data: log_event.data,
-                            }),
-                        );
-                        if let Err(e) = peer_ref.send_notification(notification).await {
-                            warn!("Failed to send logging notification: {}", e);
-                        }
-                    }
-                }
-            }
-        }
-    });
 }
 
 /// Disables the given tool routes on the router.

--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -10,12 +10,10 @@ use tracing_subscriber::filter::LevelFilter;
 pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     let peer = Arc::new(TokioMutex::new(None));
     let log_level_filter = Arc::new(Mutex::new(LevelFilter::INFO));
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<aptu_coder::LogEvent>();
     let (metrics_tx, _metrics_rx) = tokio::sync::mpsc::unbounded_channel();
     aptu_coder::CodeAnalyzer::new(
         peer,
         log_level_filter,
-        rx,
         aptu_coder::MetricsSender(metrics_tx),
     )
 }

--- a/crates/aptu-coder/tests/transport_closed_after_tracing_event.rs
+++ b/crates/aptu-coder/tests/transport_closed_after_tracing_event.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+//! Transport stability: a tracing event must not close the transport.
+//!
+//! Before fix (308d66f dropped enable_logging() but left the log-consumer task running),
+//! the first tracing event emitted during a tool call caused the log-consumer task to
+//! send a logging/message notification to the peer. Since the logging capability was not
+//! advertised, the transport write failed and closed stdout. Every subsequent tool call
+//! then returned -32603 Transport closed.
+
+mod common;
+
+/// Transport must stay open after a tool call that emits a tracing event.
+///
+/// Before the fix, exec_command (id:3) would return a JSON-RPC error with code -32603
+/// ("Transport closed") because the log-consumer task closed stdout on the first
+/// tracing event (analyze_file cache-miss path). Any tool emitting a tracing event
+/// before the session's first response would trigger the same failure.
+#[tokio::test]
+async fn transport_stays_open_after_tracing_event() {
+    let responses = common::call_tool_raw_seq(vec![
+        (
+            "analyze_file",
+            serde_json::json!({
+                "path": "Cargo.toml",
+                "page_size": 100
+            }),
+        ),
+        (
+            "exec_command",
+            serde_json::json!({
+                "command": "echo ok"
+            }),
+        ),
+    ])
+    .await;
+
+    assert_eq!(responses.len(), 2, "expected exactly 2 responses");
+
+    // analyze_file must succeed (no JSON-RPC protocol error)
+    let af = &responses[0];
+    assert!(
+        af.get("result").is_some(),
+        "analyze_file must return a result, got: {af}"
+    );
+    assert!(
+        af.get("error").is_none(),
+        "analyze_file must not return a JSON-RPC error, got: {af}"
+    );
+
+    // exec_command must succeed -- before the fix this returned -32603 Transport closed
+    let ec = &responses[1];
+    assert!(
+        ec.get("result").is_some(),
+        "exec_command must return a result after analyze_file (transport must stay open), got: {ec}"
+    );
+    assert!(
+        ec.get("error").is_none(),
+        "exec_command must not return -32603 Transport closed after analyze_file, got: {ec}"
+    );
+}


### PR DESCRIPTION
## Summary

Removes the log-consumer task from `on_initialized_impl` that was sending `logging/message` MCP notifications to the peer even though the logging capability was no longer advertised to clients. Also removes the now-dead `event_rx` field and all associated wiring end-to-end.

## Root cause

Commit 308d66f dropped `enable_logging()` from `ServerCapabilities` when upgrading to rmcp 1.8.0 (`ServerCapabilitiesBuilder::enable_logging` was deprecated per SEP-2577, MCP logging notifications removal). The `on_initialized_impl` log-consumer task was not removed alongside it.

On every tracing event (e.g. the `tracing::debug!` fired by `analyze_file` on its cache-miss path), the task called:

```rust
peer_ref.send_notification(ServerNotification::LoggingMessageNotification(...)).await
```

`Peer::send_notification` writes to the transport worker's internal channel and awaits a oneshot confirmation. The worker's sink serialises the notification to JSON and writes it to stdout. When logging capability is not advertised, the MCP client's JSON-RPC layer rejects the write, causing a `ServiceError::TransportClosed`. This closes stdout permanently. Every subsequent tool call then returns `-32603 Transport closed`.

`analyze_file` is the first tool in a typical session to fire a tracing event (cache miss), which is why the crash appeared to be specific to that tool -- any tool that emits a tracing event before the session's first tool-call response would trigger the same failure.

## Minimal repro

```
Client → initialize (no logging capability)
Client → notifications/initialized
Client → tools/call analyze_file  ← succeeds; tracing::debug! fires → notification sent → stdout closed
Client → tools/call exec_command  ← -32603 Transport closed
```

## Fix

Remove the `tokio::spawn` log-consumer block entirely from `on_initialized_impl`, and clean up the now-dead `event_rx` field from `CodeAnalyzer`, `build_analyzer`, `CodeAnalyzer::new`, `main.rs`, and all test call sites. The logging capability is intentionally not advertised, so the task serves no purpose. The `McpLoggingLayer` sender already ignores closed-receiver errors with `let _ = self.event_tx.send(log_event)`.

## Regression test

Added `crates/aptu-coder/tests/transport_closed_after_tracing_event.rs` using the `call_tool_raw_seq` harness. Calls `analyze_file` then `exec_command` and asserts both return `result` with no JSON-RPC error. This test would have failed on v0.22.x before this fix.

## Checklist

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` all passing (700+ tests)
- [x] Regression test added and passing
