### PR TITLE
fix(deps): remove stale RUSTSEC-2023-0071, unused CDLA-Permissive-2.0, enforce bans in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,8 @@ jobs:
         uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
         with:
           tool: cargo-deny
-      - name: Check advisories and licenses
-        run: cargo deny check advisories licenses
+      - name: Check advisories, licenses, and bans
+        run: cargo deny check advisories licenses bans
       - name: Check package age
         run: bash .github/scripts/check-package-age.sh
 

--- a/deny.toml
+++ b/deny.toml
@@ -3,9 +3,6 @@
 
 [advisories]
 version = 2
-ignore = [
-    { id = "RUSTSEC-2023-0071", reason = "Marvin Attack in rsa crate, no upstream patch available; transitive via octocrab -> jsonwebtoken -> rsa" },
-]
 
 [licenses]
 version = 2
@@ -14,7 +11,6 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "Unicode-3.0",


### PR DESCRIPTION
## Summary
Remove three stale/unused entries from deny.toml (RUSTSEC-2023-0071 ignore block, CDLA-Permissive-2.0 license) and expand the CI cargo deny invocation to include bans. All changes are config-only with zero code impact.

## Changes
- deny.toml
- .github/workflows/ci.yml

## Test plan
- [x] Tests pass (see 03-build.json test_results: 3 passed, 0 failed)
- [x] Linter clean (cargo deny check advisories licenses bans exits 0)
- [x] Security scan clean (no findings)

Closes #1271
