### PR TITLE
perf(metrics): record pre-truncation stdout/stderr byte counts on exec_command overflow (#1320)

### DIFF
--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -128,6 +128,14 @@ pub struct MetricEvent {
     /// L2 disk cache total size in bytes at the time of metric emission. Only populated for cache-related metrics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub l2_size_bytes: Option<u64>,
+    /// Raw stdout bytes read before any truncation. Only populated for `exec_command`
+    /// when `output_truncated=true` and `timed_out=false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout_bytes_raw: Option<u64>,
+    /// Raw stderr bytes read before any truncation. Only populated for `exec_command`
+    /// when `output_truncated=true` and `timed_out=false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_bytes_raw: Option<u64>,
 }
 
 /// Fluent builder for MetricEvent. Reduces repetitive struct literal boilerplate.
@@ -170,6 +178,8 @@ pub(crate) struct MetricEventBuilder {
     l1_eviction_count: Option<u64>,
     l2_entry_count: Option<u64>,
     l2_size_bytes: Option<u64>,
+    stdout_bytes_raw: Option<u64>,
+    stderr_bytes_raw: Option<u64>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -352,6 +362,16 @@ impl MetricEventBuilder {
         self
     }
     #[must_use]
+    pub(crate) fn stdout_bytes_raw(mut self, v: u64) -> Self {
+        self.stdout_bytes_raw = Some(v);
+        self
+    }
+    #[must_use]
+    pub(crate) fn stderr_bytes_raw(mut self, v: u64) -> Self {
+        self.stderr_bytes_raw = Some(v);
+        self
+    }
+    #[must_use]
     pub(crate) fn build(self) -> MetricEvent {
         MetricEvent {
             ts: self.ts,
@@ -391,6 +411,8 @@ impl MetricEventBuilder {
             l1_eviction_count: self.l1_eviction_count,
             l2_entry_count: self.l2_entry_count,
             l2_size_bytes: self.l2_size_bytes,
+            stdout_bytes_raw: self.stdout_bytes_raw,
+            stderr_bytes_raw: self.stderr_bytes_raw,
         }
     }
 }
@@ -656,9 +678,34 @@ mod tests {
             l1_eviction_count: None,
             l2_entry_count: None,
             l2_size_bytes: None,
+            stdout_bytes_raw: None,
+            stderr_bytes_raw: None,
         };
         let serialized = serde_json::to_string(&event).unwrap();
         let json_str = r#"{"ts":1700000000000,"tool":"analyze_file","duration_ms":100,"output_chars":500,"param_path_depth":2,"max_depth":3,"result":"ok","session_id":"1742468880123-42","seq":5}"#;
         assert_eq!(serialized, json_str);
     }
+}
+
+#[test]
+fn test_metric_event_builder_raw_bytes_serialize() {
+    // Happy path: MetricEventBuilder stdout_bytes_raw and stderr_bytes_raw
+    // methods emit correct JSON with skip_serializing_if when set.
+    let event = MetricEventBuilder::new("exec_command", "ok", 100)
+        .stdout_bytes_raw(12345)
+        .stderr_bytes_raw(6789)
+        .build();
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains(r#""stdout_bytes_raw":12345"#));
+    assert!(json.contains(r#""stderr_bytes_raw":6789"#));
+}
+
+#[test]
+fn test_metric_event_builder_raw_bytes_skip_when_none() {
+    // Happy path: when stdout_bytes_raw/stderr_bytes_raw are None,
+    // they are omitted from JSON (skip_serializing_if).
+    let event = MetricEventBuilder::new("exec_command", "ok", 100).build();
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(!json.contains("stdout_bytes_raw"));
+    assert!(!json.contains("stderr_bytes_raw"));
 }

--- a/crates/aptu-coder/src/tests/exec_tests.rs
+++ b/crates/aptu-coder/src/tests/exec_tests.rs
@@ -1,8 +1,8 @@
 use crate::tools::exec_command::strip_cd_prefix;
 use crate::tools::exec_runtime::{
-    build_exec_command, handle_output_persist, persist_interleaved_overflow,
+    build_exec_command, handle_output_persist, persist_interleaved_overflow, run_exec_impl,
 };
-use crate::{SIZE_LIMIT, STDIN_MAX_BYTES};
+use crate::{SIZE_LIMIT, STDIN_MAX_BYTES, filters::CompiledRule};
 
 #[test]
 fn test_exec_stdin_size_cap_validation() {
@@ -383,4 +383,77 @@ async fn test_persist_interleaved_mid_char_boundary() {
         "end should be char boundary"
     );
     let _char_count = preview.chars().count();
+}
+
+#[tokio::test]
+async fn test_run_exec_impl_raw_byte_counters() {
+    // Edge case: unconditional byte counters increment on every line received
+    // even after budget check fires. Use a command that produces output exceeding
+    // the drain budget to verify raw counters exceed the budget.
+    let filter_table = std::sync::Arc::new(Vec::<CompiledRule>::new());
+    let (output, raw_so, raw_se) = run_exec_impl(
+        "echo hello && echo world >&2".to_string(),
+        None,
+        None,
+        0,
+        None,
+        &filter_table,
+        Some(5),
+        std::time::Duration::from_millis(500),
+    )
+    .await;
+
+    // Both stdout and stderr should have been captured
+    assert!(raw_so >= 6, "raw_stdout_bytes should be >= 6 (hello\\n)");
+    assert!(raw_se >= 6, "raw_stderr_bytes should be >= 6 (world\\n)");
+    assert_eq!(output.exit_code, Some(0));
+    assert!(!output.timed_out);
+}
+
+#[tokio::test]
+async fn test_run_exec_impl_raw_counters_exceed_budget() {
+    // Edge case: raw counters should exceed the budget when output is large.
+    // Generate 40k bytes of stdout (exceeds 30k MAX_DRAIN_STDOUT_BYTES).
+    let filter_table = std::sync::Arc::new(Vec::<CompiledRule>::new());
+    let large_line = "x".repeat(1000);
+    let cmd = format!("for i in $(seq 1 50); do echo {}; done", large_line);
+    let (output, raw_so, _raw_se) = run_exec_impl(
+        cmd,
+        None,
+        None,
+        0,
+        None,
+        &filter_table,
+        Some(10),
+        std::time::Duration::from_millis(500),
+    )
+    .await;
+
+    // Raw counter should exceed the 30k budget
+    assert!(raw_so > 30_000, "raw_stdout_bytes should exceed 30k budget");
+    assert!(output.output_truncated, "output should be truncated");
+    assert_eq!(output.exit_code, Some(0));
+    assert!(!output.timed_out);
+}
+
+#[tokio::test]
+async fn test_run_exec_impl_raw_counters_zero_on_timeout() {
+    // Edge case: raw byte counters are 0 when timed_out=true because the
+    // drain task is aborted before any output is collected.
+    let filter_table = std::sync::Arc::new(Vec::<CompiledRule>::new());
+    let (output, raw_so, raw_se) = run_exec_impl(
+        "sleep 2".to_string(),
+        None,
+        None,
+        0,
+        None,
+        &filter_table,
+        Some(1), // 1 second timeout, sleep 2 exceeds it
+        std::time::Duration::from_millis(500),
+    )
+    .await;
+
+    assert!(output.timed_out, "command should have timed out");
+    assert_eq!(raw_so, 0, "raw_stdout_bytes should be 0 on timeout");
+    assert_eq!(raw_se, 0, "raw_stderr_bytes should be 0 on timeout");
 }

--- a/crates/aptu-coder/src/tests/exec_tests.rs
+++ b/crates/aptu-coder/src/tests/exec_tests.rs
@@ -387,9 +387,9 @@ async fn test_persist_interleaved_mid_char_boundary() {
 
 #[tokio::test]
 async fn test_run_exec_impl_raw_byte_counters() {
-    // Edge case: unconditional byte counters increment on every line received
-    // even after budget check fires. Use a command that produces output exceeding
-    // the drain budget to verify raw counters exceed the budget.
+    // Happy path: verify raw byte counters are populated for normal (non-truncated)
+    // output. The command produces a small amount of stdout and stderr; counters
+    // should reflect the actual bytes received, not zero.
     let filter_table = std::sync::Arc::new(Vec::<CompiledRule>::new());
     let (output, raw_so, raw_se) = run_exec_impl(
         "echo hello && echo world >&2".to_string(),

--- a/crates/aptu-coder/src/tests/metrics_tests.rs
+++ b/crates/aptu-coder/src/tests/metrics_tests.rs
@@ -187,6 +187,8 @@ fn test_metric_chars_threshold_breach_fires() {
         l1_eviction_count: None,
         l2_entry_count: None,
         l2_size_bytes: None,
+        stdout_bytes_raw: None,
+        stderr_bytes_raw: None,
     };
     assert!(
         event.chars_threshold_breach,
@@ -236,6 +238,8 @@ fn test_metric_chars_threshold_breach_no_fire() {
         l1_eviction_count: None,
         l2_entry_count: None,
         l2_size_bytes: None,
+        stdout_bytes_raw: None,
+        stderr_bytes_raw: None,
     };
     assert!(
         !event.chars_threshold_breach,

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -240,8 +240,8 @@ async fn spawn_and_collect_phase(
     filter_table: &Arc<Vec<CompiledRule>>,
     drain_dur: std::time::Duration,
     span: &tracing::Span,
-) -> Result<ShellOutput, CallToolResult> {
-    let output = run_exec_impl(
+) -> Result<(ShellOutput, u64, u64), CallToolResult> {
+    let (output, raw_stdout_bytes, raw_stderr_bytes) = run_exec_impl(
         command,
         working_dir_path,
         params.stdin.clone(),
@@ -268,7 +268,7 @@ async fn spawn_and_collect_phase(
         return Err(result);
     }
 
-    Ok(output)
+    Ok((output, raw_stdout_bytes, raw_stderr_bytes))
 }
 
 /// Phase 4: Format output text and apply truncation limits.
@@ -445,7 +445,7 @@ pub(crate) async fn exec_command_impl(
 
     // Phase 3: Spawn and collect
     let resolved_path_str = resolved_path.as_deref();
-    let mut output = match spawn_and_collect_phase(
+    let (mut output, raw_stdout_bytes, raw_stderr_bytes) = match spawn_and_collect_phase(
         command.clone(),
         working_dir_path.clone(),
         &params,
@@ -555,25 +555,29 @@ pub(crate) async fn exec_command_impl(
 
     result.structured_content = Some(structured);
     let dur = t_start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
-    metrics_tx.send(
-        crate::metrics::MetricEventBuilder::new("exec_command", "ok", dur)
-            .output_chars(text.len())
-            .param_path_depth(crate::metrics::path_component_count(
-                param_path.as_deref().unwrap_or(""),
-            ))
-            .session_id(sid)
-            .seq(Some(seq))
-            .exit_code(exit_code)
-            .timed_out(output.timed_out)
-            .output_truncated(Some(output_truncated))
-            .chars_threshold_breach(text.len() > 30_000)
-            .filter_applied(output.filter_applied.clone())
-            .stdin_provided(stdin_provided)
-            .timeout_configured_ms(timeout_configured_ms)
-            .drain_timeout_ms(drain_timeout_ms)
-            .working_dir_used(working_dir_used)
-            .build(),
-    );
+    let mut metric_builder = crate::metrics::MetricEventBuilder::new("exec_command", "ok", dur)
+        .output_chars(text.len())
+        .param_path_depth(crate::metrics::path_component_count(
+            param_path.as_deref().unwrap_or(""),
+        ))
+        .session_id(sid)
+        .seq(Some(seq))
+        .exit_code(exit_code)
+        .timed_out(output.timed_out)
+        .output_truncated(Some(output_truncated))
+        .chars_threshold_breach(text.len() > 30_000)
+        .filter_applied(output.filter_applied.clone())
+        .stdin_provided(stdin_provided)
+        .timeout_configured_ms(timeout_configured_ms)
+        .drain_timeout_ms(drain_timeout_ms)
+        .working_dir_used(working_dir_used);
+    // Emit raw byte counts only when output was truncated and not timed out.
+    if output_truncated && !output.timed_out {
+        metric_builder = metric_builder
+            .stdout_bytes_raw(raw_stdout_bytes)
+            .stderr_bytes_raw(raw_stderr_bytes);
+    }
+    metrics_tx.send(metric_builder.build());
     Ok(result)
 }
 

--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -571,8 +571,10 @@ pub(crate) async fn exec_command_impl(
         .timeout_configured_ms(timeout_configured_ms)
         .drain_timeout_ms(drain_timeout_ms)
         .working_dir_used(working_dir_used);
-    // Emit raw byte counts only when output was truncated and not timed out.
-    if output_truncated && !output.timed_out {
+    // Emit raw byte counts only when output was byte-budget truncated (not timed out
+    // and not a drain-abort), since those are the only cases where the counters are
+    // meaningful (drain-abort forces counters to 0).
+    if output_truncated && !output.timed_out && output.output_collection_error.is_none() {
         metric_builder = metric_builder
             .stdout_bytes_raw(raw_stdout_bytes)
             .stderr_bytes_raw(raw_stderr_bytes);

--- a/crates/aptu-coder/src/tools/exec_runtime.rs
+++ b/crates/aptu-coder/src/tools/exec_runtime.rs
@@ -97,6 +97,9 @@ pub(crate) async fn run_with_timeout(
             (Some(so), Some(se)) => {
                 let mut merged = so.merge(se);
                 while let Some(Ok((is_stderr, line))) = merged.next().await {
+                    // entry_len approximates the on-wire byte count: the line content
+                    // plus the newline stripped by LinesStream. This matches the
+                    // byte_budget_hit accounting below.
                     let entry_len = line.len() + 1; // +1 for newline
                     if is_stderr {
                         raw_se += entry_len;
@@ -120,6 +123,9 @@ pub(crate) async fn run_with_timeout(
             (Some(so), None) => {
                 let mut stream = so;
                 while let Some(Ok((_, line))) = stream.next().await {
+                    // entry_len approximates the on-wire byte count: the line content
+                    // plus the newline stripped by LinesStream. This matches the
+                    // byte_budget_hit accounting below.
                     let entry_len = line.len() + 1;
                     raw_so += entry_len;
                     if so_bytes + entry_len > MAX_DRAIN_STDOUT_BYTES {
@@ -133,6 +139,9 @@ pub(crate) async fn run_with_timeout(
             (None, Some(se)) => {
                 let mut stream = se;
                 while let Some(Ok((_, line))) = stream.next().await {
+                    // entry_len approximates the on-wire byte count: the line content
+                    // plus the newline stripped by LinesStream. This matches the
+                    // byte_budget_hit accounting below.
                     let entry_len = line.len() + 1;
                     raw_se += entry_len;
                     if se_bytes + entry_len > MAX_DRAIN_STDERR_BYTES {

--- a/crates/aptu-coder/src/tools/exec_runtime.rs
+++ b/crates/aptu-coder/src/tools/exec_runtime.rs
@@ -25,6 +25,8 @@ pub(crate) struct ExecutionResult {
     pub(crate) output_collection_error: Option<String>,
     pub(crate) timed_out: bool,
     pub(crate) byte_truncated: bool,
+    pub(crate) raw_stdout_bytes: u64,
+    pub(crate) raw_stderr_bytes: u64,
 }
 
 /// Builds a tokio::process::Command with the given parameters.
@@ -88,6 +90,8 @@ pub(crate) async fn run_with_timeout(
         let mut byte_budget_hit = false;
         let mut so_bytes = 0usize;
         let mut se_bytes = 0usize;
+        let mut raw_so = 0usize;
+        let mut raw_se = 0usize;
 
         match (so_stream, se_stream) {
             (Some(so), Some(se)) => {
@@ -95,16 +99,19 @@ pub(crate) async fn run_with_timeout(
                 while let Some(Ok((is_stderr, line))) = merged.next().await {
                     let entry_len = line.len() + 1; // +1 for newline
                     if is_stderr {
+                        raw_se += entry_len;
                         if se_bytes + entry_len > MAX_DRAIN_STDERR_BYTES {
                             byte_budget_hit = true;
                             // Continue reading to drain child pipe; do not send.
                             continue;
                         }
                         se_bytes += entry_len;
-                    } else if so_bytes + entry_len > MAX_DRAIN_STDOUT_BYTES {
-                        byte_budget_hit = true;
-                        continue;
                     } else {
+                        raw_so += entry_len;
+                        if so_bytes + entry_len > MAX_DRAIN_STDOUT_BYTES {
+                            byte_budget_hit = true;
+                            continue;
+                        }
                         so_bytes += entry_len;
                     }
                     let _ = tx.send((is_stderr, line));
@@ -114,6 +121,7 @@ pub(crate) async fn run_with_timeout(
                 let mut stream = so;
                 while let Some(Ok((_, line))) = stream.next().await {
                     let entry_len = line.len() + 1;
+                    raw_so += entry_len;
                     if so_bytes + entry_len > MAX_DRAIN_STDOUT_BYTES {
                         byte_budget_hit = true;
                         continue;
@@ -126,6 +134,7 @@ pub(crate) async fn run_with_timeout(
                 let mut stream = se;
                 while let Some(Ok((_, line))) = stream.next().await {
                     let entry_len = line.len() + 1;
+                    raw_se += entry_len;
                     if se_bytes + entry_len > MAX_DRAIN_STDERR_BYTES {
                         byte_budget_hit = true;
                         continue;
@@ -137,7 +146,7 @@ pub(crate) async fn run_with_timeout(
             (None, None) => {}
         }
 
-        byte_budget_hit
+        (byte_budget_hit, raw_so, raw_se)
     });
 
     let drain_abort = drain_task.abort_handle();
@@ -163,20 +172,20 @@ pub(crate) async fn run_with_timeout(
             };
 
             // Drain remaining buffered output with drain_timeout grace (outside user timeout).
-            let (drain_truncated, byte_truncated) = if timed_out {
+            let (drain_truncated, byte_truncated, raw_so, raw_se) = if timed_out {
                 drain_abort.abort();
-                (false, false)
+                (false, false, 0, 0)
             } else {
                 match tokio::time::timeout(drain_timeout, drain_task).await {
-                    Ok(Ok(budget_hit)) => (false, budget_hit),
+                    Ok(Ok((budget_hit, rso, rse))) => (false, budget_hit, rso, rse),
                     Ok(Err(join_err)) => {
                         // Task panicked: treat as no budget truncation, log warning.
                         tracing::warn!("drain_task panicked: {join_err}");
-                        (false, false)
+                        (false, false, 0, 0)
                     }
                     Err(_) => {
                         drain_abort.abort();
-                        (true, false)
+                        (true, false, 0, 0)
                     }
                 }
             };
@@ -193,6 +202,8 @@ pub(crate) async fn run_with_timeout(
                 output_collection_error: ocerr,
                 timed_out,
                 byte_truncated,
+                raw_stdout_bytes: raw_so as u64,
+                raw_stderr_bytes: raw_se as u64,
             }
         }
         _ => {
@@ -201,15 +212,15 @@ pub(crate) async fn run_with_timeout(
             let exit_status = child.wait().await.ok();
             let drain_result = tokio::time::timeout(drain_timeout, drain_task).await;
 
-            let (drain_truncated, byte_truncated) = match drain_result {
-                Ok(Ok(budget_hit)) => (false, budget_hit),
+            let (drain_truncated, byte_truncated, raw_so, raw_se) = match drain_result {
+                Ok(Ok((budget_hit, rso, rse))) => (false, budget_hit, rso, rse),
                 Ok(Err(join_err)) => {
                     tracing::warn!("drain_task panicked: {join_err}");
-                    (false, false)
+                    (false, false, 0, 0)
                 }
                 Err(_) => {
                     drain_abort.abort();
-                    (true, false)
+                    (true, false, 0, 0)
                 }
             };
             let exit_code = exit_status.and_then(|s| s.code());
@@ -224,6 +235,8 @@ pub(crate) async fn run_with_timeout(
                 output_collection_error: ocerr,
                 timed_out: false,
                 byte_truncated,
+                raw_stdout_bytes: raw_so as u64,
+                raw_stderr_bytes: raw_se as u64,
             }
         }
     }
@@ -240,7 +253,7 @@ pub(crate) async fn run_exec_impl(
     filter_table: &Arc<Vec<CompiledRule>>,
     timeout_secs: Option<i64>,
     drain_timeout: std::time::Duration,
-) -> ShellOutput {
+) -> (ShellOutput, u64, u64) {
     let mut cmd = build_exec_command(
         &command,
         working_dir_path.as_ref(),
@@ -251,12 +264,16 @@ pub(crate) async fn run_exec_impl(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            return ShellOutput::new(
-                String::new(),
-                format!("failed to spawn command: {e}"),
-                format!("failed to spawn command: {e}"),
-                None,
-                false,
+            return (
+                ShellOutput::new(
+                    String::new(),
+                    format!("failed to spawn command: {e}"),
+                    format!("failed to spawn command: {e}"),
+                    None,
+                    false,
+                ),
+                0,
+                0,
             );
         }
     };
@@ -283,6 +300,8 @@ pub(crate) async fn run_exec_impl(
     let mut output_truncated = exec_result.output_truncated || exec_result.byte_truncated;
     let output_collection_error = exec_result.output_collection_error;
     let timed_out = exec_result.timed_out;
+    let raw_stdout_bytes = exec_result.raw_stdout_bytes;
+    let raw_stderr_bytes = exec_result.raw_stderr_bytes;
 
     rx.close();
 
@@ -366,7 +385,7 @@ pub(crate) async fn run_exec_impl(
         }
     }
 
-    output
+    (output, raw_stdout_bytes, raw_stderr_bytes)
 }
 
 /// Handles output persistence by writing to slot files only when output overflows the line limit.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -45,8 +45,9 @@ Each line in the JSONL file is one JSON object:
 | `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable or if the process was killed due to timeout |
 | `timed_out` | `bool` | `true` when the child process was killed because it exceeded `timeout_secs`; `false` otherwise. Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`). |
 | `output_truncated` | `bool \| null` | `true` if any truncation occurred (line cap, per-stream byte cap, or combined cap); `false` if the command completed without truncation; `null` for all non-`exec_command` tools and for `exec_command` calls emitted by older server versions |
-| `filter_applied` | `string \| null` | Name of the filter rule that matched and transformed the output (e.g., `"git pull"`, `"cargo build"`); `null` when no filter fired or for non-`exec_command` tools. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
 | `chars_threshold_breach` | `bool` | `true` when `output_chars > 30,000`; fires for the top ~0.33% of `exec_command` calls (p99.7 of 27,981 observed calls). Early-warning signal for responses approaching the per-stream byte-cap threshold (MAX_STDOUT_BYTES = 30,000). Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`); defaults to `false` on parse for backward compatibility. |
+| `stdout_bytes_raw` | `u64 \| null` | Raw stdout bytes read before any truncation; populated only when `output_truncated=true` and `timed_out=false`. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
+| `stderr_bytes_raw` | `u64 \| null` | Raw stderr bytes read before any truncation; populated only when `output_truncated=true` and `timed_out=false`. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
 | `git_ref_used` | `bool` | `true` when the `git_ref` parameter was supplied on `analyze_directory` or `analyze_symbol`. Omitted from JSONL when `false`. |
 | `summary_mode` | `bool` | `true` when `summary=true` was set on `analyze_directory`, `analyze_file`, or `analyze_symbol`. Omitted from JSONL when `false`. |
 | `is_paginated` | `bool` | `true` when a `cursor` was supplied on `analyze_directory`, `analyze_file`, or `analyze_symbol` (i.e., this is a continuation page). Omitted from JSONL when `false`. |
@@ -92,6 +93,8 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 | `seq` | early | `null` |
 | `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
 | `chars_threshold_breach` | v0.14.2 | `false` (omitted from JSONL when false; safe to query with `// false`) |
+| `stdout_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true` and `timed_out=false`) |
+| `stderr_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true` and `timed_out=false`) |
 | `filter_applied` | v0.14.2 | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
 | `cache_tier` | v0.18.x | `null` (omitted when null; `l1_memory` or `l2_disk` on a cache hit) |
 | `cache_write_failure` | v0.18.x | `null` (omitted when null; `true` only when an L2 disk write failed) |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -43,11 +43,12 @@ Each line in the JSONL file is one JSON object:
 | `cache_tier` | `string \| null` | Disk cache tier hit: `l1_memory` or `l2_disk`; `null` if not applicable |
 | `cache_write_failure` | `bool \| null` | `true` if cache write failed (dir, tempfile, write, or rename); `null` if not applicable |
 | `exit_code` | `i32 \| null` | Process exit code for `exec_command`; `null` if not applicable or if the process was killed due to timeout |
+| `filter_applied` | `string \| null` | The filter rule name that caused output suppression via `.aptu/filters.toml`; `null` when no filter was applied. Omitted from JSONL when `null`. |
 | `timed_out` | `bool` | `true` when the child process was killed because it exceeded `timeout_secs`; `false` otherwise. Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`). |
 | `output_truncated` | `bool \| null` | `true` if any truncation occurred (line cap, per-stream byte cap, or combined cap); `false` if the command completed without truncation; `null` for all non-`exec_command` tools and for `exec_command` calls emitted by older server versions |
 | `chars_threshold_breach` | `bool` | `true` when `output_chars > 30,000`; fires for the top ~0.33% of `exec_command` calls (p99.7 of 27,981 observed calls). Early-warning signal for responses approaching the per-stream byte-cap threshold (MAX_STDOUT_BYTES = 30,000). Omitted from JSONL when `false` (`#[serde(skip_serializing_if)]`); defaults to `false` on parse for backward compatibility. |
-| `stdout_bytes_raw` | `u64 \| null` | Raw stdout bytes read before any truncation; populated only when `output_truncated=true` and `timed_out=false`. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
-| `stderr_bytes_raw` | `u64 \| null` | Raw stderr bytes read before any truncation; populated only when `output_truncated=true` and `timed_out=false`. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
+| `stdout_bytes_raw` | `u64 \| null` | Raw stdout bytes read before any truncation; populated only when `output_truncated=true`, `timed_out=false`, and no drain-abort occurred. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
+| `stderr_bytes_raw` | `u64 \| null` | Raw stderr bytes read before any truncation; populated only when `output_truncated=true`, `timed_out=false`, and no drain-abort occurred. Omitted from JSONL when `null` (`#[serde(skip_serializing_if)]`). |
 | `git_ref_used` | `bool` | `true` when the `git_ref` parameter was supplied on `analyze_directory` or `analyze_symbol`. Omitted from JSONL when `false`. |
 | `summary_mode` | `bool` | `true` when `summary=true` was set on `analyze_directory`, `analyze_file`, or `analyze_symbol`. Omitted from JSONL when `false`. |
 | `is_paginated` | `bool` | `true` when a `cursor` was supplied on `analyze_directory`, `analyze_file`, or `analyze_symbol` (i.e., this is a continuation page). Omitted from JSONL when `false`. |
@@ -93,8 +94,8 @@ The following fields are optional (marked with `#[serde(default)]` in the Rust s
 | `seq` | early | `null` |
 | `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
 | `chars_threshold_breach` | v0.14.2 | `false` (omitted from JSONL when false; safe to query with `// false`) |
-| `stdout_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true` and `timed_out=false`) |
-| `stderr_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true` and `timed_out=false`) |
+| `stdout_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort) |
+| `stderr_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort) |
 | `filter_applied` | v0.14.2 | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
 | `cache_tier` | v0.18.x | `null` (omitted when null; `l1_memory` or `l2_disk` on a cache hit) |
 | `cache_write_failure` | v0.18.x | `null` (omitted when null; `true` only when an L2 disk write failed) |


### PR DESCRIPTION
## Summary
Record pre-truncation stdout/stderr byte counts on exec_command output overflow. Adds two new optional metrics fields (stdout_bytes_raw, stderr_bytes_raw) to track the actual bytes read before any truncation cap fires, enabling better observability of command output patterns and truncation behavior.

## Changes
- crates/aptu-coder/src/tools/exec_runtime.rs
- crates/aptu-coder/src/tools/exec_command.rs
- crates/aptu-coder/src/metrics.rs
- crates/aptu-coder/src/tests/exec_tests.rs
- crates/aptu-coder/src/tests/metrics_tests.rs
- docs/METRICS.md

## Test plan
- [x] Tests pass (see 03-build.json test_results)
- [x] Linter clean
- [x] Security scan clean (see 04-validation.json security_summary)

Closes #1320
