### PR TITLE
docs: fix stale README and add MCP-surface doc comments (#1260)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,14 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 | `summary` | boolean | auto | Compact output; auto-triggers above 50K chars |
 | `cursor` | string | -- | Pagination cursor from a previous response's `next_cursor` |
 | `page_size` | integer | 100 | Items per page |
+| `git_ref` | string | -- | Restrict analysis to files changed relative to this git ref (branch, tag, or commit); requires a git repository; supported by `analyze_directory` and `analyze_symbol` |
 
 | Tool | Purpose | Languages |
 |------|---------|-----------|
 | `analyze_directory` | Directory tree with LOC, function, and class counts; respects `.gitignore` | all |
 | `analyze_file` | Functions, classes, and imports with signatures and line ranges; returns graceful fallback (line count, file head, no AST) for unsupported extensions | all |
 | `analyze_module` | Lightweight function and import index (~75% smaller than `analyze_file`); returns graceful fallback (empty index with note) for unsupported extensions | all |
-| `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth | all |
+| `analyze_symbol` | Call graph for a named symbol across a directory; callers, callees, call depth. `def_use=true` extracts write/read sites (paginated: first call returns cursor, paginate to retrieve results). `import_lookup=true` finds all files importing a module path; mutually exclusive with call-graph and def_use | all |
 | `edit_overwrite` | Create or overwrite a file; creates parent directories | any file |
 | `edit_replace` | Replace a unique exact text block; errors if zero or multiple matches; empty `new_text` deletes the block; CRLF normalized before matching | all |
 | `exec_command` | Run a shell command; returns stdout, stderr, exit code; output capped and filtered; optional `timeout_secs` (kill on expiry) and `drain_timeout_secs` (post-exit drain window); heredoc rejected before spawn (file-write pattern, stdin-consuming flag, stdin parameter conflict, or missing closing delimiter) | any |
@@ -186,7 +187,7 @@ For large codebases, several mechanisms prevent context overflow.
 
 **Pagination**
 
-`analyze_file` and `analyze_symbol` append a `NEXT_CURSOR:` line when output is truncated. Pass the token back as `cursor` to fetch the next page. `summary=true` and `cursor` are mutually exclusive; passing both returns an error.
+`analyze_file` and `analyze_symbol` append a `NEXT_CURSOR:` line when output is truncated. Pass the token back as `cursor` to fetch the next page. `summary=true` and `cursor` are mutually exclusive; passing both returns `INVALID_PARAMS`. See [AGENTS.md](https://github.com/clouatre-labs/aptu-coder/blob/main/AGENTS.md) for the full parameter constraint list.
 
 ```
 # Response ends with:
@@ -250,7 +251,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export on shutdown. |
 | `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
-| `APTU_CODER_PROFILE` | unset | Tool subset: `edit` (edit tools + `exec_command` only), `analyze` (analyze tools + `exec_command` only). Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
+| `APTU_CODER_PROFILE` | unset | Tool subset: `edit` disables all analyze_* tools (analyze_directory, analyze_file, analyze_module, analyze_symbol); `analyze` disables edit tools (edit_overwrite, edit_replace, exec_command, and aliases); absent or unknown enables all 7 tools. Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
 | `APTU_SHELL` | unset | Shell for `exec_command`. Defaults to `bash` then `/bin/sh`. |
 
 ### Telemetry

--- a/crates/aptu-coder-core/src/analyze.rs
+++ b/crates/aptu-coder-core/src/analyze.rs
@@ -30,6 +30,9 @@ use tracing::instrument;
 
 pub const MAX_FILE_SIZE_BYTES: u64 = 10_000_000;
 
+/// Errors that can occur during code analysis in the MCP tool surface.
+/// Returned as `isError: true` results by `analyze_directory`, `analyze_file`,
+/// `analyze_module`, and `analyze_symbol` tools.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum AnalyzeError {
@@ -63,7 +66,9 @@ pub enum AnalyzeError {
     ParseTimeout { path: PathBuf, micros: u64 },
 }
 
-/// Result of directory analysis containing both formatted output and file data.
+/// Result of a directory or module analysis, returned by `analyze_directory` and
+/// `analyze_module` MCP tools. Contains a formatted text tree view (`formatted`) and
+/// structured file metadata (`files`). Pagination is supported via `next_cursor`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[non_exhaustive]
@@ -98,7 +103,9 @@ pub struct AnalysisOutput {
     pub next_cursor: Option<String>,
 }
 
-/// Result of file-level semantic analysis.
+/// Result of a single-file semantic analysis, returned by the `analyze_file` MCP tool.
+/// Contains a formatted text preview (`formatted`), structured function/class/import
+/// data (`semantic`), and pagination support via `next_cursor`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[non_exhaustive]
@@ -322,7 +329,9 @@ pub fn analyze_directory_with_progress(
     Ok(build_analysis_output(entries, analysis_results))
 }
 
-/// Analyze a directory structure and return formatted output and file data.
+/// Analyze a directory tree and return a tree view with per-file LOC, function, and class counts.
+/// Backs the `analyze_directory` MCP tool. Accepts a filesystem root path and optional max depth.
+/// Returns [`AnalysisOutput`] containing both formatted text and structured file metadata.
 #[instrument(skip_all, fields(path = %root.display()))]
 pub fn analyze_directory(
     root: &Path,
@@ -349,7 +358,9 @@ pub fn determine_mode(path: &str, focus: Option<&str>) -> AnalysisMode {
     }
 }
 
-/// Analyze a single file and return semantic analysis with formatted output.
+/// Analyze a single file and return functions, classes, imports, and signatures.
+/// Backs the `analyze_file` MCP tool. Accepts a file path and optional AST recursion limit.
+/// Returns [`FileAnalysisOutput`] with formatted output and structured semantic data.
 #[instrument(skip_all, fields(path))]
 pub fn analyze_file(
     path: &str,
@@ -1230,6 +1241,11 @@ pub fn analyze_focused_with_progress_with_entries(
     )
 }
 
+/// Analyze a symbol's call graph across a directory tree.
+/// Backs the `analyze_symbol` MCP tool. Walks the directory, builds a call graph,
+/// and returns callers, callees, and call depth for the matching symbol.
+/// Accepts optional `follow_depth`, `max_depth`, and `ast_recursion_limit`.
+/// Returns [`FocusedAnalysisOutput`] with formatted chains and structured results.
 #[instrument(skip_all, fields(path = %root.display(), symbol = %focus))]
 pub fn analyze_focused(
     root: &Path,
@@ -1255,8 +1271,10 @@ pub fn analyze_focused(
     analyze_focused_with_progress_with_entries(root, &params, &counter, &ct, &entries)
 }
 
-/// Analyze a single file and return a minimal fixed schema (name, line count, language,
-/// functions, imports) for lightweight code understanding.
+/// Analyze a single file and return a lightweight function/import index (~75% smaller than
+/// `analyze_file`). Backs the `analyze_module` MCP tool. Returns
+/// [`ModuleInfo`](crate::types::ModuleInfo) with name, line count, language, and compact
+/// function/import lists.
 #[instrument(skip_all, fields(path))]
 pub fn analyze_module_file(path: &str) -> Result<crate::types::ModuleInfo, AnalyzeError> {
     // Check file size before reading


### PR DESCRIPTION
## Summary

Fix stale README documentation by adding five missing feature descriptions (git_ref, def_use, import_lookup, APTU_CODER_PROFILE, summary/cursor mutual exclusion) and enhance Rust doc comments on seven MCP-surface public items in analyze.rs.

## Changes

- README.md
- crates/aptu-coder-core/src/analyze.rs

## Test plan

- [x] Tests pass (153 passed, 0 failed; see 03-build.json test_results)
- [x] Linter clean (cargo clippy passed)
- [x] Security scan clean (no findings; see 04-validation.json security_summary)

Closes #1260
