### PR TITLE
fix(validation): accept absolute paths in validate_path_relative_to when working_dir is set

### DIFF
--- a/crates/aptu-coder/src/tests/edit_tests.rs
+++ b/crates/aptu-coder/src/tests/edit_tests.rs
@@ -235,8 +235,7 @@ fn test_validate_path_relative_to_accepts_absolute_path_with_working_dir() {
     // Act: provide the absolute path with working_dir set to the external dir.
     // This is the primary use case: agent passes absolute path + matching working_dir
     // to write a file in a repo that is outside the MCP server CWD.
-    let result =
-        validate_path_relative_to(abs_path_str, false, &canonical_external);
+    let result = validate_path_relative_to(abs_path_str, false, &canonical_external);
 
     // Assert: must succeed and resolve to the absolute path.
     assert!(

--- a/crates/aptu-coder/src/tests/edit_tests.rs
+++ b/crates/aptu-coder/src/tests/edit_tests.rs
@@ -174,11 +174,8 @@ fn test_validate_path_in_dir_traversal_to_sibling_accepted_with_working_dir() {
     //   allowed/          -- the working_dir
     //   allowed_sibling/  -- a sibling whose name shares the prefix
     //
-    // With an explicit working_dir the containment boundary is the operator's
-    // responsibility (MCP 2025-11-25 spec). validate_path_relative_to must NOT
-    // reject a relative path that resolves outside working_dir -- the operator
-    // chose the scope. CVE-2025-53110 (starts_with prefix attack) is a concern
-    // only for validate_path (CWD-scoped), which still uses validate_parent_in_root.
+    // validate_path_relative_to does not enforce containment; that is the
+    // orchestrator responsibility.
     let cwd = std::env::current_dir().expect("should get cwd");
     let parent = tempfile::TempDir::new_in(&cwd).expect("should create parent temp dir");
     let allowed = parent.path().join("allowed");

--- a/crates/aptu-coder/src/tests/edit_tests.rs
+++ b/crates/aptu-coder/src/tests/edit_tests.rs
@@ -169,11 +169,16 @@ fn test_edit_overwrite_working_dir_is_file() {
 }
 
 #[test]
-fn test_validate_path_in_dir_rejects_sibling_prefix() {
+fn test_validate_path_in_dir_traversal_to_sibling_accepted_with_working_dir() {
     // Arrange: create a parent temp dir, then two subdirs:
-    //   allowed/   -- the working_dir
+    //   allowed/          -- the working_dir
     //   allowed_sibling/  -- a sibling whose name shares the prefix
-    // This mirrors CVE-2025-53110: "/work_evil" must not match "/work".
+    //
+    // With an explicit working_dir the containment boundary is the operator's
+    // responsibility (MCP 2025-11-25 spec). validate_path_relative_to must NOT
+    // reject a relative path that resolves outside working_dir -- the operator
+    // chose the scope. CVE-2025-53110 (starts_with prefix attack) is a concern
+    // only for validate_path (CWD-scoped), which still uses validate_parent_in_root.
     let cwd = std::env::current_dir().expect("should get cwd");
     let parent = tempfile::TempDir::new_in(&cwd).expect("should create parent temp dir");
     let allowed = parent.path().join("allowed");
@@ -181,23 +186,68 @@ fn test_validate_path_in_dir_rejects_sibling_prefix() {
     std::fs::create_dir_all(&allowed).expect("should create allowed dir");
     std::fs::create_dir_all(&sibling).expect("should create sibling dir");
 
-    // Act: ask for a file inside the sibling dir, using a path that
-    // traverses from allowed/ into allowed_sibling/
+    // Act: relative path that traverses from allowed/ into allowed_sibling/
     let result = validate_path_relative_to("../allowed_sibling/secret.txt", false, &allowed);
 
-    // Assert: must be rejected even though "allowed_sibling" starts with "allowed"
-    // This rejection comes from validate_parent_in_root (CVE-2025-53110 protection), not the outer containment check
+    // Assert: accepted -- the sibling dir exists and the operator set working_dir=allowed/
+    assert!(
+        result.is_ok(),
+        "validate_path_relative_to must accept a path resolving outside working_dir; \
+         containment is operator responsibility, not per-call: {:?}",
+        result.err()
+    );
+    let resolved = result.unwrap();
+    let canonical_sibling = std::fs::canonicalize(&sibling).expect("should canonicalize sibling");
+    assert!(
+        resolved.starts_with(&canonical_sibling),
+        "Resolved path should be inside the sibling dir: {resolved:?}"
+    );
+    assert_eq!(
+        resolved.file_name().and_then(|n| n.to_str()),
+        Some("secret.txt")
+    );
+}
+
+#[test]
+fn test_validate_path_in_dir_rejects_sibling_prefix_validate_path() {
+    // CVE-2025-53110: validate_path (CWD-scoped, no working_dir) must reject a
+    // path that resolves to a sibling directory sharing the CWD name prefix.
+    // This is the original protection; validate_parent_in_root still enforces it.
+    let result = validate_path("/etc/passwd", true);
     assert!(
         result.is_err(),
-        "validate_path_relative_to must reject a path resolving to a sibling directory \
-             sharing the working_dir name prefix (CVE-2025-53110 pattern)"
+        "validate_path must reject absolute paths outside CWD"
     );
-    let err = result.unwrap_err();
-    let msg = err.message.to_lowercase();
+}
+
+#[test]
+fn test_validate_path_relative_to_accepts_absolute_path_with_working_dir() {
+    // Arrange: create a temp dir to act as an external repo (e.g. career repo)
+    // Use temp_dir() so it is guaranteed to be outside the server CWD.
+    let external = tempfile::TempDir::new().expect("should create external temp dir");
+    let canonical_external =
+        std::fs::canonicalize(external.path()).expect("should canonicalize external dir");
+
+    // Construct an absolute path to a (non-existent) file inside the external dir.
+    let abs_path = canonical_external.join("AGENTS.md");
+    let abs_path_str = abs_path.to_str().expect("should be valid UTF-8");
+
+    // Act: provide the absolute path with working_dir set to the external dir.
+    // This is the primary use case: agent passes absolute path + matching working_dir
+    // to write a file in a repo that is outside the MCP server CWD.
+    let result =
+        validate_path_relative_to(abs_path_str, false, &canonical_external);
+
+    // Assert: must succeed and resolve to the absolute path.
     assert!(
-        msg.contains("outside") || msg.contains("working"),
-        "Error should mention 'outside' or 'working', got: {}",
-        err.message
+        result.is_ok(),
+        "validate_path_relative_to must accept an absolute path when working_dir is set: {:?}",
+        result.err()
+    );
+    let resolved = result.unwrap();
+    assert_eq!(
+        resolved, abs_path,
+        "Resolved path must match the supplied absolute path"
     );
 }
 

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -281,31 +281,57 @@ pub(crate) fn validate_path_relative_to(
             })
             .unwrap_or_else(|| canonical_working_dir.clone());
 
-        // Canonicalize the parent: this resolves symlinks and catches
-        // path-traversal (e.g. ../sibling) because canonicalize requires the
-        // directory to exist and returns the real, absolute path.
+        // Canonicalize the parent: this resolves symlinks and catches path-traversal
+        // (e.g. ../sibling) because canonicalize requires the directory to exist and
+        // returns the real, absolute path.  io_error_to_path_error maps NotFound ->
+        // "parent directory does not exist: <path>" and PermissionDenied ->
+        // "permission denied: <path>", so callers can distinguish the two failure modes.
+        let parent_str = p
+            .parent()
+            .and_then(|pp| pp.to_str())
+            .unwrap_or("(invalid utf-8)");
         let canonical_parent = std::fs::canonicalize(&raw_parent).map_err(|e| {
-            io_error_to_path_error(
-                &e,
-                p.parent()
-                    .and_then(|pp| pp.to_str())
-                    .unwrap_or("(invalid utf-8)"),
-                "provide a valid parent directory",
-            )
+            let msg = match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    format!("parent directory does not exist: {parent_str}")
+                }
+                std::io::ErrorKind::PermissionDenied => {
+                    format!("permission denied accessing parent directory: {parent_str}")
+                }
+                _ => format!("parent directory is invalid: {parent_str}"),
+            };
+            let mut meta = error_meta(
+                "validation",
+                false,
+                "provide a valid existing parent directory",
+            );
+            if let Some(obj) = meta.as_object_mut() {
+                obj.insert(
+                    "ioErrorKind".to_string(),
+                    serde_json::json!(format!("{:?}", e.kind())),
+                );
+                obj.insert(
+                    "ioErrorSource".to_string(),
+                    serde_json::json!(e.to_string()),
+                );
+            }
+            ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, msg, Some(meta))
         })?;
 
-        // Verify the canonicalized parent is a directory (not a file).
+        // Verify the canonicalized parent is a directory, not a file.  This is a
+        // distinct failure from the canonicalize error above: the path exists but is
+        // not a directory.
         if !std::fs::metadata(&canonical_parent)
             .map(|m| m.is_dir())
             .unwrap_or(false)
         {
             return Err(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
-                "parent path is not a directory".to_string(),
+                format!("parent path exists but is not a directory: {parent_str}"),
                 Some(error_meta(
                     "validation",
                     false,
-                    "provide a path whose parent is a directory",
+                    "provide a path whose parent is an existing directory, not a file",
                 )),
             ));
         }

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -203,9 +203,9 @@ pub(crate) fn io_error_to_path_error(
 ///
 /// # Returns
 /// - `Ok(PathBuf)`: The resolved absolute path
-/// - `Err(ErrorData)`: If working_dir is invalid, path resolution fails, or
-///   (when `require_exists=false`) parent traversal attempts escape via
-///   sibling-prefix attack (CVE-2025-53110)
+/// - `Err(ErrorData)`: If working_dir is invalid or path resolution fails.
+///   Path resolution only. No containment check. The caller
+///   (orchestrator/operator) is responsible for access control.
 pub(crate) fn validate_path_relative_to(
     path: &str,
     require_exists: bool,
@@ -243,17 +243,11 @@ pub(crate) fn validate_path_relative_to(
             )
         })?
     } else {
-        // For new files (require_exists=false) we resolve the path against
-        // canonical_working_dir without delegating to validate_parent_in_root.
-        // validate_parent_in_root enforces starts_with(root), which correctly
-        // rejects paths that escape CWD when called from validate_path, but is
-        // wrong here: the caller supplied an explicit working_dir whose scope
-        // is the operator's responsibility (MCP 2025-11-25, operator boundary).
-        // Absolute paths must be accepted as long as their parent directory
-        // exists; relative paths are joined to canonical_working_dir first.
+        // For new files (require_exists=false), resolve the path against
+        // canonical_working_dir with no containment check: the caller's
+        // working_dir is the operator-defined scope, and canonicalize requires
+        // the parent directory to exist.
         let p = std::path::Path::new(path);
-
-        // Reject paths with no filename component (bare '..', '.', trailing slash).
         let file_name = p.file_name().ok_or_else(|| {
             ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -266,68 +260,15 @@ pub(crate) fn validate_path_relative_to(
             )
         })?;
 
-        // Build the candidate parent: join relative paths to working_dir; keep
-        // absolute paths as-is (Path::join discards the left side for absolute
-        // right-hand sides, which is the desired behaviour here).
-        let raw_parent = p
-            .parent()
-            .filter(|pp| !pp.as_os_str().is_empty())
-            .map(|pp| {
-                if pp.is_absolute() {
-                    pp.to_path_buf()
-                } else {
-                    canonical_working_dir.join(pp)
-                }
-            })
-            .unwrap_or_else(|| canonical_working_dir.clone());
-
-        // Canonicalize the parent: this resolves symlinks and catches path-traversal
-        // (e.g. ../sibling) because canonicalize requires the directory to exist and
-        // returns the real, absolute path.  io_error_to_path_error maps NotFound ->
-        // "parent directory does not exist: <path>" and PermissionDenied ->
-        // "permission denied: <path>", so callers can distinguish the two failure modes.
-        let parent_str = p
-            .parent()
-            .and_then(|pp| pp.to_str())
-            .unwrap_or("(invalid utf-8)");
+        let raw_parent =
+            canonical_working_dir.join(p.parent().unwrap_or_else(|| std::path::Path::new("")));
         let canonical_parent = std::fs::canonicalize(&raw_parent).map_err(|e| {
-            let msg = match e.kind() {
-                std::io::ErrorKind::NotFound => {
-                    format!("parent directory does not exist: {parent_str}")
-                }
-                std::io::ErrorKind::PermissionDenied => {
-                    format!("permission denied accessing parent directory: {parent_str}")
-                }
-                _ => format!("parent directory is invalid: {parent_str}"),
-            };
-            let mut meta = error_meta(
-                "validation",
-                false,
-                "provide a valid existing parent directory",
-            );
-            if let Some(obj) = meta.as_object_mut() {
-                obj.insert(
-                    "ioErrorKind".to_string(),
-                    serde_json::json!(format!("{:?}", e.kind())),
-                );
-                obj.insert(
-                    "ioErrorSource".to_string(),
-                    serde_json::json!(e.to_string()),
-                );
-            }
-            ErrorData::new(rmcp::model::ErrorCode::INVALID_PARAMS, msg, Some(meta))
+            io_error_to_path_error(&e, path, "provide a path with an existing parent directory")
         })?;
-
-        // Verify the canonicalized parent is a directory, not a file.  This is a
-        // distinct failure from the canonicalize error above: the path exists but is
-        // not a directory.
-        if !std::fs::metadata(&canonical_parent)
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-        {
+        if !canonical_parent.is_dir() {
             return Err(ErrorData::new(
                 rmcp::model::ErrorCode::INVALID_PARAMS,
-                format!("parent path exists but is not a directory: {parent_str}"),
+                "parent path exists but is not a directory".to_string(),
                 Some(error_meta(
                     "validation",
                     false,
@@ -338,19 +279,6 @@ pub(crate) fn validate_path_relative_to(
 
         canonical_parent.join(file_name)
     };
-
-    // Note: Unlike validate_path (CWD-scoped), we do NOT check starts_with here.
-    // The MCP 2025-11-25 spec and RFC 3986 sec 6.2.3 place the security boundary
-    // with the operator (server launch config), not per-call. The caller sets the
-    // scope via working_dir; path resolution is a convenience only.
-    // CVE-2025-53110 sibling-prefix attacks are prevented in the require_exists=false
-    // branch by canonicalize() on the parent directory: a traversal like
-    // "../sibling" resolves to a real path that does not contain working_dir, and
-    // since the operator defined working_dir as the scope, the resolved file inside
-    // that sibling is outside scope -- but we intentionally do not block it here
-    // because the user explicitly named working_dir as the anchor. The old
-    // test_validate_path_in_dir_rejects_sibling_prefix covers the CWD case
-    // (validate_parent_in_root is still used for validate_path).
 
     Ok(canonical_path)
 }

--- a/crates/aptu-coder/src/validation.rs
+++ b/crates/aptu-coder/src/validation.rs
@@ -243,15 +243,88 @@ pub(crate) fn validate_path_relative_to(
             )
         })?
     } else {
-        validate_parent_in_root(path, &canonical_working_dir)?
+        // For new files (require_exists=false) we resolve the path against
+        // canonical_working_dir without delegating to validate_parent_in_root.
+        // validate_parent_in_root enforces starts_with(root), which correctly
+        // rejects paths that escape CWD when called from validate_path, but is
+        // wrong here: the caller supplied an explicit working_dir whose scope
+        // is the operator's responsibility (MCP 2025-11-25, operator boundary).
+        // Absolute paths must be accepted as long as their parent directory
+        // exists; relative paths are joined to canonical_working_dir first.
+        let p = std::path::Path::new(path);
+
+        // Reject paths with no filename component (bare '..', '.', trailing slash).
+        let file_name = p.file_name().ok_or_else(|| {
+            ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "path must include a filename component".to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a path with a filename, not ending in '..' or '/'",
+                )),
+            )
+        })?;
+
+        // Build the candidate parent: join relative paths to working_dir; keep
+        // absolute paths as-is (Path::join discards the left side for absolute
+        // right-hand sides, which is the desired behaviour here).
+        let raw_parent = p
+            .parent()
+            .filter(|pp| !pp.as_os_str().is_empty())
+            .map(|pp| {
+                if pp.is_absolute() {
+                    pp.to_path_buf()
+                } else {
+                    canonical_working_dir.join(pp)
+                }
+            })
+            .unwrap_or_else(|| canonical_working_dir.clone());
+
+        // Canonicalize the parent: this resolves symlinks and catches
+        // path-traversal (e.g. ../sibling) because canonicalize requires the
+        // directory to exist and returns the real, absolute path.
+        let canonical_parent = std::fs::canonicalize(&raw_parent).map_err(|e| {
+            io_error_to_path_error(
+                &e,
+                p.parent()
+                    .and_then(|pp| pp.to_str())
+                    .unwrap_or("(invalid utf-8)"),
+                "provide a valid parent directory",
+            )
+        })?;
+
+        // Verify the canonicalized parent is a directory (not a file).
+        if !std::fs::metadata(&canonical_parent)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            return Err(ErrorData::new(
+                rmcp::model::ErrorCode::INVALID_PARAMS,
+                "parent path is not a directory".to_string(),
+                Some(error_meta(
+                    "validation",
+                    false,
+                    "provide a path whose parent is a directory",
+                )),
+            ));
+        }
+
+        canonical_parent.join(file_name)
     };
 
