### PR TITLE
chore(protocol): replace hardcoded 2025-11-25 with ProtocolVersion::LATEST

### DIFF
--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -707,6 +707,18 @@ impl ServerHandler for CodeAnalyzer {
         Ok(self.get_info())
     }
 
+    /// Returns the `InitializeResult` describing server capabilities and metadata.
+    ///
+    /// Once `rmcp` exposes `ServerHandler::discover` (tracked in issue #1349,
+    /// blocked on #998 and modelcontextprotocol/rust-sdk#869), the implementation
+    /// should be:
+    /// ```ignore
+    /// async fn discover(&self, _context: RequestContext<RoleServer>)
+    ///     -> Result<DiscoverResult, ErrorData>
+    /// {
+    ///     Ok(self.get_info().into())
+    /// }
+    /// ```
     fn get_info(&self) -> InitializeResult {
         let excluded = aptu_coder_core::EXCLUDED_DIRS.join(", ");
         let instructions = format!(

--- a/crates/aptu-coder/src/metrics.rs
+++ b/crates/aptu-coder/src/metrics.rs
@@ -17,6 +17,7 @@ pub(crate) use crate::metrics_export::{
 
 use opentelemetry::metrics::{Counter, Histogram};
 use opentelemetry::{KeyValue, global};
+use rmcp::model::ProtocolVersion;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
@@ -499,7 +500,7 @@ pub(crate) fn record_otel_metrics(event: &MetricEvent) {
         KeyValue::new("gen_ai.tool.name", event.tool),
         KeyValue::new("error.type", error_type.to_string()),
         KeyValue::new("mcp.method.name", "tools/call"),
-        KeyValue::new("mcp.protocol.version", "2025-11-25"),
+        KeyValue::new("mcp.protocol.version", ProtocolVersion::LATEST.as_str()),
         KeyValue::new("network.transport", "pipe"),
     ];
 

--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -32,7 +32,7 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
             "capabilities": {},
             "clientInfo": {"name": "test-client", "version": "0.1.0"}
         }
@@ -133,7 +133,7 @@ pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
             "capabilities": {},
             "clientInfo": {"name": "test-client", "version": "0.1.0"}
         }

--- a/crates/aptu-coder/tests/exec_command.rs
+++ b/crates/aptu-coder/tests/exec_command.rs
@@ -1685,7 +1685,7 @@ async fn test_concurrent_interleaved_overflow() {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
             "capabilities": {},
             "clientInfo": {"name": "test-client", "version": "0.1.0"}
         }

--- a/crates/aptu-coder/tests/mcp_smoke.rs
+++ b/crates/aptu-coder/tests/mcp_smoke.rs
@@ -30,7 +30,17 @@ fn test_mcp_server_responds_to_tools_call() {
     let mut stdin = child.stdin.take().expect("failed to get stdin");
 
     // Send initialize message
-    let init_msg = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+    let init_msg = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"}
+        }
+    })
+    .to_string();
     stdin
         .write_all(init_msg.as_bytes())
         .expect("failed to write");
@@ -125,7 +135,17 @@ fn test_mcp_server_recovers_after_tool_error() {
 
     // Writer thread: pace messages to avoid EOF race with the server's async reader.
     let writer = thread::spawn(move || {
-        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        let init = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0"}
+            }
+        })
+        .to_string();
         stdin.write_all(init.as_bytes()).expect("write init");
         stdin.write_all(b"\n").expect("newline");
 
@@ -242,7 +262,17 @@ fn test_mcp_server_exec_command() {
 
     // Writer thread: pace messages to avoid EOF race with the server's async reader.
     let writer = thread::spawn(move || {
-        let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+        let init = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0"}
+            }
+        })
+        .to_string();
         stdin.write_all(init.as_bytes()).expect("write init");
         stdin.write_all(b"\n").expect("newline");
 

--- a/crates/aptu-coder/tests/symbol_cache_tests.rs
+++ b/crates/aptu-coder/tests/symbol_cache_tests.rs
@@ -32,7 +32,7 @@ async fn call_tool_twice_sequential(
     let init = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "initialize",
         "params": {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
             "capabilities": {},
             "clientInfo": {"name": "test-client", "version": "0.1.0"}
         }


### PR DESCRIPTION
## Summary

Replace 8 hardcoded `"2025-11-25"` protocol version string literals with `rmcp::model::ProtocolVersion::LATEST.as_str()` so the emitted OTEL span attribute and test fixtures auto-update when rmcp bumps `LATEST`.

Also documents the future `server/discover` implementation on `get_info()` (blocked on rmcp publishing SEP-2575 support).

## Changes

- `crates/aptu-coder/src/metrics.rs`: add `use rmcp::model::ProtocolVersion;`, replace hardcoded literal with `ProtocolVersion::LATEST.as_str()` in `mcp.protocol.version` OTEL attribute
- `crates/aptu-coder/tests/common/mod.rs`: interpolate `ProtocolVersion::LATEST.as_str()` in both `json!()` initialize payloads
- `crates/aptu-coder/tests/mcp_smoke.rs`: convert 3 raw `r#"..."#` initialize strings to `json!()` macro form and interpolate version constant
- `crates/aptu-coder/tests/symbol_cache_tests.rs`: interpolate version constant in `json!()` initialize payload
- `crates/aptu-coder/tests/exec_command.rs`: interpolate version constant in `json!()` initialize payload
- `crates/aptu-coder/src/lib.rs`: add doc comment above `get_info()` documenting the future `discover()` implementation

## Test plan

- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)

## Issues

Closes #1348

Note: #1349 (`server/discover`) is blocked on rmcp publishing SEP-2575 support (modelcontextprotocol/rust-sdk#869). A doc comment documents the intended implementation on `get_info()`.
