### PR TITLE
feat(metrics): add error metrics to analyze_symbol (#1289)

### DIFF
--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -52,6 +52,27 @@ struct FocusedAnalysisParams {
     parse_timeout_micros: Option<u64>,
 }
 
+/// Helper function to emit error metrics for analyze_symbol.
+/// Extracts the error_type string from ErrorCode and records it on the span.
+fn emit_error_metric(
+    ctx: &AnalyzeSymbolContext,
+    error_type: &str,
+    t_start: std::time::Instant,
+    param_path_depth: Option<usize>,
+) {
+    let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+    tracing::Span::current().record("error", true);
+    tracing::Span::current().record("error.type", error_type);
+    let mut builder = crate::metrics::MetricEventBuilder::new("analyze_symbol", "error", dur)
+        .error_type(Some(error_type.to_string()))
+        .session_id(ctx.sid.clone())
+        .seq(Some(ctx.seq));
+    if let Some(depth) = param_path_depth {
+        builder = builder.param_path_depth(depth);
+    }
+    ctx.metrics_tx.send(builder.build());
+}
+
 /// Validate that `impl_only=true` is only used with directories containing Rust source files.
 pub(crate) fn validate_impl_only(entries: &[WalkEntry]) -> Result<(), ErrorData> {
     let has_rust = entries.iter().any(|e| {
@@ -152,7 +173,7 @@ fn paginate_focus_chains(
 
 /// Run focused analysis with auto-summary retry on SIZE_LIMIT overflow.
 async fn run_focused_with_auto_summary(
-    _ctx: &AnalyzeSymbolContext,
+    ctx: &AnalyzeSymbolContext,
     params: &AnalyzeSymbolParams,
     analysis_params: &FocusedAnalysisParams,
     counter: Arc<std::sync::atomic::AtomicUsize>,
@@ -173,6 +194,8 @@ async fn run_focused_with_auto_summary(
         parse_timeout_micros: analysis_params.parse_timeout_micros,
     };
 
+    let t_start = std::time::Instant::now();
+
     let mut output = tokio::task::spawn_blocking({
         let path = analysis_params.path.clone();
         let entries = entries.clone();
@@ -187,6 +210,7 @@ async fn run_focused_with_auto_summary(
     })
     .await
     .map_err(|e| {
+        emit_error_metric(ctx, "internal_error", t_start, None);
         ErrorData::new(
             rmcp::model::ErrorCode::INTERNAL_ERROR,
             format!("analysis task panicked: {e}"),
@@ -194,6 +218,7 @@ async fn run_focused_with_auto_summary(
         )
     })?
     .map_err(|e| {
+        emit_error_metric(ctx, "internal_error", t_start, None);
         ErrorData::new(
             rmcp::model::ErrorCode::INTERNAL_ERROR,
             format!("analysis failed: {e}"),
@@ -237,15 +262,18 @@ async fn run_focused_with_auto_summary(
                 output.formatted.len(),
                 estimated_tokens
             );
-            return Err(ErrorData::new(
-                rmcp::model::ErrorCode::INVALID_PARAMS,
-                message,
-                Some(error_meta(
-                    "validation",
-                    false,
-                    "use summary=true or narrow scope",
-                )),
-            ));
+            return Err({
+                emit_error_metric(ctx, "invalid_params", t_start, None);
+                ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    message,
+                    Some(error_meta(
+                        "validation",
+                        false,
+                        "use summary=true or narrow scope",
+                    )),
+                )
+            });
         }
     } else if output.formatted.len() > SIZE_LIMIT && params.output_control.summary == Some(false) {
         let estimated_tokens = output.formatted.len() / 4;
@@ -256,15 +284,18 @@ async fn run_focused_with_auto_summary(
             output.formatted.len(),
             estimated_tokens
         );
-        return Err(ErrorData::new(
-            rmcp::model::ErrorCode::INVALID_PARAMS,
-            message,
-            Some(error_meta(
-                "validation",
-                false,
-                "use summary=true or narrow scope",
-            )),
-        ));
+        return Err({
+            emit_error_metric(ctx, "invalid_params", t_start, None);
+            ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                message,
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "use summary=true or narrow scope",
+                )),
+            )
+        });
     }
 
     Ok(output)
@@ -531,8 +562,27 @@ async fn handle_import_lookup(
 
     let output = match handle.await {
         Ok(Ok(v)) => v,
-        Ok(Err(e)) => return Ok(err_to_tool_result(e)),
+        Ok(Err(e)) => {
+            let error_type_str = match e.code {
+                rmcp::model::ErrorCode::INVALID_PARAMS => "invalid_params",
+                rmcp::model::ErrorCode::INTERNAL_ERROR => "internal_error",
+                _ => "unknown",
+            };
+            emit_error_metric(
+                &ctx,
+                error_type_str,
+                t_start,
+                Some(crate::metrics::path_component_count(&param_path)),
+            );
+            return Ok(err_to_tool_result(e));
+        }
         Err(e) => {
+            emit_error_metric(
+                &ctx,
+                "internal_error",
+                t_start,
+                Some(crate::metrics::path_component_count(&param_path)),
+            );
             return Ok(err_to_tool_result(ErrorData::new(
                 rmcp::model::ErrorCode::INTERNAL_ERROR,
                 format!("spawn_blocking failed: {e}"),
@@ -740,7 +790,20 @@ async fn handle_call_graph(
     // Call handler for analysis and progress tracking
     let (graph_cache_tier, mut output) = match handle_focused_mode(&ctx, &params, ct).await {
         Ok(v) => v,
-        Err(e) => return Ok(err_to_tool_result(e)),
+        Err(e) => {
+            let error_type_str = match e.code {
+                rmcp::model::ErrorCode::INVALID_PARAMS => "invalid_params",
+                rmcp::model::ErrorCode::INTERNAL_ERROR => "internal_error",
+                _ => "unknown",
+            };
+            emit_error_metric(
+                &ctx,
+                error_type_str,
+                t_start,
+                Some(crate::metrics::path_component_count(&param_path)),
+            );
+            return Ok(err_to_tool_result(e));
+        }
     };
 
     // Surface cache tier in structuredContent for observability and testing.
@@ -749,7 +812,15 @@ async fn handle_call_graph(
     let page_size = params.pagination.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
     let (offset, cursor_mode) = match decode_call_graph_cursor(&params) {
         Ok(v) => v,
-        Err(e) => return Ok(e),
+        Err(e) => {
+            emit_error_metric(
+                &ctx,
+                "invalid_params",
+                t_start,
+                Some(crate::metrics::path_component_count(&param_path)),
+            );
+            return Ok(e);
+        }
     };
 
     let use_summary = params.output_control.summary == Some(true);
@@ -763,7 +834,15 @@ async fn handle_call_graph(
         use_summary,
     ) {
         Ok(v) => v,
-        Err(e) => return Ok(e),
+        Err(e) => {
+            emit_error_metric(
+                &ctx,
+                "invalid_params",
+                t_start,
+                Some(crate::metrics::path_component_count(&param_path)),
+            );
+            return Ok(e);
+        }
     };
 
     // When callers are exhausted and callees exist, bootstrap callee pagination
@@ -882,8 +961,10 @@ pub(crate) async fn analyze_symbol_handler(
     call: crate::tools::AnalyzeSymbolCall,
 ) -> Result<CallToolResult, ErrorData> {
     let span = &call.span;
+    let t_start = call.t_start;
 
     if std::path::Path::new(&params.path).is_file() {
+        emit_error_metric(&ctx, "invalid_params", t_start, None);
         return invalid_params(
             span,
             format!(
@@ -898,6 +979,7 @@ pub(crate) async fn analyze_symbol_handler(
         params.output_control.summary,
         params.pagination.cursor.as_deref(),
     ) {
+        emit_error_metric(&ctx, "invalid_params", t_start, None);
         return invalid_params(
             span,
             "summary=true is incompatible with a pagination cursor; use one or the other",
@@ -906,6 +988,7 @@ pub(crate) async fn analyze_symbol_handler(
     }
 
     if params.import_lookup == Some(true) && params.def_use == Some(true) {
+        emit_error_metric(&ctx, "invalid_params", t_start, None);
         return invalid_params(
             span,
             "import_lookup=true and def_use=true are mutually exclusive; use one or the other",
@@ -914,8 +997,7 @@ pub(crate) async fn analyze_symbol_handler(
     }
 
     if let Err(e) = validate_import_lookup(params.import_lookup, &params.symbol) {
-        span.record("error", true);
-        span.record("error.type", "invalid_params");
+        emit_error_metric(&ctx, "invalid_params", t_start, None);
         return Ok(err_to_tool_result(e));
     }
 

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -73,6 +73,21 @@ fn emit_error_metric(
     ctx.metrics_tx.send(builder.build());
 }
 
+/// Emit an invalid_params error metric and return the corresponding `ErrorData`.
+fn err_invalid_params(
+    ctx: &AnalyzeSymbolContext,
+    t_start: std::time::Instant,
+    message: String,
+    hint: &'static str,
+) -> ErrorData {
+    emit_error_metric(ctx, "invalid_params", t_start, None);
+    ErrorData::new(
+        rmcp::model::ErrorCode::INVALID_PARAMS,
+        message,
+        Some(error_meta("validation", false, hint)),
+    )
+}
+
 /// Validate that `impl_only=true` is only used with directories containing Rust source files.
 pub(crate) fn validate_impl_only(entries: &[WalkEntry]) -> Result<(), ErrorData> {
     let has_rust = entries.iter().any(|e| {
@@ -262,18 +277,12 @@ async fn run_focused_with_auto_summary(
                 output.formatted.len(),
                 estimated_tokens
             );
-            return Err({
-                emit_error_metric(ctx, "invalid_params", t_start, None);
-                ErrorData::new(
-                    rmcp::model::ErrorCode::INVALID_PARAMS,
-                    message,
-                    Some(error_meta(
-                        "validation",
-                        false,
-                        "use summary=true or narrow scope",
-                    )),
-                )
-            });
+            return Err(err_invalid_params(
+                ctx,
+                t_start,
+                message,
+                "use summary=true or narrow scope",
+            ));
         }
     } else if output.formatted.len() > SIZE_LIMIT && params.output_control.summary == Some(false) {
         let estimated_tokens = output.formatted.len() / 4;
@@ -284,18 +293,12 @@ async fn run_focused_with_auto_summary(
             output.formatted.len(),
             estimated_tokens
         );
-        return Err({
-            emit_error_metric(ctx, "invalid_params", t_start, None);
-            ErrorData::new(
-                rmcp::model::ErrorCode::INVALID_PARAMS,
-                message,
-                Some(error_meta(
-                    "validation",
-                    false,
-                    "use summary=true or narrow scope",
-                )),
-            )
-        });
+        return Err(err_invalid_params(
+            ctx,
+            t_start,
+            message,
+            "use summary=true or narrow scope",
+        ));
     }
 
     Ok(output)

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -60,7 +60,7 @@ fn emit_error_metric(
     t_start: std::time::Instant,
     param_path_depth: Option<usize>,
 ) {
-    let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+    let dur = t_start.elapsed().as_millis().min(u64::MAX as u128) as u64;
     tracing::Span::current().record("error", true);
     tracing::Span::current().record("error.type", error_type);
     let mut builder = crate::metrics::MetricEventBuilder::new("analyze_symbol", "error", dur)

--- a/crates/aptu-coder/tests/analyze_symbol_error_metrics_tests.rs
+++ b/crates/aptu-coder/tests/analyze_symbol_error_metrics_tests.rs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use common::call_tool_raw;
+use serde_json::json;
+use std::io::Write as _;
+use tempfile::NamedTempFile;
+
+/// Test that analyze_symbol emits result=error with error_type=invalid_params
+/// when passed a file path instead of directory (happy_path).
+#[tokio::test]
+async fn test_analyze_symbol_file_path_error_metrics() {
+    // Arrange: create a temp file inside CWD so validate_path accepts it
+    let cwd = std::env::current_dir().unwrap();
+    let mut f = NamedTempFile::with_suffix_in(".rs", &cwd).unwrap();
+    write!(f, "fn foo() {{}}\n").unwrap();
+    f.flush().unwrap();
+
+    // Act: call analyze_symbol with file path
+    let params = json!({
+        "path": f.path().to_str().unwrap(),
+        "symbol": "foo",
+        "follow_depth": 1,
+    });
+    let response = call_tool_raw("analyze_symbol", params).await;
+
+    // Assert: error response with invalid_params
+    let result = response.get("result").unwrap();
+    assert_eq!(
+        result.get("isError").unwrap().as_bool().unwrap(),
+        true,
+        "expected isError=true"
+    );
+    let content = result.get("content").unwrap().as_array().unwrap();
+    assert!(!content.is_empty(), "expected content");
+    let text = content[0].get("text").unwrap().as_str().unwrap();
+    assert!(
+        text.contains("file"),
+        "error message should mention file: {}",
+        text
+    );
+}
+
+/// Test that analyze_symbol emits result=error with error_type=invalid_params
+/// when both import_lookup=true and def_use=true (edge_case).
+#[tokio::test]
+async fn test_analyze_symbol_import_lookup_def_use_conflict_error_metrics() {
+    // Arrange: create a temp directory with a Rust file inside CWD
+    let cwd = std::env::current_dir().unwrap();
+    let dir = tempfile::TempDir::new_in(&cwd).unwrap();
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}").unwrap();
+
+    // Act: call analyze_symbol with both import_lookup=true and def_use=true
+    let params = json!({
+        "path": dir.path().to_str().unwrap(),
+        "symbol": "std::collections",
+        "follow_depth": 1,
+        "import_lookup": true,
+        "def_use": true,
+    });
+    let response = call_tool_raw("analyze_symbol", params).await;
+
+    // Assert: error response with invalid_params
+    let result = response.get("result").unwrap();
+    assert_eq!(
+        result.get("isError").unwrap().as_bool().unwrap(),
+        true,
+        "expected isError=true"
+    );
+    let content = result.get("content").unwrap().as_array().unwrap();
+    assert!(!content.is_empty(), "expected content");
+    let text = content[0].get("text").unwrap().as_str().unwrap();
+    assert!(
+        text.contains("mutually exclusive"),
+        "error message should mention mutually exclusive: {}",
+        text
+    );
+}
+
+/// Test that analyze_symbol emits result=error with error_type=invalid_params
+/// when summary=true and cursor are both provided (edge_case).
+#[tokio::test]
+async fn test_analyze_symbol_summary_cursor_conflict_error_metrics() {
+    // Arrange: create a temp directory with a Rust file inside CWD
+    let cwd = std::env::current_dir().unwrap();
+    let dir = tempfile::TempDir::new_in(&cwd).unwrap();
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}").unwrap();
+
+    // Act: call analyze_symbol with both summary=true and cursor
+    let params = json!({
+        "path": dir.path().to_str().unwrap(),
+        "symbol": "foo",
+        "follow_depth": 1,
+        "summary": true,
+        "cursor": "some_cursor",
+    });
+    let response = call_tool_raw("analyze_symbol", params).await;
+
+    // Assert: error response with invalid_params
+    let result = response.get("result").unwrap();
+    assert_eq!(
+        result.get("isError").unwrap().as_bool().unwrap(),
+        true,
+        "expected isError=true"
+    );
+    let content = result.get("content").unwrap().as_array().unwrap();
+    assert!(!content.is_empty(), "expected content");
+    let text = content[0].get("text").unwrap().as_str().unwrap();
+    assert!(
+        text.contains("incompatible"),
+        "error message should mention incompatible: {}",
+        text
+    );
+}
+
+/// Test that analyze_symbol emits result=error with error_type=invalid_params
+/// when import_lookup=true with empty symbol (edge_case).
+#[tokio::test]
+async fn test_analyze_symbol_import_lookup_empty_symbol_error_metrics() {
+    // Arrange: create a temp directory with a Rust file inside CWD
+    let cwd = std::env::current_dir().unwrap();
+    let dir = tempfile::TempDir::new_in(&cwd).unwrap();
+    std::fs::write(dir.path().join("lib.rs"), "fn foo() {}").unwrap();
+
+    // Act: call analyze_symbol with import_lookup=true and empty symbol
+    let params = json!({
+        "path": dir.path().to_str().unwrap(),
+        "symbol": "",
+        "follow_depth": 1,
+        "import_lookup": true,
+    });
+    let response = call_tool_raw("analyze_symbol", params).await;
+
+    // Assert: error response with invalid_params
+    let result = response.get("result").unwrap();
+    assert_eq!(
+        result.get("isError").unwrap().as_bool().unwrap(),
+        true,
+        "expected isError=true"
+    );
+    let content = result.get("content").unwrap().as_array().unwrap();
+    assert!(!content.is_empty(), "expected content");
+    let text = content[0].get("text").unwrap().as_str().unwrap();
+    assert!(
+        text.contains("module path"),
+        "error message should mention module path: {}",
+        text
+    );
+}


### PR DESCRIPTION
## Summary

`analyze_symbol` was the only tool missing JSONL error metrics. All error paths recorded on the tracing span only, making error rates unmeasurable. This PR instruments all error exit points in `analyze_symbol_handler` and its callees, mirroring the pattern in `analyze_file.rs`.

Follow-up review feedback addressed in subsequent commits:
- Saturating cast in `emit_error_metric`: replaced `try_into().unwrap_or(u64::MAX)` with `.min(u64::MAX as u128) as u64` to make overflow intent explicit
- Extracted `err_invalid_params` helper that fuses `emit_error_metric` + `ErrorData::new`, collapsing the two verbose `return Err({ ... })` blocks in `run_focused_with_auto_summary` to single-call form

## Changes

- `crates/aptu-coder/src/tools/analyze_symbol.rs`
- `crates/aptu-coder/tests/analyze_symbol_error_metrics_tests.rs`

## Test plan

- [x] Tests pass (`cargo test`)
- [x] Linter clean (`cargo clippy -- -D warnings`)
- [x] Security scan clean (no findings)

Closes #1289
