### PR TITLE
docs(audit): MCP 2026-07-28 specification alignment audit

### DIFF
--- a/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
+++ b/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
@@ -1,9 +1,9 @@
 # Audit: MCP 2026-07-28 Specification Alignment
 
-Date: 2026-08-01
-Commit: e91cfc8
-Version: v0.26.1
-Toolchain: Rust / rmcp 2.2.0 / tokio async
+Date: 2026-08-01  
+Commit: e91cfc8  
+Version: v0.26.1  
+Toolchain: Rust / rmcp 2.2.0 / tokio async  
 
 ## Purpose
 

--- a/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
+++ b/docs/audit/2026-08-01-mcp-spec-2026-07-28.md
@@ -1,0 +1,370 @@
+# Audit: MCP 2026-07-28 Specification Alignment
+
+Date: 2026-08-01
+Commit: e91cfc8
+Version: v0.26.1
+Toolchain: Rust / rmcp 2.2.0 / tokio async
+
+## Purpose
+
+Point-in-time audit of `aptu-coder` v0.26.1 against the MCP 2026-07-28 specification, published
+as final on July 28, 2026. This is the largest MCP revision since launch and the first with a
+formal feature lifecycle and deprecation policy.
+
+Scope: breaking changes from removed features, deprecated features in active use, opportunities
+from new spec capabilities, and clean findings. Each deprecated-and-in-use pattern is treated as
+a removal target (no deprecation window accepted; technical debt is not carried).
+
+## Background: What Changed in MCP 2026-07-28
+
+Six Specification Enhancement Proposals (SEPs) drove this release.
+
+**Breaking removals (no deprecation window):**
+
+| Removed | SEP | Replacement |
+|---|---|---|
+| `initialize` / `initialized` handshake | SEP-2575 | Protocol version + capabilities in `_meta` per-request; `server/discover` RPC |
+| `Mcp-Session-Id` header + protocol session | SEP-2567 | Explicit handles passed as tool arguments |
+| `tasks/list` + blocking `tasks/result` | SEP-2663 | `io.modelcontextprotocol/tasks` extension; poll via `tasks/get` |
+| `resources/subscribe`, `resources/unsubscribe`, standalone HTTP GET stream | SEP-2549 | `subscriptions/listen` (transport-neutral, per-category opt-in) |
+
+**Deprecated (12-month minimum window; this project removes immediately):**
+
+| Feature | SEP | Migration |
+|---|---|---|
+| Logging (`notifications/message`, `logging/setLevel`) | SEP-2577 | stderr (stdio) or OpenTelemetry |
+| Roots | SEP-2577 | Tool parameters or server config |
+| Sampling | SEP-2577 | Direct LLM provider API calls |
+| HTTP+SSE transport | SEP-2596 | Streamable HTTP (already in use) |
+
+**New optional features (opportunities):**
+
+| Feature | SEP |
+|---|---|
+| `server/discover` RPC (servers MUST implement) | SEP-2575 |
+| Multi Round-Trip Requests (MRTR) + `resultType` field | SEP-2322 |
+| `Mcp-Method` / `Mcp-Name` headers on Streamable HTTP POSTs | SEP-2243 |
+| `ttlMs` + `cacheScope` on list results | SEP-2549 |
+| W3C Trace Context (`traceparent`, `tracestate`, `baggage`) in `_meta` | SEP-414 |
+| Extensions framework (reverse-DNS IDs) | SEP-2133 |
+| Full JSON Schema 2020-12 for tool schemas | SEP-2106 |
+
+**Error code change:**
+
+| Old | New | Name |
+|---|---|---|
+| `-32002` | `-32602` | Resource not found → standard JSON-RPC Invalid Params |
+
+## rmcp 2.2.0 Alignment Status
+
+rmcp 2.2.0 (published crates.io release, confirmed in `Cargo.lock`) is in a transitional state:
+
+- `ProtocolVersion::V_2026_07_28` constant exists in `KNOWN_VERSIONS`
+- `ProtocolVersion::LATEST` still resolves to `V_2025_11_25` -- explicit opt-in required
+- `initialize`, `on_initialized`, `set_level`, `sampling`, `roots` all still present in the
+  `ServerHandler` trait -- backward-compat handshake retained
+- `enable_logging_with()` explicitly marked `#[deprecated since = "1.8.0"]`
+- `server/discover`, MRTR `resultType` field, `Mcp-Method`/`Mcp-Name` headers: present on the
+  `main` branch (git dependency) but NOT confirmed in the published 2.2.0 release
+
+**Implication:** Findings blocked on `initialize`/`on_initialized` removal require the rust-sdk
+to publish a crates.io release with full SEP-2575 / SEP-2567 support. The tracking issues are
+open: modelcontextprotocol/rust-sdk#869 (SEP-2575), #870 (SEP-2567), #871 (SEP-2322),
+#872 (SEP-2243), #873 (SEP-2260), #867 (SEP-2164).
+
+## Methodology
+
+Static analysis via `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` on
+the full source tree. No code was modified. Findings classified as:
+
+- **BREAKING**: will fail or regress once rmcp absorbs the spec change
+- **REMOVE**: uses a removed or deprecated feature; must be deleted (no deprecation window)
+- **OPPORTUNITY**: new spec capability the server could adopt
+- **CLEAN**: already aligned; no action required
+- **BLOCKED**: correct action identified but gated on rmcp publishing the new API
+
+---
+
+## Findings
+
+### C01 -- REMOVE (high) -- Dead MCP logging infrastructure
+
+**Files:** `crates/aptu-coder/src/logging.rs` (146 lines), `crates/aptu-coder/src/main.rs`
+(lines 223-236)
+
+`McpLoggingLayer` is a `tracing_subscriber::Layer` that bridges `tracing` events to an mpsc
+channel of `LogEvent{level, logger, data}`. It was built to forward events as MCP
+`notifications/message` to clients.
+
+The log-consumer task was intentionally disabled: `main.rs` creates the channel sender and
+immediately drops the receiver (`_event_rx`), with an inline comment acknowledging this. The
+`ServerCapabilities` builder in `lib.rs` does not call `enable_logging()`, so the server does
+not advertise the logging capability to any client.
+
+Result: `logging.rs` is dead code. It is never reached in any code path. MCP logging
+(`notifications/message` / `logging/setLevel`) is deprecated by SEP-2577; the spec migration
+target for stdio is stderr, which `tracing`'s `fmt::layer()` already provides via `main.rs`.
+
+**Action:** Delete `crates/aptu-coder/src/logging.rs`. Remove the `McpLoggingLayer` construction
+and channel setup from `main.rs`. Remove the `logging.rs` module declaration from `lib.rs`.
+Remove unit tests in `tests/logging_layer_tests.rs` (tests for dead code have no value).
+
+---
+
+### C02 -- BLOCKED (high) -- Application-level `initialize` / `on_initialized` handlers
+
+**Files:** `crates/aptu-coder/src/lib.rs` (lines 690-734, 759-768),
+`crates/aptu-coder/src/tools/server.rs` (lines 121-155)
+
+The `initialize` override captures `client_info.name`/`version` into
+`Arc<TokioMutex<Option<String>>>` fields on `CodeAnalyzer`. The `on_initialized` override
+generates an aptu-level `session_id` (format: `MILLIS-N`, driven by a global atomic counter),
+stores the `Peer<RoleServer>` handle, resets `session_call_seq`, and calls
+`router.bind_peer_notifier()`.
+
+SEP-2575 removes the `initialize`/`initialized` handshake entirely. Under the 2026-07-28 spec:
+protocol version, client info, and client capabilities travel in `_meta` on every request; there
+is no front-loaded handshake. `server/discover` replaces the capability exchange.
+
+rmcp 2.2.0 still carries `initialize`/`on_initialized` in `ServerHandler` -- the migration is
+blocked on rmcp publishing full SEP-2575 support.
+
+**Action (when rmcp removes `initialize`):**
+
+1. Remove the `initialize` override and `on_initialized` override from `lib.rs`.
+2. Remove `client_name`, `client_version`, `session_id` `Arc` fields from `CodeAnalyzer`;
+   remove all read sites (approximately 103 call sites across `lib.rs` and `metrics.rs`).
+3. Extract `client_name`/`client_version` from per-request `_meta` if the new spec defines a
+   carrying field; otherwise drop from metric records.
+4. Derive per-call identity from the W3C `traceparent` trace-id already extracted in `otel.rs`
+   -- a stable, per-call identifier requiring no extra state.
+5. Move peer acquisition to the first `call_tool` or a new rmcp lifecycle hook.
+6. Move profile-based tool filtering (currently in `on_initialized`) to a per-request path.
+
+**Tracked in:** issue #998 (pre-existing; update with rmcp release link when it ships).
+
+---
+
+### C03 -- BLOCKED (high) -- Hardcoded protocol version string `"2025-11-25"`
+
+**Files:** `crates/aptu-coder/src/metrics.rs` (line 502), integration tests
+(`tests/mcp_smoke.rs`, `tests/common/mod.rs`, `tests/symbol_cache_tests.rs`,
+`tests/exec_command.rs`)
+
+`metrics.rs` attaches a static OTEL span attribute `mcp.protocol.version = "2025-11-25"` to
+every metrics instrument. Integration test fixtures construct synthetic `initialize` request
+payloads with `protocolVersion: "2025-11-25"`.
+
+Once rmcp switches `ProtocolVersion::LATEST` to `V_2026_07_28` and the handshake is removed:
+
+- The static attribute in `metrics.rs` will misreport the negotiated version.
+- The synthetic `initialize` fixtures in tests become invalid (no handshake means no
+  `protocolVersion` field in test payloads).
+
+**Action (when rmcp updates `LATEST`):**
+
+1. In `metrics.rs`, derive the protocol version from `rmcp::model::ProtocolVersion::LATEST`
+   at compile time rather than a hardcoded string literal.
+2. In integration tests, remove `protocolVersion` from synthetic request payloads or derive it
+   from the same constant; update `make_test_analyzer()` harness in `tests/common/mod.rs`.
+
+---
+
+### C04 -- OPPORTUNITY (medium) -- No `server/discover` RPC implementation
+
+**Files:** `crates/aptu-coder/src/lib.rs` (ServerHandler impl)
+
+SEP-2575 requires servers to implement `server/discover`, which advertises supported protocol
+versions, capabilities, and server identity. It replaces the front-loaded `initialize` capability
+exchange and allows stateless load-balanced deployments where any replica can answer any request
+without a prior handshake.
+
+`server/discover` is not yet in the published rmcp 2.2.0 API (`ServerHandler` trait has no
+`discover` method). It is present on the rust-sdk `main` branch.
+
+**Action (when rmcp exposes the method):**
+
+Implement `discover` in `ServerHandler` for `CodeAnalyzer`. Return the same capability set
+currently built in `get_info()`. Reuse `get_info()` to avoid duplication.
+
+---
+
+### C05 -- OPPORTUNITY (low) -- No `resultType` field on `CallToolResult`
+
+**Files:** all `crates/aptu-coder/src/tools/*.rs` (7 tool handlers)
+
+SEP-2322 (MRTR) adds a required `resultType` field to every tool result (`"complete"` or
+`"input_required"`). All current results are `"complete"`. rmcp 2.2.0 does not yet expose this
+field in `CallToolResult`. Once rmcp adds the field, all success and error `CallToolResult`
+constructions across the 7 handlers must set `result_type: ResultType::Complete` (or equivalent).
+
+**Action (when rmcp exposes the field):** Add `result_type: ResultType::Complete` to every
+`CallToolResult::success(...)` and `err_to_tool_result(...)` call site.
+
+---
+
+### C06 -- OPPORTUNITY (low) -- `Mcp-Method` / `Mcp-Name` headers not validated server-side
+
+**File:** `crates/aptu-coder/src/main.rs` (axum router, auth middleware)
+
+SEP-2243 requires Streamable HTTP POST requests to include `Mcp-Method` and `Mcp-Name` headers
+so gateways and load balancers can route without parsing the JSON body. The current axum router
+and auth middleware do not validate or log these headers.
+
+rmcp 2.2.0 does not confirm automatic injection or validation of these headers. No action is
+possible until rmcp surfaces the behavior. If rmcp handles them at the transport layer, no
+application-level change is needed.
+
+**Action (when rmcp confirms behavior):** If not handled by rmcp, add an axum middleware layer
+that returns `400 Bad Request` when `Mcp-Method` or `Mcp-Name` are absent on POST requests to
+the MCP endpoint.
+
+---
+
+### C07 -- OPPORTUNITY (low) -- No `ttlMs` / `cacheScope` on tool list results
+
+**File:** `crates/aptu-coder/src/lib.rs` (`list_tools` via rmcp default)
+
+SEP-2549 adds `ttlMs` and `cacheScope` to `tools/list`, `resources/list`, `prompts/list`, and
+`resources/read` responses to enable client-side caching. The tool list for aptu-coder is static
+(no hot-reload); a generous TTL would reduce redundant `tools/list` round-trips for long-running
+agent sessions.
+
+rmcp 2.2.0 does not expose a `ttlMs`/`cacheScope` API for `ListToolsResult`. Defer until rmcp
+surfaces the API.
+
+**Action (when rmcp exposes the field):** Annotate `list_tools` response with a long TTL (e.g.
+`3_600_000` ms) and `cacheScope: "global"` since tool definitions are process-invariant.
+
+---
+
+### C08 -- CLEAN (info) -- W3C Trace Context already implemented
+
+**File:** `crates/aptu-coder/src/otel.rs`
+
+`extract_and_set_trace_context()` reads `traceparent` and `tracestate` from the MCP request
+`_meta`, builds an `ExtractMap` implementing the OpenTelemetry `Extractor` trait, and calls
+`set_parent()` to re-parent the current span into the caller's distributed trace. Called from
+all 7 tool call sites. This is the forward observability path recommended by SEP-414 as a
+replacement for the deprecated MCP logging feature.
+
+No action required.
+
+---
+
+### C09 -- CLEAN (info) -- Already stateless HTTP transport (NeverSessionManager)
+
+**File:** `crates/aptu-coder/src/main.rs`
+
+`StreamableHttpService::<CodeAnalyzer, NeverSessionManager>` with
+`with_stateful_mode(false)` is already configured. The server does not issue or consume
+`Mcp-Session-Id` headers. This aligns with SEP-2567's removal of protocol-level sessions ahead
+of rmcp formally dropping the handshake.
+
+No action required.
+
+---
+
+### C10 -- CLEAN (info) -- No Sampling, Roots, or Dynamic Client Registration usage
+
+No references to Sampling, Roots, or Dynamic Client Registration were found anywhere under
+`crates/`. `ServerCapabilities` does not advertise these capabilities. The three deprecated
+features (SEP-2577) have zero implementation surface in aptu-coder.
+
+No action required.
+
+---
+
+### C11 -- CLEAN (info) -- HTTP+SSE transport not in use
+
+**File:** `crates/aptu-coder/Cargo.toml`
+
+rmcp feature flag is `transport-streamable-http-server`, not the legacy SSE-only transport. The
+deprecated HTTP+SSE transport (SEP-2596) migration does not apply.
+
+No action required.
+
+---
+
+### C12 -- CLEAN (info) -- No legacy error codes (-32001 to -32004)
+
+No references to `-32001`, `-32002`, `-32003`, or `-32004` exist anywhere in the workspace. All
+error construction uses `ErrorCode::INVALID_PARAMS` and `ErrorCode::INTERNAL_ERROR` exclusively.
+The SEP-2164 error code renumbering does not affect aptu-coder.
+
+No action required.
+
+---
+
+### C13 -- CLEAN (info) -- `no_cache_meta()` is aptu-specific, not a spec conflict
+
+**File:** `crates/aptu-coder/src/tools/common.rs`
+
+`no_cache_meta()` builds a `Meta` with a single key `cache_hint: "no-cache"` applied to every
+`CallToolResult`. This is an aptu-specific convention instructing the calling MCP client not to
+cache tool results (point-in-time filesystem snapshots). It is unrelated to and does not conflict
+with the spec's new `ttlMs`/`cacheScope` fields, which apply to list/read responses, not tool
+call results.
+
+No action required.
+
+---
+
+## Open Issues Cross-Reference
+
+| Issue | Title | Relation to This Audit |
+|---|---|---|
+| [#998](https://github.com/clouatre-labs/aptu-coder/issues/998) | chore: migrate to MCP 2026-07-28 once rmcp v2 ships | Pre-existing. Covers C02. Close when rmcp ships the stateless-core APIs and the migration is complete. |
+| new | fix(logging): remove McpLoggingLayer dead code | Created from this audit. Covers C01. |
+| new | chore(protocol): update hardcoded protocol version string | Created from this audit. Covers C03. |
+| new | feat(protocol): implement server/discover RPC | Created from this audit. Covers C04. Blocked on rmcp. |
+
+Issues for C05, C06, C07 are deferred until rmcp exposes the relevant APIs. Track via #998.
+
+---
+
+## Summary
+
+*Table 1: Finding classification by count.*
+
+| Category | Count | Severity breakdown |
+|---|---|---|
+| REMOVE | 1 | 1 high (C01) |
+| BLOCKED | 2 | 2 high (C02, C03) |
+| OPPORTUNITY | 4 | 1 medium (C04), 3 low (C05-C07) |
+| CLEAN | 6 | 6 info (C08-C13) |
+
+**The server has no active use of any removed or deprecated MCP feature.** The MCP logging
+infrastructure (C01) is already dead code -- the consumer was intentionally disabled and the
+capability is not advertised. It must be deleted, not carried as dead weight.
+
+**The two blocked findings (C02, C03) require rmcp to publish a crates.io release with full
+SEP-2575/SEP-2567 support.** The migration surface is well-understood (documented in issue #998),
+and aptu-coder is already structurally prepared (stateless transport, W3C trace context, no
+session-header usage). The only work that cannot proceed is the removal of the
+`initialize`/`on_initialized` overrides and the three `Arc<TokioMutex<Option<String>>>` fields,
+because rmcp still requires those trait implementations for the handshake it currently runs.
+
+**The four opportunity findings (C04-C07) are all blocked on rmcp API surface.** No action
+is possible until rmcp exposes `server/discover`, `resultType`, routing headers, and TTL cache
+fields via its `ServerHandler` trait and result types.
+
+## Recommended Action Order
+
+1. **C01 (logging dead code) -- new issue** -- Delete `logging.rs`, remove channel setup from
+   `main.rs`, remove `logging_layer_tests.rs`. Zero risk of regression; the code is unreachable.
+   One PR, straightforward deletion.
+
+2. **C02 (initialize/on_initialized removal) -- #998** -- Execute when rmcp publishes SEP-2575
+   support. Follow the action steps in C02 and the existing analysis in #998. High blast radius
+   (~103 call sites); requires careful test coverage before merging.
+
+3. **C03 (protocol version string) -- new issue** -- Execute alongside C02; the two changes are
+   coupled (the synthetic `initialize` test fixtures become invalid at the same time rmcp drops
+   the handshake).
+
+4. **C04 (server/discover) -- new issue** -- Execute when rmcp exposes the `discover` trait
+   method. Straightforward: delegate to the existing `get_info()` implementation.
+
+5. **C05-C07 (resultType, routing headers, ttlMs)** -- Defer; track under #998 until rmcp
+   surfaces the APIs.


### PR DESCRIPTION
## Summary

Point-in-time audit of `aptu-coder` v0.26.1 against the MCP 2026-07-28 specification.
Full report: `docs/audit/2026-08-01-mcp-spec-2026-07-28.md`

## What changed in MCP 2026-07-28

| Type | Feature | SEP |
|---|---|---|
| Removed | `initialize`/`initialized` handshake | SEP-2575 |
| Removed | `Mcp-Session-Id` header / protocol sessions | SEP-2567 |
| Removed | `tasks/list`, blocking `tasks/result` | SEP-2663 |
| Deprecated | Logging (`notifications/message`, `logging/setLevel`) | SEP-2577 |
| Deprecated | Roots, Sampling | SEP-2577 |
| New | `server/discover` RPC (required) | SEP-2575 |
| New | MRTR `resultType` field | SEP-2322 |

## aptu-coder alignment findings

| Finding | Status | Action |
|---|---|---|
| C01: `McpLoggingLayer` dead code | REMOVE | #1347 |
| C02: `initialize`/`on_initialized` handlers | BLOCKED on rmcp | #998 |
| C03: Hardcoded `"2025-11-25"` protocol version | BLOCKED on rmcp | #1348 |
| C04: No `server/discover` implementation | BLOCKED on rmcp | #1349 |
| C05-C07: `resultType`, routing headers, `ttlMs` | BLOCKED on rmcp | track via #998 |
| C08: W3C Trace Context | CLEAN | no action |
| C09: Already stateless (`NeverSessionManager`) | CLEAN | no action |
| C10: No Sampling/Roots/DCR usage | CLEAN | no action |
| C11: Streamable HTTP (not SSE) in use | CLEAN | no action |
| C12: No legacy error codes | CLEAN | no action |
| C13: `no_cache_meta()` is aptu-specific | CLEAN | no action |

**The server has no active use of any removed or deprecated MCP feature.**
The only actionable item not blocked on rmcp is #1347 (delete dead code).

## rmcp 2.2.0 status

`ProtocolVersion::LATEST` = `V_2025_11_25` in the published release. Full SEP-2575/SEP-2567
stateless-core APIs (server/discover, MRTR, routing headers) are on the rust-sdk `main` branch,
not yet in a crates.io release. Blocked findings (#998, #1348, #1349) execute when rmcp ships.

## Issues created

- #1347 -- fix(logging): remove McpLoggingLayer dead code
- #1348 -- chore(protocol): remove hardcoded protocol version string
- #1349 -- feat(protocol): implement server/discover RPC