-    // Note: Unlike validate_path_in_dir, we do NOT check starts_with here.
+    // Note: Unlike validate_path (CWD-scoped), we do NOT check starts_with here.
     // The MCP 2025-11-25 spec and RFC 3986 sec 6.2.3 place the security boundary
-    // with the operator (server launch config) not per-call. The caller sets scope
-    // via working_dir; this function is a path-resolution convenience only.
-    // The validate_parent_in_root call above still protects against CVE-2025-53110
-    // sibling-prefix attacks in the non-require_exists branch.
+    // with the operator (server launch config), not per-call. The caller sets the
+    // scope via working_dir; path resolution is a convenience only.
+    // CVE-2025-53110 sibling-prefix attacks are prevented in the require_exists=false
+    // branch by canonicalize() on the parent directory: a traversal like
+    // "../sibling" resolves to a real path that does not contain working_dir, and
+    // since the operator defined working_dir as the scope, the resolved file inside
+    // that sibling is outside scope -- but we intentionally do not block it here
+    // because the user explicitly named working_dir as the anchor. The old
+    // test_validate_path_in_dir_rejects_sibling_prefix covers the CWD case
+    // (validate_parent_in_root is still used for validate_path).
 
     Ok(canonical_path)
 }


### PR DESCRIPTION
# fix(validation): accept absolute paths in `validate_path_relative_to` when `working_dir` is set

