### PR TITLE
fix(ci): arm64 binary, rust-cache SHA, and codeql runner (#1270)

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -61,7 +61,7 @@ jobs:
           target: ${{ inputs.target }}
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: aptu-coder
           key: ${{ inputs.target }}

--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -49,7 +49,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
           targets: ${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt, clippy
       - name: Setup Rust cache
@@ -152,7 +152,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
           components: llvm-tools-preview
@@ -211,7 +211,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: "1.96.0"
       - name: Setup Rust cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (actions)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (actions)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/publish-registry-manual.yml
+++ b/.github/workflows/publish-registry-manual.yml
@@ -98,9 +98,9 @@ jobs:
           set -euo pipefail
           gh release download v1.7.8 \
             --repo modelcontextprotocol/registry \
-            --pattern "mcp-publisher_linux_amd64.tar.gz" \
+            --pattern "mcp-publisher_linux_arm64.tar.gz" \
             --output /tmp/mcp-publisher.tar.gz
-          echo "48230dbec85bd88a0d42977ef533cddda23235f0db4331b9263ce53b432cb75c  /tmp/mcp-publisher.tar.gz" | sha256sum --check
+          echo "3eaa88ea0590433b538d3971a6ca0863d0345d3ff5937b0d1874b7a8de71a591  /tmp/mcp-publisher.tar.gz" | sha256sum --check
           tar -xzf /tmp/mcp-publisher.tar.gz -C /tmp mcp-publisher
           test -f /tmp/mcp-publisher || { echo "mcp-publisher binary not found in tarball"; exit 1; }
           sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,7 +443,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: stable
 


### PR DESCRIPTION
## Summary

Three CI workflow fixes from the v0.22.3 audit (issue #1270) plus a zizmor `impostor-commit` fix.

- **F02 (HIGH):** `publish-registry-manual.yml` was downloading `mcp-publisher_linux_amd64.tar.gz` on an `ubuntu-24.04-arm` runner, causing "Exec format error" at execution. Swapped to `mcp-publisher_linux_arm64.tar.gz` with the correct ARM64 SHA256.
- **F03 (MEDIUM):** `build-and-attest.yml` pinned `Swatinem/rust-cache` to `e18b4977` (v2 floating) while all three references in `ci.yml` used `c19371144` (v2.9.1). Pinned to `c19371144` to match.
- **F04 (MEDIUM) -- not applied:** `codeql.yml` was left on `ubuntu-24.04`. CodeQL CLI v2.25.6 bundles an AMD64 JVM and cannot execute on `linux/arm64`; migrating the CodeQL runner requires a separate action version bump.
- **zizmor impostor-commit:** `dtolnay/rust-toolchain@29eef336` is a dangling commit — the prior tip of the `stable` branch, no longer reachable from any branch or tag. Updated to `4be7066a` (current `stable` tip) across all 6 occurrences in `build-and-attest.yml`, `ci.yml` (x3), `release.yml`, and `update-deps.yml`.

## Changes

- `.github/workflows/publish-registry-manual.yml` — arm64 artifact + SHA256
- `.github/workflows/build-and-attest.yml` — rust-cache SHA + rust-toolchain SHA
- `.github/workflows/ci.yml` — rust-toolchain SHA (3x)
- `.github/workflows/release.yml` — rust-toolchain SHA
- `.github/workflows/update-deps.yml` — rust-toolchain SHA

Closes #1270
