### PR TITLE
fix(exec): fix floor_char_boundary panic on multi-byte UTF-8 truncation boundary

### DIFF
--- a/crates/aptu-coder/src/tests/exec_tests.rs
+++ b/crates/aptu-coder/src/tests/exec_tests.rs
@@ -1,5 +1,7 @@
 use crate::tools::exec_command::strip_cd_prefix;
-use crate::tools::exec_runtime::{build_exec_command, handle_output_persist};
+use crate::tools::exec_runtime::{
+    build_exec_command, handle_output_persist, persist_interleaved_overflow,
+};
 use crate::{SIZE_LIMIT, STDIN_MAX_BYTES};
 
 #[test]
@@ -221,7 +223,7 @@ fn test_exec_byte_overflow_combined_exceeds_50k() {
     let truncated = if large_output.len() > SIZE_LIMIT {
         combined_truncated = true;
         let tail_start = large_output.len().saturating_sub(SIZE_LIMIT);
-        let safe_start = large_output[..tail_start].floor_char_boundary(tail_start);
+        let safe_start = large_output.floor_char_boundary(tail_start);
         large_output[safe_start..].to_string()
     } else {
         large_output.clone()
@@ -327,4 +329,58 @@ fn test_strip_cd_prefix_splits_on_first_ampersand_only() {
     let (cmd, path) = strip_cd_prefix("cd /a && cmd1 && cd /b && cmd2");
     assert_eq!(path, Some("/a"));
     assert_eq!(cmd, "cmd1 && cd /b && cmd2");
+}
+
+#[tokio::test]
+async fn test_handle_output_persist_mid_char_boundary() {
+    // Regression: tail_start falls inside a multi-byte UTF-8 char.
+    // Construct stdout of exactly MAX_STDOUT_BYTES + 1 bytes where byte 1
+    // is the second byte of a 3-byte char (中, U+4E2D).
+    // Old code: stdout[..tail_start] panics because byte 1 is not a char boundary.
+    // Fix: floor_char_boundary on the full string returns 0, no panic.
+    let mut stdout = String::new();
+    stdout.push('\u{4E2D}'); // 3 bytes: 0xE4 0xB8 0xAD
+    stdout.push_str(&"a".repeat(29998)); // total = 30001 bytes
+    assert_eq!(stdout.len(), 30_001);
+
+    let stderr = String::new();
+    let slot = 99u32;
+
+    let (out_stdout, _out_stderr, _stdout_path, _stderr_path, byte_truncated) =
+        handle_output_persist(stdout, stderr, slot);
+
+    assert!(byte_truncated, "byte_truncated should be true");
+    assert!(
+        out_stdout.is_char_boundary(0),
+        "start should be char boundary"
+    );
+    assert!(
+        out_stdout.is_char_boundary(out_stdout.len()),
+        "end should be char boundary"
+    );
+    let _char_count = out_stdout.chars().count();
+}
+
+#[tokio::test]
+async fn test_persist_interleaved_mid_char_boundary() {
+    // Regression: tail_start falls inside a multi-byte UTF-8 char.
+    // Construct interleaved of max_bytes + 1 bytes where byte 1
+    // is the second byte of a 3-byte char.
+    let mut interleaved = String::new();
+    interleaved.push('\u{4E2D}'); // 3 bytes
+    interleaved.push_str(&"a".repeat(98)); // total = 101 bytes
+    assert_eq!(interleaved.len(), 101);
+
+    let max_bytes = 100usize;
+    let slot = 42u32;
+
+    let (preview, path) = persist_interleaved_overflow(interleaved, max_bytes, slot).await;
+
+    assert!(path.is_some(), "should have overflowed to slot file");
+    assert!(preview.is_char_boundary(0), "start should be char boundary");
+    assert!(
+        preview.is_char_boundary(preview.len()),
+        "end should be char boundary"
+    );
+    let _char_count = preview.chars().count();
 }

--- a/crates/aptu-coder/src/tools/analyze_directory.rs
+++ b/crates/aptu-coder/src/tools/analyze_directory.rs
@@ -51,7 +51,7 @@ pub(crate) async fn handle_overview_mode(
         )
     })?;
 
