### PR TITLE
docs(agents): correct analyze profile tool count in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `exec_command` accepts an optional `drain_timeout_secs` (integer >= 0; 0 or omitted means 500ms default, negative = INVALID_PARAMS, positive = drain window in milliseconds). Controls how long the post-exit drain waits for a background subprocess holding pipes open before returning `output_truncated: true`.
 - `analyze_symbol` uses an L2 on-disk call-graph cache in addition to the L1 in-memory LRU. Configure with `APTU_CODER_DISK_CACHE_DIR` (default: `$XDG_DATA_HOME/aptu-coder/analysis-cache`); disable with `APTU_CODER_DISK_CACHE_DISABLED=1`.
 - `call_frequency` on `analyze_symbol` is filtered out when the `Functions` field is not in the projected fields set.
-- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (4 tools: analyze_directory, analyze_file, analyze_module, analyze_symbol); `analyze` disables edit_* tools (5 tools: edit_overwrite, edit_replace, exec_command, and aliases); absent/unknown enables all 7 tools. By default, all 7 tools are available.
+- `APTU_CODER_PROFILE` (env var) or `io.clouatre-labs/profile` (MCP `_meta`) activates a tool subset: `edit` disables all analyze_* tools (4 tools: analyze_directory, analyze_file, analyze_module, analyze_symbol); `analyze` disables edit_* tools (2 tools: edit_overwrite, edit_replace); absent/unknown enables all 7 tools. By default, all 7 tools are available.
 
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 


### PR DESCRIPTION
## Summary

AGENTS.md line 92 incorrectly stated that the `analyze` profile disables 5 tools including `exec_command`. The code and tests show it only disables 2 tools (`edit_overwrite`, `edit_replace`).

## Root cause

Audit finding A03 in `docs/audit/2026-07-05-v0.22.3.md` treated AGENTS.md as the canonical operator contract for `APTU_CODER_PROFILE`. It is not -- it is the orchestration-layer document for AI agents running in this session. The actual contract is defined by `server.rs` and verified by `profiles.rs`.

**Code (`server.rs` `analyze` arm, unchanged):**
```rust
"analyze" => {
    disable_routes(&mut router, &["edit_replace", "edit_overwrite"]);
}
```

**Test (`profiles.rs`, unchanged):**
```
assert_eq!(tool_count, 5, ...)
assert!(tool_names.contains("exec_command"), "analyze profile should include exec_command")
```

AGENTS.md was the only source that disagreed.

## Change

- `AGENTS.md` line 92: `analyze` disables edit_* tools **(5 tools: edit_overwrite, edit_replace, exec_command, and aliases)** -> **(2 tools: edit_overwrite, edit_replace)**

No code, test, or other documentation changes.

Closes #1272
