### PR TITLE
feat(edit): add replace_all flag to edit_replace for sed-style global replace

### DIFF
--- a/crates/aptu-coder-core/src/edit.rs
+++ b/crates/aptu-coder-core/src/edit.rs
@@ -35,6 +35,8 @@ pub enum EditError {
         path: String,
         match_lines: Vec<usize>,
     },
+    #[error("edit_replace invalid params: {0}")]
+    InvalidParams(String),
 }
 
 fn write_file_atomic(path: &Path, content: &str) -> Result<(), EditError> {
@@ -112,12 +114,38 @@ pub fn edit_replace_block(
     old_text: &str,
     new_text: &str,
 ) -> Result<EditReplaceOutput, EditError> {
+    edit_replace_block_inner(path, old_text, new_text, false)
+}
+
+/// Same as `edit_replace_block` but with an explicit `replace_all` flag.
+/// When `replace_all` is true, all non-overlapping occurrences of `old_text`
+/// are replaced in a single pass.
+pub fn edit_replace_block_with_options(
+    path: &Path,
+    old_text: &str,
+    new_text: &str,
+    replace_all: bool,
+) -> Result<EditReplaceOutput, EditError> {
+    edit_replace_block_inner(path, old_text, new_text, replace_all)
+}
+
+pub(crate) fn edit_replace_block_inner(
+    path: &Path,
+    old_text: &str,
+    new_text: &str,
+    replace_all: bool,
+) -> Result<EditReplaceOutput, EditError> {
     if path.is_dir() {
         return Err(EditError::NotAFile(path.to_path_buf()));
     }
     let content = std::fs::read_to_string(path)?;
     let norm_content = normalize_for_match(&content);
     let norm_old = normalize_for_match(old_text);
+    if norm_old.is_empty() && replace_all {
+        return Err(EditError::InvalidParams(
+            "old_text must not be empty when replace_all is true".to_string(),
+        ));
+    }
     let count = norm_content.matches(&norm_old).count();
     match count {
         0 => {
@@ -127,8 +155,8 @@ pub fn edit_replace_block(
                 first_20_lines,
             });
         }
-        1 => {}
-        n => {
+        1 if !replace_all => {}
+        n if !replace_all => {
             let match_lines: Vec<usize> = norm_content
                 .match_indices(&norm_old)
                 .map(|(offset, _)| {
@@ -145,30 +173,71 @@ pub fn edit_replace_block(
                 match_lines,
             });
         }
+        _ => {} // replace_all=true: fall through to single-pass splice
     }
     let bytes_before = content.len();
-    // Find match offset in normalized space, then map back to original byte range
-    // SAFETY: match was verified above via count check; find must succeed.
-    // If count verification logic changes, this expect() site must be re-audited.
-    #[allow(clippy::expect_used)]
-    let norm_match_offset = norm_content
-        .find(&norm_old)
-        .expect("match was verified above via count check; find must succeed");
-    let original_start = norm_offset_to_original(&content, norm_match_offset);
-    let original_end = norm_offset_to_original_from(&content, norm_old.len(), original_start);
-    let updated = [
-        &content[..original_start],
-        new_text,
-        &content[original_end..],
-    ]
-    .concat();
-    let bytes_after = updated.len();
-    write_file_atomic(path, &updated)?;
-    Ok(EditReplaceOutput {
-        path: path.display().to_string(),
-        bytes_before,
-        bytes_after,
-    })
+
+    if replace_all {
+        // Single-pass over original normalized content: collect all match spans,
+        // then splice new_text between unmatched spans in original byte space.
+        let matches: Vec<(usize, usize)> = norm_content
+            .match_indices(&norm_old)
+            .map(|(norm_start, m)| {
+                let original_start = norm_offset_to_original(&content, norm_start);
+                let original_end = norm_offset_to_original_from(&content, m.len(), original_start);
+                (original_start, original_end)
+            })
+            .collect();
+        let occurrences_replaced = matches.len();
+        if occurrences_replaced == 0 {
+            let first_20_lines = content.lines().take(20).collect::<Vec<_>>().join("\n");
+            return Err(EditError::NotFound {
+                path: path.display().to_string(),
+                first_20_lines,
+            });
+        }
+        let mut result =
+            String::with_capacity(bytes_before + new_text.len() * occurrences_replaced);
+        let mut last_end = 0usize;
+        for (start, end) in &matches {
+            result.push_str(&content[last_end..*start]);
+            result.push_str(new_text);
+            last_end = *end;
+        }
+        result.push_str(&content[last_end..]);
+        let bytes_after = result.len();
+        write_file_atomic(path, &result)?;
+        Ok(EditReplaceOutput {
+            path: path.display().to_string(),
+            bytes_before,
+            bytes_after,
+            occurrences_replaced,
+        })
+    } else {
+        // Single-match path (existing behavior)
+        // SAFETY: match was verified above via count check; find must succeed.
+        // If count verification logic changes, this expect() site must be re-audited.
+        #[allow(clippy::expect_used)]
+        let norm_match_offset = norm_content
+            .find(&norm_old)
+            .expect("match was verified above via count check; find must succeed");
+        let original_start = norm_offset_to_original(&content, norm_match_offset);
+        let original_end = norm_offset_to_original_from(&content, norm_old.len(), original_start);
+        let updated = [
+            &content[..original_start],
+            new_text,
+            &content[original_end..],
+        ]
+        .concat();
+        let bytes_after = updated.len();
+        write_file_atomic(path, &updated)?;
+        Ok(EditReplaceOutput {
+            path: path.display().to_string(),
+            bytes_before,
+            bytes_after,
+            occurrences_replaced: 1,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -300,5 +369,46 @@ mod tests {
         assert_eq!(output, "foo  \nbar\nreplaced");
         assert_eq!(result.bytes_before, 17); // "foo  \nbar\nfoo\nbar" = 17 bytes
         assert_eq!(result.bytes_after, 18); // "foo  \nbar\nreplaced" = 18 bytes
+    }
+
+    #[test]
+    fn edit_replace_block_replace_all_three_occurrences() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("all.txt");
+        std::fs::write(&path, "a b a c a d").unwrap();
+        let result = edit_replace_block_with_options(&path, "a", "x", true).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "x b x c x d");
+        assert_eq!(result.bytes_before, 11);
+        assert_eq!(result.bytes_after, 11);
+        assert_eq!(result.occurrences_replaced, 3);
+    }
+
+    #[test]
+    fn edit_replace_block_replace_all_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nf.txt");
+        std::fs::write(&path, "foo bar baz").unwrap();
+        let err = edit_replace_block_with_options(&path, "missing", "x", true).unwrap_err();
+        std::assert_matches!(&err, EditError::NotFound { .. });
+    }
+
+    #[test]
+    fn edit_replace_block_replace_all_empty_oldtext() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.txt");
+        std::fs::write(&path, "foo bar baz").unwrap();
+        let err = edit_replace_block_with_options(&path, "", "x", true).unwrap_err();
+        std::assert_matches!(&err, EditError::InvalidParams(_));
+    }
+
+    #[test]
+    fn edit_replace_block_replace_all_preserves_crlf() {
+        // CRLF file with replace_all: unmatched spans retain CRLF bytes
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crlf_all.txt");
+        std::fs::write(&path, b"a\r\nb\r\na\r\nc").unwrap();
+        let result = edit_replace_block_with_options(&path, "a", "x", true).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "x\r\nb\r\nx\r\nc");
+        assert_eq!(result.occurrences_replaced, 2);
     }
 }