-    let canonical_max_depth = max_depth.and_then(|d| if d == 0 { None } else { Some(d) });
+    let canonical_max_depth = max_depth.filter(|&d| d != 0);
     let git_ref_val = params.git_ref.as_deref().filter(|s| !s.is_empty());
     let cache_key = DirectoryCacheKey::from_entries(
         &all_entries,

--- a/crates/aptu-coder/src/tools/analyze_symbol.rs
+++ b/crates/aptu-coder/src/tools/analyze_symbol.rs
@@ -298,16 +298,15 @@ fn decode_call_graph_cursor(
         .unwrap_or(PaginationMode::Callers);
 
     let offset = if let Some(ref cursor_str) = params.pagination.cursor {
-        match decode_cursor(cursor_str).map_err(|e| {
-            err_to_tool_result(ErrorData::new(
-                rmcp::model::ErrorCode::INVALID_PARAMS,
-                e.to_string(),
-                Some(error_meta("validation", false, "invalid cursor format")),
-            ))
-        }) {
-            Ok(v) => v.offset,
-            Err(e) => return Err(e),
-        }
+        decode_cursor(cursor_str)
+            .map_err(|e| {
+                err_to_tool_result(ErrorData::new(
+                    rmcp::model::ErrorCode::INVALID_PARAMS,
+                    e.to_string(),
+                    Some(error_meta("validation", false, "invalid cursor format")),
+                ))
+            })?
+            .offset
     } else {
         0
     };

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -291,7 +291,7 @@ fn format_shell_output_phase(output: &ShellOutput, params: &ExecCommandParams) -
         combined_truncated = true;
         // Use char-boundary-safe tail truncation
         let tail_start = output_text.len().saturating_sub(SIZE_LIMIT);
-        let safe_start = output_text[..tail_start].floor_char_boundary(tail_start);
+        let safe_start = output_text.floor_char_boundary(tail_start);
         output_text[safe_start..].to_string()
     } else {
         output_text
@@ -596,4 +596,55 @@ pub(crate) fn strip_cd_prefix(cmd: &str) -> (&str, Option<&str>) {
     let path = path_part.trim();
     let stripped = rest_part.trim();
     (stripped, Some(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ShellOutput;
+
+    #[test]
+    fn test_format_shell_output_mid_char_boundary() {
+        // Regression: tail_start falls inside a multi-byte UTF-8 char.
+        // Construct interleaved of SIZE_LIMIT + 1 bytes where byte 1
+        // is the second byte of a 3-byte char (中, U+4E2D).
+        // Old code: output_text[..tail_start] panics.
+        // Fix: floor_char_boundary on the full string returns 0, no panic.
+        let mut interleaved = String::new();
+        interleaved.push('\u{4E2D}'); // 3 bytes: 0xE4 0xB8 0xAD
+        interleaved.push_str(&"a".repeat(4998)); // total = 5001 bytes
+        assert_eq!(interleaved.len(), 5001);
+
+        let output = ShellOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            interleaved,
+            exit_code: Some(0),
+            output_truncated: false,
+            output_collection_error: None,
+            stdout_path: None,
+            stderr_path: None,
+            interleaved_path: None,
+            filter_applied: None,
+            timed_out: false,
+        };
+
+        let params = ExecCommandParams {
+            command: "echo test".to_string(),
+            working_dir: None,
+            stdin: None,
+            timeout_secs: None,
+            drain_timeout_secs: None,
+        };
+
+        let (result, truncated) = format_shell_output_phase(&output, &params);
+
+        assert!(truncated, "should be truncated");
+        assert!(result.is_char_boundary(0), "start should be char boundary");
+        assert!(
+            result.is_char_boundary(result.len()),
+            "end should be char boundary"
+        );
+        let _char_count = result.chars().count();
+    }
 }

--- a/crates/aptu-coder/src/tools/exec_runtime.rs
+++ b/crates/aptu-coder/src/tools/exec_runtime.rs
@@ -392,7 +392,7 @@ pub(crate) async fn persist_interleaved_overflow(
     let path = interleaved_file.display().to_string();
     // Tail preview: show the most recent output, respecting char boundaries.
     let tail_start = interleaved.len().saturating_sub(max_bytes);
-    let safe_start = interleaved[..tail_start].floor_char_boundary(tail_start);
+    let safe_start = interleaved.floor_char_boundary(tail_start);
     (interleaved[safe_start..].to_string(), Some(path))
 }
 
@@ -449,7 +449,7 @@ pub(crate) fn handle_output_persist(
         byte_truncated = true;
         // Use char-boundary-safe tail truncation
         let tail_start = stdout.len().saturating_sub(MAX_STDOUT_BYTES);
-        let safe_start = stdout[..tail_start].floor_char_boundary(tail_start);
+        let safe_start = stdout.floor_char_boundary(tail_start);
         stdout[safe_start..].to_string()
     } else if stdout_lines.len() > MAX_OUTPUT_LINES {
         stdout_lines[stdout_lines.len().saturating_sub(OVERFLOW_PREVIEW_LINES)..].join("\n")
@@ -462,7 +462,7 @@ pub(crate) fn handle_output_persist(
         byte_truncated = true;
         // Use char-boundary-safe tail truncation
         let tail_start = stderr.len().saturating_sub(MAX_STDERR_BYTES);
-        let safe_start = stderr[..tail_start].floor_char_boundary(tail_start);
+        let safe_start = stderr.floor_char_boundary(tail_start);
         stderr[safe_start..].to_string()
     } else if stderr_lines.len() > MAX_OUTPUT_LINES {
         stderr_lines[stderr_lines.len().saturating_sub(OVERFLOW_PREVIEW_LINES)..].join("\n")


### PR DESCRIPTION
## What

Fix a panic in `exec_command` that kills the MCP server process on large output containing multi-byte UTF-8 characters near a truncation boundary.

## Root cause

Four production call sites in `exec_runtime.rs` and `exec_command.rs` called `floor_char_boundary` on a *slice* `s[..tail_start]` rather than on the full string `s`:

```rust
// Buggy: panics when tail_start is not a char boundary
let safe_start = s[..tail_start].floor_char_boundary(tail_start);

// Fixed: floor_char_boundary finds the nearest valid boundary
let safe_start = s.floor_char_boundary(tail_start);
```

The slice indexing `s[..tail_start]` panics (index not on char boundary) before `floor_char_boundary` is even called. With `panic = "abort"` in the release profile the process exits immediately, permanently breaking the MCP transport for the session -- all subsequent tool calls return `-32603: Transport closed`.

## Changes

- `crates/aptu-coder/src/tools/exec_runtime.rs`: fix 3 sites in `persist_interleaved_overflow` and `handle_output_persist`
- `crates/aptu-coder/src/tools/exec_command.rs`: fix 1 site in `format_shell_output_phase`
- `crates/aptu-coder/src/tests/exec_tests.rs`: fix 1 latent site (currently masked by ASCII-only input)
- Regression tests: 3 new unit tests that place a 3-byte UTF-8 character (`中`, U+4E2D) at the exact truncation boundary, verifying no panic and valid UTF-8 output

## Testing

```
cargo test -p aptu-coder   # all tests pass
cargo clippy -p aptu-coder -- -D warnings   # clean
cargo fmt --check -p aptu-coder   # clean
```
