### PR TITLE
chore(release): bump version to 0.26.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aptu-coder"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "aptu-coder-core",
  "axum",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "aptu-coder-core"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "base64 0.23.0",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 rust-version = "1.96.0"
 authors = ["Hugues Clouatre"]


### PR DESCRIPTION
## Release 0.26.2

Patch release. Bumps `version` in `Cargo.toml` from `0.26.1` to `0.26.2`.

### Changes since v0.26.1

- `feat(protocol)`: implement `server/discover` RPC (MCP SEP-2575) (#1354)
- `fix(edit)`: remove CWD containment check from edit tools when no `working_dir` is set (#1353)
- `fix(logging)`: remove `McpLoggingLayer` dead code (MCP SEP-2577) (#1351)
- `chore(protocol)`: replace hardcoded `2025-11-25` with `ProtocolVersion::LATEST` (#1352)
- `docs`: update markdown files for rmcp v2, SEP-2577, `ProtocolVersion::LATEST`, `replace_all`, `server/discover` (#1355)