--- a/crates/aptu-coder-core/src/lib.rs
+++ b/crates/aptu-coder-core/src/lib.rs
@@ -71,7 +71,9 @@ pub use analyze::{
     analyze_module_file, analyze_str,
 };
 pub use config::AnalysisConfig;
-pub use edit::{EditError, edit_overwrite_content, edit_replace_block};
+pub use edit::{
+    EditError, edit_overwrite_content, edit_replace_block, edit_replace_block_with_options,
+};
 pub use graph::{GraphError, InternalCallChain};
 pub use lang::{language_for_extension, supported_languages};
 pub use pagination::{CursorData, PaginationError};

--- a/crates/aptu-coder-core/src/types.rs
+++ b/crates/aptu-coder-core/src/types.rs
@@ -879,10 +879,19 @@ pub struct EditReplaceParams {
     pub path: String,
     /// Optional base directory for path resolution (default: server CWD).
     pub working_dir: Option<String>,
-    /// Exact text block to find and replace. Must appear exactly once in the file.
+    /// Exact text block to find and replace. When `replace_all` is false (default), must appear
+    /// exactly once; fails with `ambiguous` if multiple matches are found. When `replace_all` is
+    /// true, every non-overlapping occurrence is replaced. Must be non-empty.
     pub old_text: String,
-    /// Replacement text. Pass empty string to delete the matched block.
+    /// Replacement text. Pass empty string to delete every matched block.
     pub new_text: String,
+    /// When `true`, replaces every non-overlapping occurrence of `old_text` in a single pass
+    /// (sed `s/old/new/g` semantics). Returns `INVALID_PARAMS` if `old_text` is empty.
+    /// When `false` (default), `old_text` must appear exactly once; fails with `ambiguous` if
+    /// multiple matches are found. Check `occurrences_replaced` in the output to confirm how
+    /// many substitutions were made.
+    #[serde(default)]
+    pub replace_all: Option<bool>,
 }
 
 #[non_exhaustive]
