### PR TITLE
fix(core): add expect_used lint, cache observability, and fix AGENTS.md cfg_attr claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ cargo bench
 cargo install --path crates/aptu-coder --profile release   # local install; binary lands in ~/.cargo/bin/
 ```
 
-Workspace lints enforced in CI (deny): undocumented_unsafe_blocks, unwrap_used (test code exempted via cfg_attr).
+Workspace lints enforced in CI (deny): undocumented_unsafe_blocks, unwrap_used, expect_used. Both unwrap_used and expect_used have test-code exemptions via cfg_attr in each crate's lib.rs.
 Dependency freshness: new Cargo.lock entries must be >=7 days old; bypass with SKIP_PACKAGE_AGE_CHECK=true.
 
 ## Observability

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ unreachable_pub = "warn"
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
 unwrap_used = "deny"
+expect_used = "deny"
 # Lints below are "warn" until all violations are cleared; promote each to "deny"
 # once zero warnings are confirmed in CI (tracked in issue #1225).
 must_use_candidate = "warn"

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -114,9 +114,13 @@ where
     match mutex.lock() {
         Ok(mut guard) => recovery(&mut guard),
         Err(poisoned) => {
+            tracing::warn!("Mutex poisoned in lock_or_recover; creating fresh LruCache");
             // SAFETY: 100 is a non-zero literal
-            let cache_size = NonZeroUsize::new(capacity)
-                .unwrap_or_else(|| NonZeroUsize::new(100).expect("100 is non-zero"));
+            let cache_size = NonZeroUsize::new(capacity).unwrap_or_else(|| {
+                // SAFETY: 100 is guaranteed non-zero
+                #[allow(clippy::expect_used)]
+                NonZeroUsize::new(100).expect("100 is non-zero")
+            });
             let new_cache = LruCache::new(cache_size);
             let mut guard = poisoned.into_inner();
             *guard = new_cache;
@@ -196,6 +200,8 @@ impl CallGraphCache {
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
+        // SAFETY: capacity is clamped to a minimum of 1 by .max(1), so NonZeroUsize::new() returns Some.
+        #[allow(clippy::expect_used)]
         let cache_size = NonZeroUsize::new(capacity).expect("capacity is non-zero after .max(1)");
         Self {
             capacity,
@@ -242,8 +248,12 @@ impl AnalysisCache {
     pub fn new(capacity: usize) -> Self {
         let file_capacity = capacity.max(1);
         let dir_capacity = parse_cache_capacity("APTU_CODER_DIR_CACHE_CAPACITY", 20);
+        // SAFETY: file_capacity is clamped to a minimum of 1 by .max(1), so NonZeroUsize::new() returns Some.
+        #[allow(clippy::expect_used)]
         let cache_size =
             NonZeroUsize::new(file_capacity).expect("file_capacity is non-zero after .max(1)");
+        // SAFETY: dir_capacity is clamped to a minimum of 1 by parse_cache_capacity, so NonZeroUsize::new() returns Some.
+        #[allow(clippy::expect_used)]
         let dir_cache_size =
             NonZeroUsize::new(dir_capacity).expect("dir_capacity is non-zero after .max(1)");
         Self {
@@ -649,7 +659,9 @@ impl DiskCache {
             return None;
         }
         let path = self.entry_path(tool, key);
-        // Acquire shared lock on per-shard .lock sentinel before reading
+        // Acquire shared lock on per-shard .lock sentinel before reading.
+        // F13: If the lock file cannot be created/opened (e.g. read-only filesystem),
+        // lock_shard_shared returns None and we gracefully fall through without locking.
         let _lock = lock_shard_shared(path.parent()?);
         let compressed = match std::fs::read(&path) {
             Ok(b) => b,

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -105,7 +105,10 @@ impl DirectoryCacheKey {
 }
 
 /// Fallback cache capacity used in `lock_or_recover` when the caller-supplied capacity is zero.
-const DEFAULT_LOCK_RECOVER_CAPACITY: usize = 100;
+// SAFETY: 100 is non-zero; verified at compile time by NonZeroUsize::new.
+#[allow(clippy::expect_used)]
+const DEFAULT_LOCK_RECOVER_CAPACITY: NonZeroUsize =
+    NonZeroUsize::new(100).expect("100 is non-zero");
 
 /// Recover from a poisoned mutex by clearing the cache.
 /// On poison, creates a new empty cache and returns the recovery value.
@@ -118,12 +121,7 @@ where
         Ok(mut guard) => recovery(&mut guard),
         Err(poisoned) => {
             tracing::warn!("Mutex poisoned in lock_or_recover; creating fresh LruCache");
-            // SAFETY: DEFAULT_LOCK_RECOVER_CAPACITY is a non-zero named constant.
-            let cache_size = NonZeroUsize::new(capacity).unwrap_or_else(|| {
-                #[allow(clippy::expect_used)]
-                NonZeroUsize::new(DEFAULT_LOCK_RECOVER_CAPACITY)
-                    .expect("DEFAULT_LOCK_RECOVER_CAPACITY is non-zero")
-            });
+            let cache_size = NonZeroUsize::new(capacity).unwrap_or(DEFAULT_LOCK_RECOVER_CAPACITY);
             let new_cache = LruCache::new(cache_size);
             let mut guard = poisoned.into_inner();
             *guard = new_cache;

--- a/crates/aptu-coder-core/src/cache.rs
+++ b/crates/aptu-coder-core/src/cache.rs
@@ -104,6 +104,9 @@ impl DirectoryCacheKey {
     }
 }
 
+/// Fallback cache capacity used in `lock_or_recover` when the caller-supplied capacity is zero.
+const DEFAULT_LOCK_RECOVER_CAPACITY: usize = 100;
+
 /// Recover from a poisoned mutex by clearing the cache.
 /// On poison, creates a new empty cache and returns the recovery value.
 fn lock_or_recover<K, V, T, F>(mutex: &Mutex<LruCache<K, V>>, capacity: usize, recovery: F) -> T
@@ -115,11 +118,11 @@ where
         Ok(mut guard) => recovery(&mut guard),
         Err(poisoned) => {
             tracing::warn!("Mutex poisoned in lock_or_recover; creating fresh LruCache");
-            // SAFETY: 100 is a non-zero literal
+            // SAFETY: DEFAULT_LOCK_RECOVER_CAPACITY is a non-zero named constant.
             let cache_size = NonZeroUsize::new(capacity).unwrap_or_else(|| {
-                // SAFETY: 100 is guaranteed non-zero
                 #[allow(clippy::expect_used)]
-                NonZeroUsize::new(100).expect("100 is non-zero")
+                NonZeroUsize::new(DEFAULT_LOCK_RECOVER_CAPACITY)
+                    .expect("DEFAULT_LOCK_RECOVER_CAPACITY is non-zero")
             });
             let new_cache = LruCache::new(cache_size);
             let mut guard = poisoned.into_inner();

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -149,6 +149,7 @@ pub fn edit_replace_block(
     let bytes_before = content.len();
     // Find match offset in normalized space, then map back to original byte range
     // SAFETY: match was verified above via count check; find must succeed.
+    // If count verification logic changes, this expect() site must be re-audited.
     #[allow(clippy::expect_used)]
     let norm_match_offset = norm_content
         .find(&norm_old)

--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -148,6 +148,8 @@ pub fn edit_replace_block(
     }
     let bytes_before = content.len();
     // Find match offset in normalized space, then map back to original byte range
+    // SAFETY: match was verified above via count check; find must succeed.
+    #[allow(clippy::expect_used)]
     let norm_match_offset = norm_content
         .find(&norm_old)
         .expect("match was verified above via count check; find must succeed");

--- a/crates/aptu-coder-core/src/graph.rs
+++ b/crates/aptu-coder-core/src/graph.rs
@@ -79,7 +79,11 @@ pub fn resolve_symbol<'a>(
     );
 
     match matches.len() {
-        1 => Ok(matches.into_iter().next().expect("len==1")),
+        1 => {
+            // SAFETY: match arm for `1` guarantees exactly one element in matches; next() cannot return None.
+            #[allow(clippy::expect_used)]
+            Ok(matches.into_iter().next().expect("len==1"))
+        }
         0 => {
             let hint = match mode {
                 SymbolMatchMode::Exact => {
@@ -171,7 +175,11 @@ impl CallGraph {
         );
 
         match matches.len() {
-            1 => Ok(matches.into_iter().next().expect("len==1")),
+            1 => {
+                // SAFETY: match arm for `1` guarantees exactly one element in matches; next() cannot return None.
+                #[allow(clippy::expect_used)]
+                Ok(matches.into_iter().next().expect("len==1"))
+            }
             0 => Err(GraphError::SymbolNotFound {
                 symbol: query.to_string(),
                 hint: "No symbols matched; try a shorter query or match_mode=contains.".to_string(),

--- a/crates/aptu-coder-core/src/languages/regex_fallback.rs
+++ b/crates/aptu-coder-core/src/languages/regex_fallback.rs
@@ -16,18 +16,29 @@ use tracing;
 
 // --- compiled patterns (compiled once at startup) ---
 
-static CSS_SELECTOR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[.#][\w-]+[\s,:{]").expect("valid CSS selector pattern"));
+static CSS_SELECTOR: LazyLock<Regex> = LazyLock::new(|| {
+    // SAFETY: static regex patterns are hardcoded literals; compilation never fails.
+    #[allow(clippy::expect_used)]
+    Regex::new(r"^[.#][\w-]+[\s,:{]").expect("valid CSS selector pattern")
+});
 
-static YAML_TOP_KEY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\w[\w-]*): ").expect("valid YAML top-level key pattern"));
+static YAML_TOP_KEY: LazyLock<Regex> = LazyLock::new(|| {
+    // SAFETY: static regex patterns are hardcoded literals; compilation never fails.
+    #[allow(clippy::expect_used)]
+    Regex::new(r"^(\w[\w-]*): ").expect("valid YAML top-level key pattern")
+});
 
 static JSON_FIRST_KEY: LazyLock<Regex> = LazyLock::new(|| {
+    // SAFETY: static regex patterns are hardcoded literals; compilation never fails.
+    #[allow(clippy::expect_used)]
     Regex::new(r#"^\s{0,2}"(\w+)":"#).expect("valid JSON first-level key pattern")
 });
 
-static TOML_SECTION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\[([^\]]+)\]").expect("valid TOML section header pattern"));
+static TOML_SECTION: LazyLock<Regex> = LazyLock::new(|| {
+    // SAFETY: static regex patterns are hardcoded literals; compilation never fails.
+    #[allow(clippy::expect_used)]
+    Regex::new(r"^\[([^\]]+)\]").expect("valid TOML section header pattern")
+});
 
 // --- extraction functions ---
 

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -27,6 +27,7 @@
 //! ```
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::expect_used))]
 
 pub mod analyze;
 pub mod cache;

