### PR TITLE
fix(exec_command): sync output_truncated to structuredContent and add interleaved slot-file overflow

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -109,6 +109,9 @@ pub struct ShellOutput {
     /// Path to the slot file containing full stderr (if output was persisted).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stderr_path: Option<String>,
+    /// Path to the slot file containing full interleaved output (if output was persisted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interleaved_path: Option<String>,
     /// Description of the filter applied to stdout (if any).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_applied: Option<String>,
@@ -137,6 +140,7 @@ impl ShellOutput {
             output_collection_error: None,
             stdout_path: None,
             stderr_path: None,
+            interleaved_path: None,
             filter_applied: None,
             timed_out: false,
         }

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -843,7 +843,7 @@ pub(crate) async fn run_exec_impl(
 
     // Handle interleaved overflow: cap at INTERLEAVED_MAX_BYTES and write to slot file if needed
     let (interleaved_preview, interleaved_path) =
-        persist_interleaved_overflow(interleaved_str, INTERLEAVED_MAX_BYTES, slot);
+        persist_interleaved_overflow(interleaved_str, INTERLEAVED_MAX_BYTES, slot).await;
     if interleaved_path.is_some() {
         output_truncated = true;
     }
@@ -893,7 +893,7 @@ pub(crate) async fn run_exec_impl(
 /// Persists interleaved output to a slot file when it exceeds `max_bytes`.
 /// Returns `(preview, path)`: on overflow, `preview` is a tail of `max_bytes` chars and
 /// `path` is `Some(slot_file_path)`; under limit, returns the original string and `None`.
-fn persist_interleaved_overflow(
+async fn persist_interleaved_overflow(
     interleaved: String,
     max_bytes: usize,
     slot: u32,
@@ -904,9 +904,9 @@ fn persist_interleaved_overflow(
     let base = std::env::temp_dir()
         .join("aptu-coder-overflow")
         .join(format!("slot-{slot}"));
-    let _ = std::fs::create_dir_all(&base);
+    let _ = tokio::fs::create_dir_all(&base).await;
     let interleaved_file = base.join("interleaved");
-    let _ = std::fs::write(&interleaved_file, interleaved.as_bytes());
+    let _ = tokio::fs::write(&interleaved_file, interleaved.as_bytes()).await;
     let path = interleaved_file.display().to_string();
     // Tail preview: show the most recent output, respecting char boundaries.
     let tail_start = interleaved.len().saturating_sub(max_bytes);

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -312,14 +312,36 @@ fn format_shell_output_phase(output: &ShellOutput, params: &ExecCommandParams) -
         output_text
     };
 
+    // Build truncation notice with slot file paths if present
+    let mut truncation_notice = String::new();
+    if output.stdout_path.is_some()
+        || output.stderr_path.is_some()
+        || output.interleaved_path.is_some()
+    {
+        truncation_notice.push_str("(Full output persisted to: ");
+        let mut paths = Vec::new();
+        if let Some(ref p) = output.stdout_path {
+            paths.push(format!("stdout={}", p));
+        }
+        if let Some(ref p) = output.stderr_path {
+            paths.push(format!("stderr={}", p));
+        }
+        if let Some(ref p) = output.interleaved_path {
+            paths.push(format!("interleaved={}", p));
+        }
+        truncation_notice.push_str(&paths.join(", "));
+        truncation_notice.push_str(")\n");
+    }
+
     let text = format!(
-        "Command: {}\nExit code: {}\nOutput truncated: {}\n\n{}",
+        "Command: {}\nExit code: {}\nOutput truncated: {}\n{}{}",
         params.command,
         output
             .exit_code
             .map(|c| c.to_string())
             .unwrap_or_else(|| "null".to_string()),
         output.output_truncated || combined_truncated,
+        truncation_notice,
         truncated_output_text,
     );
 
@@ -426,7 +448,7 @@ pub(crate) async fn exec_command_impl(
 
     // Phase 3: Spawn and collect
     let resolved_path_str = resolved_path.as_deref();
-    let output = match spawn_and_collect_phase(
+    let mut output = match spawn_and_collect_phase(
         command.clone(),
         working_dir_path.clone(),
         &params,
@@ -470,6 +492,9 @@ pub(crate) async fn exec_command_impl(
 
     // Update output_truncated flag to include combined truncation
     output_truncated = output_truncated || combined_truncated;
+
+    // Sync output_truncated to the struct before serialization (fix #1266)
+    output.output_truncated = output_truncated;
 
     span.record("output_truncated", output_truncated);
 
@@ -787,6 +812,7 @@ pub(crate) async fn run_exec_impl(
 
     // Split tagged lines into stdout, stderr, interleaved post-facto (no locks needed).
     const MAX_BYTES: usize = 50 * 1024;
+    const INTERLEAVED_MAX_BYTES: usize = 60 * 1024;
     let mut stdout_str = String::new();
     let mut stderr_str = String::new();
     let mut interleaved_str = String::new();
@@ -815,10 +841,24 @@ pub(crate) async fn run_exec_impl(
         handle_output_persist(stdout_str, stderr_str, slot);
     output_truncated = output_truncated || stdout_path.is_some() || byte_truncated;
 
-    let mut output = ShellOutput::new(stdout, stderr, interleaved_str, exit_code, output_truncated);
+    // Handle interleaved overflow: cap at INTERLEAVED_MAX_BYTES and write to slot file if needed
+    let (interleaved_preview, interleaved_path) =
+        persist_interleaved_overflow(interleaved_str, INTERLEAVED_MAX_BYTES, slot);
+    if interleaved_path.is_some() {
+        output_truncated = true;
+    }
+
+    let mut output = ShellOutput::new(
+        stdout,
+        stderr,
+        interleaved_preview,
+        exit_code,
+        output_truncated,
+    );
     output.output_collection_error = output_collection_error;
     output.stdout_path = stdout_path;
     output.stderr_path = stderr_path;
+    output.interleaved_path = interleaved_path;
     output.timed_out = timed_out;
 
     // Apply filter if exit_code == 0
@@ -850,6 +890,30 @@ pub(crate) async fn run_exec_impl(
 /// Handles output persistence by writing to slot files only when output overflows the line limit.
 /// Writes full stdout/stderr to:
 ///   {temp_dir}/aptu-coder-overflow/slot-{slot}/{stdout,stderr}
+/// Persists interleaved output to a slot file when it exceeds `max_bytes`.
+/// Returns `(preview, path)`: on overflow, `preview` is a tail of `max_bytes` chars and
+/// `path` is `Some(slot_file_path)`; under limit, returns the original string and `None`.
+fn persist_interleaved_overflow(
+    interleaved: String,
+    max_bytes: usize,
+    slot: u32,
+) -> (String, Option<String>) {
+    if interleaved.len() <= max_bytes {
+        return (interleaved, None);
+    }
+    let base = std::env::temp_dir()
+        .join("aptu-coder-overflow")
+        .join(format!("slot-{slot}"));
+    let _ = std::fs::create_dir_all(&base);
+    let interleaved_file = base.join("interleaved");
+    let _ = std::fs::write(&interleaved_file, interleaved.as_bytes());
+    let path = interleaved_file.display().to_string();
+    // Tail preview: show the most recent output, respecting char boundaries.
+    let tail_start = interleaved.len().saturating_sub(max_bytes);
+    let safe_start = interleaved[..tail_start].floor_char_boundary(tail_start);
+    (interleaved[safe_start..].to_string(), Some(path))
+}
+
 /// Returns (stdout_out, stderr_out, stdout_path, stderr_path).
 /// On overflow: truncates to last 50 lines and sets paths to Some.
 /// Under limit: returns output unchanged and paths as None (no I/O).

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1596,3 +1596,69 @@ async fn test_data_flag_d_with_heredoc_rejected() {
         "error should mention stdin conflict: {text}"
     );
 }
+
+#[tokio::test]
+async fn test_output_truncated_consistency_size_limit() {
+    // Arrange: generate output that exceeds SIZE_LIMIT (5 KB) but stays under
+    // per-stream caps (30 KB stdout / 10 KB stderr). A single stream of 6 KB
+    // of repeated text triggers the combined SIZE_LIMIT cap in format_shell_output_phase.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "python3 -c 'import sys; sys.stdout.write(chr(120) * 6000)'"
+    }))
+    .await;
+
+    // Act: inspect response text and structuredContent
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    let sc = &resp["result"]["structuredContent"];
+
+    // Assert: text says 'Output truncated: true' AND structuredContent.output_truncated == true
+    assert!(
+        text.contains("Output truncated: true"),
+        "text should indicate truncation: {text}"
+    );
+    assert_eq!(
+        sc["output_truncated"], true,
+        "structuredContent.output_truncated should be true: {sc}"
+    );
+}
+
+#[tokio::test]
+async fn test_interleaved_overflow_slot_file() {
+    // Arrange: generate interleaved output exceeding 60 KB by writing to both
+    // stdout and stderr. Each stream contributes ~35 KB for ~70 KB total.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "python3 -c 'import sys; sys.stdout.write(chr(120) * 35000); sys.stderr.write(chr(121) * 35000)'"
+    }))
+    .await;
+
+    // Act: inspect structuredContent
+    let sc = &resp["result"]["structuredContent"];
+
+    // Assert: interleaved_path is set, interleaved is a tail preview, output_truncated is true
+    let interleaved_path = sc["interleaved_path"].as_str();
+    assert!(
+        interleaved_path.is_some(),
+        "interleaved_path should be set on overflow: {sc}"
+    );
+    let path = interleaved_path.unwrap();
+    assert!(
+        path.contains("aptu-coder-overflow"),
+        "interleaved_path should reference overflow directory: {path}"
+    );
+    assert!(
+        path.contains("slot-"),
+        "interleaved_path should contain slot identifier: {path}"
+    );
+
+    let interleaved = sc["interleaved"].as_str().unwrap_or("");
+    assert!(
+        interleaved.len() <= 60 * 1024,
+        "interleaved should be tail preview (<=60 KB), got {} bytes",
+        interleaved.len()
+    );
+
+    assert_eq!(
+        sc["output_truncated"], true,
+        "output_truncated should be true: {sc}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in `exec_command` where `output_truncated` and `interleaved` output were handled inconsistently.

**Fix #1266 -- `output_truncated` divergence between response text and `structuredContent`:**
`exec_command_impl` computed the final `output_truncated` flag (incorporating the 5 KB combined display cap) but never wrote it back to the `ShellOutput` struct before serialization. `structuredContent.output_truncated` stayed `false` while the response text said `Output truncated: true`. Fix: set `output.output_truncated` on the struct before `serde_json::to_value(&output)`.

**Fix #1267 -- `interleaved` field had no slot-file overflow path:**
`stdout` and `stderr` are capped at 30 KB / 10 KB via `handle_output_persist` with full output persisted to a slot file. `interleaved` was capped inline at 100 KB but always embedded verbatim in `structuredContent` -- up to 100 KB in a single MCP frame. Fix: added `persist_interleaved_overflow`, a dedicated async helper that caps `interleaved` at 60 KB, writes overflow to `aptu-coder-overflow/slot-N/interleaved`, returns a tail preview, and sets the new `interleaved_path` field on `ShellOutput`. The slot ring (`seq % 8`) bounds the directory to 8 files at all times. `output_truncated` now includes interleaved overflow.

## Changes

- `crates/aptu-coder/src/lib.rs` -- added `interleaved_path: Option<String>` to `ShellOutput` with `#[serde(skip_serializing_if = "Option::is_none")]`
- `crates/aptu-coder/src/tools/exec_command.rs` -- set `output.output_truncated` before serialization; extracted `persist_interleaved_overflow` async helper (uses `tokio::fs`) adjacent to `handle_output_persist`; updated `format_shell_output_phase` to include `interleaved_path` in the truncation notice
- `crates/aptu-coder/tests/exec_command.rs` -- two new regression tests

## Test plan

- [x] `test_output_truncated_consistency_size_limit` -- output exceeds SIZE_LIMIT (5 KB) but stays under per-stream caps; asserts text and `structuredContent.output_truncated` both true
- [x] `test_interleaved_overflow_slot_file` -- interleaved output exceeds 60 KB; asserts `interleaved_path` is set, `interleaved` is a tail preview, `output_truncated` is true
- [x] Existing tests `test_exec_command_overflow_to_temp_file` and `test_handler_interleaved_ordering` pass unchanged
- [x] 154 tests pass, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean

Closes #1266
Closes #1267
