### PR TITLE
chore(release): bump version to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.23", features = ["schemars"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.24", features = ["schemars"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
chore(release): bump version to 0.24.0

Bumps workspace version from 0.23.0 to 0.24.0 and updates the `aptu-coder-core` dependency pin in `crates/aptu-coder/Cargo.toml` to match.

## Changes

- `Cargo.toml`: `0.23.0` → `0.24.0`
- `crates/aptu-coder/Cargo.toml`: `aptu-coder-core` pin `0.23` → `0.24`
- `Cargo.lock`: regenerated