--- a/crates/aptu-coder-core/src/schema_helpers.rs
+++ b/crates/aptu-coder-core/src/schema_helpers.rs
@@ -7,6 +7,8 @@ use serde_json::json;
 
 /// Returns a plain integer schema without the non-standard "format": "uint"
 /// that schemars emits by default for usize/u32 fields.
+// SAFETY: json! macro always produces a Value::Object for object literals.
+#[allow(clippy::expect_used)]
 pub fn integer_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     let map = json!({
         "type": "integer",
@@ -19,6 +21,8 @@ pub fn integer_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
 }
 
 /// Returns a nullable integer schema for Option<usize> / Option<u32> fields.
+// SAFETY: json! macro always produces a Value::Object for object literals.
+#[allow(clippy::expect_used)]
 pub fn option_integer_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     let map = json!({
         "type": ["integer", "null"],
@@ -40,6 +44,8 @@ pub const SUPPORTED_FILE_EXT_PATTERN: &str = r"(?i)\.(rs|py|go|ts|tsx|js|mjs|cjs
 
 /// Returns a string schema with a `pattern` constraint covering all supported
 /// source file extensions. Used as `schema_with` on `path` fields.
+// SAFETY: json! macro always produces a Value::Object for object literals.
+#[allow(clippy::expect_used)]
 pub fn supported_file_path_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     let map = serde_json::json!({
         "type": "string",
@@ -54,6 +60,8 @@ pub fn supported_file_path_schema(_gen: &mut schemars::SchemaGenerator) -> Schem
 /// Returns a nullable integer schema for `Option<usize>` `page_size` fields.
 /// Enforces minimum: 1 to prevent callers from sending `page_size=0`, which
 /// would cause `paginate_slice` to make no progress and loop on the same cursor.
+// SAFETY: json! macro always produces a Value::Object for object literals.
+#[allow(clippy::expect_used)]
 pub fn option_page_size_schema(_gen: &mut schemars::SchemaGenerator) -> Schema {
     let map = json!({
         "type": ["integer", "null"],

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -24,6 +24,7 @@
 //! Languages supported: Astro, C/C++, C#, CSS, Fortran, Go, HTML, Java, JavaScript, JSON, Kotlin, Markdown, Python, Rust, TOML, TSX, TypeScript, YAML.
 
 #![cfg_attr(test, allow(clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::expect_used))]
 
 mod filters;
 pub(crate) mod logging;

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -55,6 +55,9 @@ async fn run_http(analyzer: CodeAnalyzer, port: u16) -> Result<(), Box<dyn std::
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};
+            // SAFETY: SIGTERM handling is a critical part of graceful shutdown; failure to install
+            // the handler propagates as a panic since the process cannot function without it.
+            #[allow(clippy::expect_used)]
             let mut sigterm =
                 signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
             tokio::select! {
@@ -191,8 +194,10 @@ fn setup_tracing(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[allow(clippy::expect_used)]
     aws_lc_rs::default_provider()
         .install_default()
+        // SAFETY: CryptoProvider installation is required for TLS; main() cannot proceed without it.
         .expect("failed to install rustls CryptoProvider");
 
     let port = match parse_cli_args() {

--- a/crates/aptu-coder/src/main.rs
+++ b/crates/aptu-coder/src/main.rs
@@ -198,7 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     aws_lc_rs::default_provider()
         .install_default()
         // SAFETY: CryptoProvider installation is required for TLS; main() cannot proceed without it.
-        .expect("failed to install rustls CryptoProvider");
+        .expect("failed to install rustls CryptoProvider: TLS is required for server startup and cannot be recovered");
 
     let port = match parse_cli_args() {
         Ok(p) => p,

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -361,8 +361,10 @@ impl MetricsWriter {
             *current_file = Some(base_dir.join(format!("metrics-{}.jsonl", current_date)));
         }
 
+        #[allow(clippy::expect_used)]
         current_file
             .as_ref()
+            // SAFETY: current_file was just set to Some() in the preceding if block if it was None.
             .expect("current_file is guaranteed Some after check above")
             .clone()
     }

--- a/crates/aptu-coder/src/tools/edit_overwrite.rs
+++ b/crates/aptu-coder/src/tools/edit_overwrite.rs
@@ -207,9 +207,12 @@ pub(crate) async fn edit_overwrite(
     {
         let sid_str = ctx.sid.clone().unwrap_or_default();
         let canonical = output.path.clone();
+        #[allow(clippy::expect_used)]
         let mut counts = ctx
             .edit_failure_counts
             .lock()
+            // SAFETY: mutex lock failure indicates a poisoned lock from a panic in another task;
+            // this is fatal and should propagate.
             .expect("edit_failure_counts poisoned");
         counts.remove(&(sid_str, canonical));
     }

--- a/crates/aptu-coder/src/tools/edit_replace.rs
+++ b/crates/aptu-coder/src/tools/edit_replace.rs
@@ -53,6 +53,9 @@ impl StaleContextGuard {
     /// Increments the failure counter for `canonical` and returns `true` when the
     /// circuit breaker threshold has been reached.
     fn increment(&mut self, canonical: &str) -> bool {
+        // SAFETY: mutex lock failure indicates a poisoned lock from a panic in another task;
+        // this is fatal and should propagate.
+        #[allow(clippy::expect_used)]
         let mut counts = self.counts.lock().expect("edit_failure_counts poisoned");
         if counts.len() >= EDIT_FAILURE_MAP_CAP {
             counts.clear();
@@ -66,6 +69,9 @@ impl StaleContextGuard {
 
     /// Resets the failure counter for `canonical` after a successful edit.
     fn reset(&mut self, canonical: &str) {
+        // SAFETY: mutex lock failure indicates a poisoned lock from a panic in another task;
+        // this is fatal and should propagate.
+        #[allow(clippy::expect_used)]
         let mut counts = self.counts.lock().expect("edit_failure_counts poisoned");
         counts.remove(&(self.sid.clone(), canonical.to_owned()));
     }


### PR DESCRIPTION
## Summary

Added `expect_used = "deny"` workspace lint alongside existing `unwrap_used` enforcement. All production `.expect()` sites annotated with `// SAFETY:` comments and `#[allow(clippy::expect_used)]` attributes. Added observability to cache poison recovery path. Updated AGENTS.md to reflect both lints with test-code exemptions.

## Findings addressed

- **F11**: Added `expect_used = "deny"` to `[workspace.lints.clippy]` in Cargo.toml; added `#![cfg_attr(test, allow(clippy::expect_used))]` to both crates' lib.rs files
- **F12**: Added `tracing::warn!()` to `lock_or_recover` poison recovery branch in cache.rs
- **F13**: Added comment at `lock_shard_shared` call site noting graceful no-lock fallback behavior
- **A01**: Updated AGENTS.md to remove inaccurate cfg_attr claim and reflect actual pattern

## Review changes

- Extracted `DEFAULT_LOCK_RECOVER_CAPACITY` as a `NonZeroUsize` const; call site simplified to `NonZeroUsize::new(capacity).unwrap_or(DEFAULT_LOCK_RECOVER_CAPACITY)` -- no closure, no `expect` at the call site
- Improved `CryptoProvider` expect message to include recovery context for production logs
- Added audit note to `edit_replace` expect site: future refactors of the count-verification match block must re-audit this site

## Files changed

- AGENTS.md
- Cargo.toml
- crates/aptu-coder-core/src/cache.rs
- crates/aptu-coder-core/src/edit.rs
- crates/aptu-coder-core/src/graph.rs
- crates/aptu-coder-core/src/languages/regex_fallback.rs
- crates/aptu-coder-core/src/lib.rs
- crates/aptu-coder-core/src/schema_helpers.rs
- crates/aptu-coder/src/lib.rs
- crates/aptu-coder/src/main.rs
- crates/aptu-coder/src/metrics.rs
- crates/aptu-coder/src/tools/edit_overwrite.rs
- crates/aptu-coder/src/tools/edit_replace.rs

## Test plan

- [x] Tests pass (153 passed, 0 failed)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)

Closes #1273
