### PR TITLE
docs(metrics): fix stdout_bytes_raw version tag and add truncation jq queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,14 @@ Two parallel telemetry channels; neither blocks tool execution.
 
 Files: `$XDG_DATA_HOME/aptu-coder/metrics-YYYY-MM-DD.jsonl` (default: `~/.local/share/aptu-coder/`). Full schema in [docs/METRICS.md](https://github.com/clouatre-labs/aptu-coder/blob/main/docs/METRICS.md).
 
-Five validated jq one-liners (run from `~/.local/share/aptu-coder/`). Always `cd` there first -- globs expand against CWD and silently match nothing from a different directory.
+Six validated jq one-liners (run from `~/.local/share/aptu-coder/`). Always `cd` there first -- globs expand against CWD and silently match nothing from a different directory.
 
 1. Tool call volume: `jq -r '.tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
 2. Avg duration by tool: `jq -r '[.tool, .duration_ms] | @tsv' metrics-*.jsonl | awk -F'\t' '{c[$1]++;s[$1]+=$2} END{for(t in c) printf "%s\t%dms avg\n",t,s[t]/c[t]}' | sort -t$'\t' -k2 -rn`
 3. Error rate by tool: `jq -r 'select(.result=="error") | .tool' metrics-*.jsonl | sort | uniq -c | sort -rn`
 4. Cache hit rate by day: `for f in metrics-*.jsonl; do d=${f#metrics-}; d=${d%.jsonl}; total=$(jq 'select(.cache_hit!=null)' $f | wc -l); hits=$(jq 'select(.cache_hit==true)' $f | wc -l); echo "$d: $hits/$total"; done`
 5. Slowest 10 calls: `jq -r '[.tool, (.duration_ms|tostring), (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn | head -10`
+6. Truncation events with overflow size: `jq -r 'select(.output_truncated==true) | [.tool, (.stdout_bytes_raw|tostring), .output_chars, (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn`
 
 For richer analysis, use `python scripts/mcp-metrics.py --help`.
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -88,43 +88,45 @@ The `cache_tier` field encodes where a result was found (or not found):
 
 The following fields are optional (marked with `#[serde(default)]` in the Rust struct). JSONL files written by older server versions without these fields parse successfully; missing fields default to `null` or `false` as indicated:
 
-| Field | Added in | Default when absent |
-|---|---|---|
-| `session_id` | early | `null` |
-| `seq` | early | `null` |
-| `output_truncated` | v0.14.2 | `null` (treat as unknown; does not mean truncation did not occur) |
-| `chars_threshold_breach` | v0.14.2 | `false` (omitted from JSONL when false; safe to query with `// false`) |
-| `stdout_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort; value is approximate, counted as `line.len() + 1` per `LinesStream` line) |
-| `stderr_bytes_raw` | v0.21.x | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort; value is approximate, counted as `line.len() + 1` per `LinesStream` line) |
-| `filter_applied` | v0.14.2 | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
-| `cache_tier` | v0.18.x | `null` (omitted when null; `l1_memory` or `l2_disk` on a cache hit) |
-| `cache_write_failure` | v0.18.x | `null` (omitted when null; `true` only when an L2 disk write failed) |
-| `error_subtype` | v0.18.x | `null` (omitted when null; e.g. `not_found`, `ambiguous` for `edit_replace` errors) |
-| `language` | v0.20.x | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
-| `file_ext` | v0.20.x | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
-| `timed_out` | v0.20.1 | `false` (omitted from JSONL when false; set when child process was killed by `timeout_secs`) |
-| `git_ref_used` | v0.23.0 | `false` (omitted when false; `true` only when `git_ref` was supplied) |
-| `summary_mode` | v0.23.0 | `false` (omitted when false; `true` only when `summary=true` was set) |
-| `is_paginated` | v0.23.0 | `false` (omitted when false; `true` only when a `cursor` was supplied) |
-| `fields_projected` | v0.23.0 | `false` (omitted when false; `true` only when `fields` was supplied on `analyze_file`) |
-| `match_mode` | v0.23.0 | `null` (omitted when null; present only when explicitly set on `analyze_symbol`) |
-| `follow_depth` | v0.23.0 | `null` (omitted when null; present only when explicitly set on `analyze_symbol`) |
-| `import_lookup` | v0.23.0 | `false` (omitted when false; `true` only when `import_lookup=true` was set) |
-| `def_use` | v0.23.0 | `false` (omitted when false; `true` only when `def_use=true` was set) |
-| `impl_only` | v0.23.0 | `false` (omitted when false; `true` only when `impl_only=true` was set) |
-| `stdin_provided` | v0.23.0 | `false` (omitted when false; `true` only when `stdin` was supplied to `exec_command`) |
-| `timeout_configured_ms` | v0.23.0 | `null` (omitted when null; present only when `timeout_secs` was supplied) |
-| `drain_timeout_ms` | v0.23.0 | `null` (omitted when null; present only when `drain_timeout_secs` was supplied) |
-| `working_dir_used` | v0.23.0 | `false` (omitted when false; `true` only when `working_dir` was supplied) |
-| `l1_eviction_count` | v0.25.0 | `null` (omitted when null; process-lifetime L1 LRU eviction counter; only for `analyze_symbol`) |
-| `l2_entry_count` | v0.25.0 | `null` (omitted when null; approximate L2 entry count; only for `analyze_symbol`) |
-| `l2_size_bytes` | v0.25.0 | `null` (omitted when null; approximate L2 compressed size in bytes; only for `analyze_symbol`) |
+| Field | Default when absent |
+|---|---|
+| `session_id` | `null` |
+| `seq` | `null` |
+| `output_truncated` | `null` (treat as unknown; does not mean truncation did not occur) |
+| `chars_threshold_breach` | `false` (omitted from JSONL when false; safe to query with `// false`) |
+| `stdout_bytes_raw` | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort; value is approximate, counted as `line.len() + 1` per `LinesStream` line) |
+| `stderr_bytes_raw` | `null` (omitted when null; populated only on `exec_command` with `output_truncated=true`, `timed_out=false`, and no drain-abort; value is approximate, counted as `line.len() + 1` per `LinesStream` line) |
+| `filter_applied` | `null` (omitted from JSONL when null; only present for `exec_command` calls where a filter matched) |
+| `cache_tier` | `null` (omitted when null; `l1_memory` or `l2_disk` on a cache hit) |
+| `cache_write_failure` | `null` (omitted when null; `true` only when an L2 disk write failed) |
+| `error_subtype` | `null` (omitted when null; e.g. `not_found`, `ambiguous` for `edit_replace` errors) |
+| `language` | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
+| `file_ext` | `null` (omitted when null; populated for `analyze_file` and `analyze_module` only) |
+| `timed_out` | `false` (omitted from JSONL when false; set when child process was killed by `timeout_secs`) |
+| `git_ref_used` | `false` (omitted when false; `true` only when `git_ref` was supplied) |
+| `summary_mode` | `false` (omitted when false; `true` only when `summary=true` was set) |
+| `is_paginated` | `false` (omitted when false; `true` only when a `cursor` was supplied) |
+| `fields_projected` | `false` (omitted when false; `true` only when `fields` was supplied on `analyze_file`) |
+| `match_mode` | `null` (omitted when null; present only when explicitly set on `analyze_symbol`) |
+| `follow_depth` | `null` (omitted when null; present only when explicitly set on `analyze_symbol`) |
+| `import_lookup` | `false` (omitted when false; `true` only when `import_lookup=true` was set) |
+| `def_use` | `false` (omitted when false; `true` only when `def_use=true` was set) |
+| `impl_only` | `false` (omitted when false; `true` only when `impl_only=true` was set) |
+| `stdin_provided` | `false` (omitted when false; `true` only when `stdin` was supplied to `exec_command`) |
+| `timeout_configured_ms` | `null` (omitted when null; present only when `timeout_secs` was supplied) |
+| `drain_timeout_ms` | `null` (omitted when null; present only when `drain_timeout_secs` was supplied) |
+| `working_dir_used` | `false` (omitted when false; `true` only when `working_dir` was supplied) |
+| `l1_eviction_count` | `null` (omitted when null; process-lifetime L1 LRU eviction counter; only for `analyze_symbol`) |
+| `l2_entry_count` | `null` (omitted when null; approximate L2 entry count; only for `analyze_symbol`) |
+| `l2_size_bytes` | `null` (omitted when null; approximate L2 compressed size in bytes; only for `analyze_symbol`) |
 
-The five jq one-liners in `AGENTS.md` do not reference `output_truncated` and are unaffected. To query truncation events across all retained JSONL files:
+To query truncation events with overflow sizes across all retained JSONL files:
 
 ```bash
-cd ~/.local/share/aptu-coder && jq -r 'select(.output_truncated==true) | [.tool, .output_chars, (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn
+cd ~/.local/share/aptu-coder && jq -r 'select(.output_truncated==true) | [.tool, (.stdout_bytes_raw|tostring), .output_chars, (.session_id//"?")] | @tsv' metrics-*.jsonl | sort -t$'\t' -k2 -rn
 ```
+
+Columns: tool, stdout_bytes_raw (pre-truncation; `null` on drain-abort), output_chars (post-truncation preview size), session_id.
 
 ## Daily Rotation and 30-Day Retention
 


### PR DESCRIPTION
## Summary

Improve `docs/METRICS.md` backward-compat table and truncation query discoverability.

## Changes

- `docs/METRICS.md`: drop the `Added in` version column from the backward-compat table. The column provided no actionable information (the default-when-absent value is what matters for parsing) and proved immediately stale within one PR cycle. Removing it eliminates an entire category of future doc rot.
- `docs/METRICS.md`: add `stdout_bytes_raw` to the truncation jq one-liner so overflow size is visible alongside the post-truncation preview size; add a column legend.
- `AGENTS.md`: add truncation one-liner as entry 6 in the validated queries; update count from five to six.

## Motivation

The `Added in` column had inconsistent formatting (`v0.X.Y`, `v0.X.x`, `v0.X.0`, `early`) and went stale immediately after PR 1321 merged. The truncation jq omitted `stdout_bytes_raw`, making overflow size invisible without a custom query.

Related: #1322
