### PR TITLE
chore(release): bump version to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.4"
+version = "0.26.0"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aptu-coder-core = { path = "../aptu-coder-core", version = "0.25", features = ["schemars"] }
+aptu-coder-core = { path = "../aptu-coder-core", version = "0.26", features = ["schemars"] }
 rmcp = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## What's Changed

### New Features

- **`feat(edit)`: add `replace_all` flag to `edit_replace` for sed-style global replace** (#1335): Adds a `replace_all` boolean parameter to `edit_replace`. When `true`, all non-overlapping occurrences of `old_text` are replaced rather than requiring a unique match. Follows the existing uniqueness constraint when `false` (default), preserving backwards compatibility.

- **`feat(aptu)`: add `ai` block to `aptu.yml`** (#1334): Required after aptu-github-app#61. Adds the `ai` configuration block to the project's `aptu.yml`.

### Performance Improvements

- **`perf(edit)`: fix O(n*k) offset mapping and validation asymmetry in `replace_all`** (#1339): Replaces the quadratic offset recalculation loop with a linear pass, and aligns pre- and post-replacement validation so both sides apply the same rules.

### Bug Fixes

- **`fix(deps)`: rename `Content` to `ContentBlock` for rmcp v2; gate lint on Renovate PRs** (#1343): Adapts to the breaking rename introduced in rmcp v2 and avoids running the full lint suite on dependency-only Renovate PRs.

### Dependencies

- **rmcp upgraded to v2** (#1341): Major version bump. `Content` renamed to `ContentBlock` throughout.
- Routine non-major dependency updates (#1337) and GitHub Actions pinning (#1336, #1340).

## Full Changelog

https://github.com/clouatre-labs/aptu-coder/compare/v0.25.4...v0.26.0
