### PR TITLE
chore(release): bump version to 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.26.0"
+version = "0.26.1"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Release 0.26.1

Patch release. Bumps `version` in `Cargo.toml` from `0.26.0` to `0.26.1`.

### Changes since v0.26.0

- `fix(validation)`: accept absolute paths in `validate_path_relative_to` when `working_dir` is set (#1345)

Closes #1345
