### PR TITLE
chore(release): bump version to 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.22.3"
+version = "0.23.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.22.3"
+version = "0.23.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.3"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.22", features = ["schemars"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.23", features = ["schemars"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
chore(release): bump version to 0.23.0

Bumps workspace version `0.22.3` -> `0.23.0` and updates the `aptu-coder-core` dependency pin from `"0.22"` to `"0.23"` in `crates/aptu-coder/Cargo.toml`.

Minor bump: `refactor(server)` (#1278) removes the `APTU_CODER_PROFILE` vendor extension, a behavioral change that warrants a minor version increment per semver.

Changes since v0.22.3 included in this release:

- fix(exec_command): sync output_truncated to structuredContent and add interleaved slot-file overflow (#1268)
- refactor(server): remove APTU_CODER_PROFILE feature (#1278)
- fix(ci): arm64 binary, rust-cache SHA, and codeql runner (#1280)
- fix(deps): remove stale RUSTSEC-2023-0071, unused CDLA-Permissive-2.0, enforce bans in CI (#1281)
- fix(core): add expect_used lint, cache observability, and fix AGENTS.md cfg_attr claim (#1282)
- fix(exec): use full seq as slot identifier to prevent concurrent overflow collision (#1283)
- chore(renovate): automerge major github-actions updates (#1284)
- docs: update audit report resolutions and fix stale OBSERVABILITY.md links (#1285)