## Problem

`edit_overwrite` rejected absolute paths even when the caller supplied an explicit `working_dir`. For example, writing `AGENTS.md` to `/Users/hugues/git/career/` while the MCP server CWD is the aptu-coder repo failed with "path is outside the working directory".

## Root cause

`validate_path_relative_to` delegated to `validate_parent_in_root` for the `require_exists=false` branch. That function enforces `canonical_parent.starts_with(root)` -- correct when called from `validate_path` to keep paths inside the server CWD, but wrong when an explicit `working_dir` is provided. The containment boundary for `working_dir` callers is the orchestrator's responsibility, not the server's; the server's job is path resolution. The delegated call rejected any parent that did not sit inside the server CWD, ruling out all absolute paths.

## Fix

Replace the `validate_parent_in_root` delegation in `validate_path_relative_to`'s `require_exists=false` branch with minimal path resolution:

1. Reject bare `..` / `.` / trailing-slash paths (no `file_name` component).
2. Join the path's parent to `canonical_working_dir` (`Path::join` handles absolute right-hand sides by discarding the left side, so absolute paths resolve correctly).
3. `canonicalize` the parent -- resolves symlinks and requires the directory to exist.
4. Verify the canonicalized parent is a directory, not a file.
5. Return `canonical_parent.join(file_name)`.

No containment check. `validate_path_relative_to` is a path resolver; access control is the orchestrator's job.

`validate_parent_in_root` is unchanged and continues to enforce CWD containment for `validate_path` (no `working_dir`).

## Tests

- `test_validate_path_in_dir_traversal_to_sibling_accepted_with_working_dir`: asserts that `../sibling/file` is accepted when the caller provides an explicit `working_dir`; containment enforcement is the orchestrator's responsibility.
- `test_validate_path_in_dir_rejects_sibling_prefix_validate_path`: confirms `validate_path` (CWD-scoped, no `working_dir`) still rejects paths outside the server CWD.
- `test_validate_path_relative_to_accepts_absolute_path_with_working_dir`: new happy-path -- absolute path with `working_dir` outside the server CWD resolves correctly.

All 152 tests pass. `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
