### PR TITLE
fix(exec): reformat overflow slot path hint in exec_command text block (#1322)

### DIFF
--- a/crates/aptu-coder/src/tools/exec_command.rs
+++ b/crates/aptu-coder/src/tools/exec_command.rs
@@ -6,6 +6,7 @@
 //! lives here, along with the five exclusive private helpers. The `#[tool(...)]`-decorated
 //! shim in `lib.rs` extracts state from `&self` and delegates to `exec_command_impl`.
 
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 use rmcp::RoleServer;
@@ -303,19 +304,15 @@ fn format_shell_output_phase(output: &ShellOutput, params: &ExecCommandParams) -
         || output.stderr_path.is_some()
         || output.interleaved_path.is_some()
     {
-        truncation_notice.push_str("(Full output persisted to: ");
-        let mut paths = Vec::new();
         if let Some(ref p) = output.stdout_path {
-            paths.push(format!("stdout={}", p));
+            let _ = writeln!(truncation_notice, "Full output available at: {p}");
         }
         if let Some(ref p) = output.stderr_path {
-            paths.push(format!("stderr={}", p));
+            let _ = writeln!(truncation_notice, "Full stderr available at: {p}");
         }
         if let Some(ref p) = output.interleaved_path {
-            paths.push(format!("interleaved={}", p));
+            let _ = writeln!(truncation_notice, "Full output available at: {p}");
         }
-        truncation_notice.push_str(&paths.join(", "));
-        truncation_notice.push_str(")\n");
     }
 
     let text = format!(
@@ -654,5 +651,116 @@ mod tests {
             "end should be char boundary"
         );
         let _char_count = result.chars().count();
+    }
+
+    #[test]
+    fn test_format_shell_output_stdout_path_hint() {
+        // Arrange: ShellOutput with stdout_path set, no stderr or interleaved paths
+        let output = ShellOutput {
+            stdout: "hello".to_string(),
+            stderr: String::new(),
+            interleaved: String::new(),
+            exit_code: Some(0),
+            output_truncated: true,
+            output_collection_error: None,
+            stdout_path: Some("/tmp/aptu-coder-overflow/slot-0/stdout".to_string()),
+            stderr_path: None,
+            interleaved_path: None,
+            filter_applied: None,
+            timed_out: false,
+        };
+        let params = ExecCommandParams {
+            command: "echo hello".to_string(),
+            working_dir: None,
+            stdin: None,
+            timeout_secs: None,
+            drain_timeout_secs: None,
+        };
+
+        // Act
+        let (result, _) = format_shell_output_phase(&output, &params);
+
+        // Assert
+        assert!(
+            result.contains("Full output available at: /tmp/aptu-coder-overflow/slot-0/stdout"),
+            "should contain stdout path hint: {result}"
+        );
+        assert!(
+            !result.contains("Full stderr available at:"),
+            "should not contain stderr hint when stderr_path is None"
+        );
+    }
+
+    #[test]
+    fn test_format_shell_output_stderr_path_hint() {
+        // Arrange: ShellOutput with only stderr_path set
+        let output = ShellOutput {
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            interleaved: String::new(),
+            exit_code: Some(1),
+            output_truncated: true,
+            output_collection_error: None,
+            stdout_path: None,
+            stderr_path: Some("/tmp/aptu-coder-overflow/slot-1/stderr".to_string()),
+            interleaved_path: None,
+            filter_applied: None,
+            timed_out: false,
+        };
+        let params = ExecCommandParams {
+            command: "false".to_string(),
+            working_dir: None,
+            stdin: None,
+            timeout_secs: None,
+            drain_timeout_secs: None,
+        };
+
+        // Act
+        let (result, _) = format_shell_output_phase(&output, &params);
+
+        // Assert
+        assert!(
+            result.contains("Full stderr available at: /tmp/aptu-coder-overflow/slot-1/stderr"),
+            "should contain stderr path hint: {result}"
+        );
+        assert!(
+            !result.contains("Full output available at:"),
+            "should not contain stdout hint when stdout_path is None"
+        );
+    }
+
+    #[test]
+    fn test_format_shell_output_interleaved_path_hint() {
+        // Arrange: ShellOutput with only interleaved_path set
+        let output = ShellOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            interleaved: "output".to_string(),
+            exit_code: Some(0),
+            output_truncated: true,
+            output_collection_error: None,
+            stdout_path: None,
+            stderr_path: None,
+            interleaved_path: Some("/tmp/aptu-coder-overflow/slot-2/interleaved".to_string()),
+            filter_applied: None,
+            timed_out: false,
+        };
+        let params = ExecCommandParams {
+            command: "echo test".to_string(),
+            working_dir: None,
+            stdin: None,
+            timeout_secs: None,
+            drain_timeout_secs: None,
+        };
+
+        // Act
+        let (result, _) = format_shell_output_phase(&output, &params);
+
+        // Assert
+        assert!(
+            result
+                .contains("Full output available at: /tmp/aptu-coder-overflow/slot-2/interleaved"),
+            "should contain interleaved path hint: {result}"
+        );
     }
 }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -355,6 +355,21 @@ async fn test_exec_command_overflow_to_temp_file() {
 }
 
 #[tokio::test]
+async fn test_exec_command_overflow_path_hint_in_text() {
+    // Assert that content[0].text contains 'Full output available at:' when
+    // stdout overflow persists to slot files.
+    let resp = call_exec_command_raw(serde_json::json!({
+        "command": "seq 1 3000"
+    }))
+    .await;
+
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("Full output available at:"),
+        "text should contain overflow path hint: {text}"
+    );
+}
+#[tokio::test]
 async fn test_exec_command_slot_isolation() {
     // Test that overflow calls use slot identifiers (0-7) visible in structuredContent.stdout_path.
     let mut slot_ids = std::collections::HashSet::new();


### PR DESCRIPTION
## Summary

Issue #1322 requests that when `exec_command` truncates output, the slot file path is surfaced in the text Content block with a clearer format. The previous format `(Full output persisted to: stdout=<path>, ...)` was introduced in commit 7c75884 but predates the issue; the author explicitly requested a more user-friendly format.

This PR reformats the truncation notice in `format_shell_output_phase` to emit per-line hints: `Full output available at: <stdout_path>`, `Full stderr available at: <stderr_path>`, and `Full output available at: <interleaved_path>` when the respective paths are set.

## Changes

- `crates/aptu-coder/src/tools/exec_command.rs`: Reformatted truncation_notice construction in `format_shell_output_phase` (lines 303-315) to emit per-line path hints instead of the parenthesized format. Added 3 unit tests for stdout, stderr, and interleaved path variants.
- `crates/aptu-coder/tests/exec_command.rs`: Added integration test `test_exec_command_overflow_path_hint_in_text` asserting that `content[0].text` contains `Full output available at:` when stdout overflows.

## Test plan

- [x] Tests pass (663 passed, 0 failed; see 03-build.json test_results)
- [x] Linter clean (cargo clippy -- -D warnings)
- [x] Security scan clean (no findings; see 04-validation.json security_summary)

Closes #1322
