### PR TITLE
fix(server): add exec_command to analyze profile disable list

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export on shutdown. |
 | `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
-| `APTU_CODER_PROFILE` | unset | Tool subset: `edit` (edit tools + `exec_command` only), `analyze` (analyze tools + `exec_command` only). Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
+| `APTU_CODER_PROFILE` | unset | Tool subset: `edit` (edit tools + `exec_command` only), `analyze` (analyze tools only). Also settable per-session via `io.clouatre-labs/profile` in MCP `_meta`. |
 | `APTU_SHELL` | unset | Shell for `exec_command`. Defaults to `bash` then `/bin/sh`. |
 
 ## Observability

--- a/crates/aptu-coder/src/tools/server.rs
+++ b/crates/aptu-coder/src/tools/server.rs
@@ -178,7 +178,10 @@ pub(crate) async fn on_initialized_impl(
                     );
                 }
                 "analyze" => {
-                    disable_routes(&mut router, &["edit_replace", "edit_overwrite"]);
+                    disable_routes(
+                        &mut router,
+                        &["edit_replace", "edit_overwrite", "exec_command"],
+                    );
                 }
                 _ => {}
             }

--- a/crates/aptu-coder/tests/profiles.rs
+++ b/crates/aptu-coder/tests/profiles.rs
@@ -248,10 +248,10 @@ async fn test_analyze_profile_tool_count() {
         .filter_map(|t| t["name"].as_str().map(|s| s.to_string()))
         .collect();
 
-    // Assert: analyze profile should have exactly 5 tools
+    // Assert: analyze profile should have exactly 4 tools
     assert_eq!(
-        tool_count, 5,
-        "analyze profile should enable exactly 5 tools, got: {:?}",
+        tool_count, 4,
+        "analyze profile should enable exactly 4 tools, got: {:?}",
         tool_names
     );
 
@@ -273,8 +273,8 @@ async fn test_analyze_profile_tool_count() {
         "analyze profile should include analyze_symbol"
     );
     assert!(
-        tool_names.contains(&"exec_command".to_string()),
-        "analyze profile should include exec_command"
+        !tool_names.contains(&"exec_command".to_string()),
+        "analyze profile should exclude exec_command"
     );
 }
 
@@ -405,9 +405,9 @@ async fn test_profile_env_var_ignored_when_meta_present() {
         .collect();
 
     // Assert: _meta profile (analyze) should override the env var (edit).
-    // analyze profile enables 5 tools.
+    // analyze profile enables 4 tools.
     assert_eq!(
-        tool_count, 5,
+        tool_count, 4,
         "_meta profile (analyze) should take precedence over env var, got: {:?}",
         tool_names
     );


### PR DESCRIPTION
## Summary
The analyze profile disable list in server.rs omits exec_command, leaving shell execution available when the documented contract says the profile is read-only. This fix adds exec_command to the disable list, corrects the integration test assertion (count 5 to 4, presence to absence), and updates README.md to document the correct behavior.

## Changes
- crates/aptu-coder/src/tools/server.rs
- crates/aptu-coder/tests/profiles.rs
- README.md

## Test plan
- [x] Tests pass (257 passed, 0 failed)
- [x] Linter clean
- [x] Security scan clean (0 findings)