@@ -903,6 +912,15 @@ pub struct EditReplaceOutput {
         schemars(schema_with = "crate::schema_helpers::integer_schema")
     )]
     pub bytes_after: usize,
+    /// Number of occurrences replaced. Always 1 when `replace_all` is false (default single-match
+    /// path). When `replace_all` is true, reflects the actual substitution count (0 triggers a
+    /// `not_found` error before this field is populated, so a successful response always has
+    /// `occurrences_replaced >= 1`).
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(schema_with = "crate::schema_helpers::integer_schema")
+    )]
+    pub occurrences_replaced: usize,
 }
 
 /// Filter rule for command output post-processing.

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -600,7 +600,7 @@ impl CodeAnalyzer {
     #[tool(
         name = "edit_replace",
         title = "Edit Replace",
-        description = "Replaces a unique exact text block; old_text must appear exactly once. Fails if zero or multiple matches (extend old_text to disambiguate). If invalid_params, re-read the file with analyze_file or analyze_module before retrying. CRLF in old_text normalized to LF; all other whitespace matched exactly. Pass empty new_text to delete. Use edit_overwrite to replace the whole file. working_dir sets the base directory for path resolution (default: server CWD).",
+        description = "Replaces an exact text block; old_text must appear exactly once. Fails if zero or multiple matches (extend old_text to disambiguate). Set replace_all=true to replace every non-overlapping occurrence (sed s/old/new/g); old_text must be non-empty. Pass empty new_text to delete. CRLF in old_text normalized to LF; all other whitespace matched exactly. If invalid_params, re-read the file with analyze_file or analyze_module before retrying. Use edit_overwrite to replace the whole file. working_dir sets the base directory for path resolution (default: server CWD).",
         output_schema = schema_for_type::<EditReplaceOutput>(),
         annotations(
             title = "Edit Replace",

--- a/crates/aptu-coder/src/tools/edit_replace.rs
+++ b/crates/aptu-coder/src/tools/edit_replace.rs
@@ -356,6 +356,27 @@ fn handle_edit_error(
                 )),
             ))
         }
