### PR TITLE
chore(aptu): switch AI provider from Gemini to OpenRouter gemma-4-26b-a4b-it:free

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -6,6 +6,6 @@ review:
   instructions-file: .github/instructions/pr-review.md
 
 ai:
-  provider: gemini
-  model: models/gemini-3.1-flash-lite
-  api-key-secret: GEMINI_API_KEY
+  provider: openrouter
+  model: google/gemma-4-26b-a4b-it:free
+  api-key-secret: OPENROUTER_API_KEY


### PR DESCRIPTION
Switch aptu AI provider from Gemini (`gemini-3.1-flash-lite`) to OpenRouter (`google/gemma-4-26b-a4b-it:free`) to eliminate Gemini billing.

## Changes

- `.github/aptu.yml`: `provider: gemini` -> `provider: openrouter`, `model: models/gemini-3.1-flash-lite` -> `model: google/gemma-4-26b-a4b-it:free`, `api-key-secret: GEMINI_API_KEY` -> `api-key-secret: OPENROUTER_API_KEY`

## Rationale

Google started billing for `gemini-3.1-flash-lite`. `google/gemma-4-26b-a4b-it:free` on OpenRouter is a free-tier model of comparable capability. `OPENROUTER_API_KEY` is already a repo secret used by CI.