+        aptu_coder_core::EditError::InvalidParams(msg) => {
+            span.record("error.type", "invalid_params");
+            ctx.metrics_tx.send(
+                crate::metrics::MetricEventBuilder::new("edit_replace", "error", dur)
+                    .param_path_depth(crate::metrics::path_component_count(param_path))
+                    .error_type(Some("invalid_params".to_string()))
+                    .session_id(ctx.sid.clone())
+                    .seq(Some(ctx.seq))
+                    .working_dir_used(working_dir_used)
+                    .build(),
+            );
+            err_to_tool_result(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                msg,
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "old_text must not be empty when replace_all is true",
+                )),
+            ))
+        }
         aptu_coder_core::EditError::Io(io_err) => {
             span.record("error.type", "internal_error");
             ctx.metrics_tx.send(
@@ -435,9 +456,15 @@ pub(crate) async fn edit_replace(
     };
     let old_text = params.old_text.clone();
     let new_text = params.new_text.clone();
+    let replace_all = params.replace_all.unwrap_or(false);
     let old_text_for_hint = old_text.clone();
     let handle = tokio::task::spawn_blocking(move || {
-        aptu_coder_core::edit_replace_block(&resolved_path, &old_text, &new_text)
+        aptu_coder_core::edit_replace_block_with_options(
+            &resolved_path,
+            &old_text,
+            &new_text,
+            replace_all,
+        )
     });
 
     let mut guard = StaleContextGuard::new(ctx.sid.clone(), Arc::clone(ctx.edit_failure_counts));

--- a/crates/aptu-coder/tests/edit_replace_errors.rs
+++ b/crates/aptu-coder/tests/edit_replace_errors.rs
@@ -600,3 +600,230 @@ async fn test_edit_replace_crlf_file_crlf_oldtext() {
     let output = std::fs::read_to_string(&file_path).expect("should read file");
     assert_eq!(output, "line1\r\nreplaced\nline3");
 }
+
+/// replace_all=true replaces every non-overlapping occurrence and returns
+/// occurrences_replaced equal to match count.
+#[tokio::test]
+async fn test_edit_replace_replace_all_happy_path() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "a b a c a d";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "a",
+            "new_text": "x",
+            "replace_all": true,
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        !resp["result"]["isError"].as_bool().unwrap_or(true),
+        "expected success but got error: {resp}"
+    );
+    let output = std::fs::read_to_string(&file_path).expect("should read file");
+    assert_eq!(output, "x b x c x d");
+    let structured = resp["result"]["structuredContent"]
+        .as_object()
+        .expect("structuredContent should be present");
+    let replaced = structured["occurrences_replaced"]
+        .as_u64()
+        .expect("occurrences_replaced should be a number");
+    assert_eq!(replaced, 3);
+}
+
+/// replace_all=true with zero matches still returns not_found error.
+#[tokio::test]
+async fn test_edit_replace_replace_all_not_found() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "foo bar baz";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "missing",
+            "new_text": "x",
+            "replace_all": true,
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+    let msg = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have error text");
+    assert!(msg.contains("not found"));
+    assert!(!msg.contains("EDIT_STALE_CONTEXT"));
+}
+
+/// replace_all=true with empty old_text returns INVALID_PARAMS.
+#[tokio::test]
+async fn test_edit_replace_replace_all_empty_oldtext() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "foo bar baz";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "",
+            "new_text": "x",
+            "replace_all": true,
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+    let msg = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have error text");
+    assert!(msg.contains("old_text must not be empty"));
+}
+
+/// replace_all=false (explicit) with two matches still returns ambiguous error.
+#[tokio::test]
+async fn test_edit_replace_replace_all_false_still_ambiguous() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "alpha\nbeta\nalpha\n";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    let resp = call_tool_raw(
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "alpha",
+            "new_text": "replacement",
+            "replace_all": false,
+            "working_dir": working_dir
+        }),
+    )
+    .await;
+
+    assert!(
+        resp["result"]["isError"].as_bool().unwrap_or(false),
+        "expected error but got success: {resp}"
+    );
+    let msg = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have error text");
+    assert!(msg.contains("Occurrences at lines:"));
+    assert!(msg.contains("2 locations"));
+}
+
+/// replace_all=true success does not trip stale-context circuit breaker.
+#[tokio::test]
+async fn test_edit_replace_replace_all_no_stale_context_trip() {
+    let cwd = std::env::current_dir().expect("should get cwd");
+    let temp_dir = tempfile::TempDir::new_in(&cwd).expect("should create temp dir in cwd");
+    let working_dir = temp_dir
+        .path()
+        .to_str()
+        .expect("temp dir path is valid UTF-8");
+    let file_name = "test.txt";
+    let file_path = temp_dir.path().join(file_name);
+    let content = "alpha\n";
+    std::fs::write(&file_path, content).expect("should write file");
+
+    // 4 not_found failures, 1 replace_all success, 1 more not_found
+    let mut calls: Vec<(&str, serde_json::Value)> = Vec::new();
+    for _ in 0..4 {
+        calls.push((
+            "edit_replace",
+            serde_json::json!({
+                "path": file_name,
+                "old_text": "nonexistent",
+                "new_text": "x",
+                "working_dir": working_dir
+            }),
+        ));
+    }
+    calls.push((
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "alpha",
+            "new_text": "beta",
+            "replace_all": true,
+            "working_dir": working_dir
+        }),
+    ));
+    calls.push((
+        "edit_replace",
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "nonexistent",
+            "new_text": "x",
+            "working_dir": working_dir
+        }),
+    ));
+
+    let responses = call_tool_raw_seq(calls).await;
+
+    for (i, resp) in responses.iter().enumerate().take(4) {
+        assert!(
+            resp["result"]["isError"].as_bool().unwrap_or(false),
+            "call {} expected error: {resp}",
+            i + 1
+        );
+    }
+    let fifth = &responses[4];
+    assert!(
+        !fifth["result"]["isError"].as_bool().unwrap_or(true),
+        "call 5 (replace_all success) expected success: {fifth}"
+    );
+    let sixth = &responses[5];
+    assert!(
+        sixth["result"]["isError"].as_bool().unwrap_or(false),
+        "call 6 expected error: {sixth}"
+    );
+    let sixth_msg = sixth["result"]["content"][0]["text"]
+        .as_str()
+        .expect("should have text");
+    assert!(
+        !sixth_msg.contains("EDIT_STALE_CONTEXT"),
+        "call 6 should NOT be stale_context after replace_all success but got: {sixth_msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Added `replace_all: Option<bool>` (default false) to `edit_replace` tool. When true, replaces every non-overlapping occurrence of `old_text` in a single call using sed s/old/new/g semantics. Previously required N sequential calls with unique surrounding context per occurrence, which was fragile and verbose.

## What

- `EditReplaceParams.replace_all: Option<bool>` with `#[serde(default)]` (default false)
- `EditReplaceOutput.occurrences_replaced: usize` field
- `EditError::InvalidParams` variant for empty old_text guard
- Single-pass implementation over original normalized content (non-iterative)
- `StaleContextGuard` not incremented on replace_all success
- Tool description updated to document replace_all behavior

## Why

Previously, replacing multiple occurrences required N sequential `edit_replace` calls, each with unique surrounding context to disambiguate. This was fragile (context changes between calls) and verbose (4 sonnet-4-6 replacements needed 4 separate calls in a recent session). The replace_all flag matches Claude Code Edit tool convention exactly and enables atomic multi-occurrence replacements.

## MCP Compatibility

Designed against MCP 2026-07-28 spec. `destructiveHint=true` and `idempotentHint=false` already set on tool annotations (replace_all on a pattern present in new_text is not idempotent). No new dependencies. Additive change; default path is byte-for-byte identical to current behavior.

## Ecosystem Precedent

Matches Claude Code Edit tool `replace_all` convention exactly. Follows codebase idiom for optional boolean toggles (`Option<bool>` with `#[serde(default)]`).

## Changes

- `crates/aptu-coder-core/src/types.rs`: EditReplaceParams.replace_all, EditReplaceOutput.occurrences_replaced
- `crates/aptu-coder-core/src/edit.rs`: EditError::InvalidParams variant, single-pass replace_all logic in edit_replace_block
- `crates/aptu-coder/src/tools/edit_replace.rs`: handle_edit_error InvalidParams arm, replace_all flag threading
- `crates/aptu-coder/src/lib.rs`: tool description update
- `crates/aptu-coder/tests/edit_replace_errors.rs`: 5 integration tests + 4 unit tests for new behavior

## Test Plan

- [x] Tests pass: 682 total (121 lib + 241 lib + 320 integration), 0 failed
- [x] Linter clean: cargo clippy -- -D warnings
- [x] Formatter clean: cargo fmt --check
- [x] Security scan clean: no findings
- [x] Line budget: 383 total lines (within 400 max), test ratio 1.45 (within 1.5 max)
- [x] No unwrap/expect in production paths (existing SAFETY comment on single-match path preserved)
- [x] Default path unchanged: all existing tests pass untouched
