### PR TITLE
chore(aptu): upgrade AI model from gemma-4-26b-a4b-it:free to gemma-4-26b-a4b-it (paid)

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -7,5 +7,5 @@ review:
 
 ai:
   provider: openrouter
-  model: google/gemma-4-26b-a4b-it:free
+  model: google/gemma-4-26b-a4b-it
   api-key-secret: OPENROUTER_API_KEY


### PR DESCRIPTION
## Summary

Upgrades the AI model from `google/gemma-4-26b-a4b-it:free` to `google/gemma-4-26b-a4b-it` (paid tier, same weights).

## Root cause

PR #1360 received a spurious inline review comment on line 1 of a markdown file: "File content appears truncated; full assessment of the document is limited." The file was delivered complete to the model — 18,521 chars, well within the 32,000-char `max_chars_per_file` budget. No `[APTU: ...]` truncation annotation was injected into the prompt. The comment is a hallucination produced by the free-tier inference endpoint.

Timeline confirmed: model switch from Gemini to Gemma at `2026-08-03T19:56:43Z`, PR #1360 created at `2026-08-03T22:09:05Z`, spurious comment posted at `2026-08-03T22:10:48Z`. The review ran on Gemma. The free tier applies rate limits and degraded inference not present on the paid tier.

## Change

`.github/aptu.yml`: `model: google/gemma-4-26b-a4b-it:free` → `model: google/gemma-4-26b-a4b-it`

Same model weights. Same OpenRouter provider. Model ID verified against OpenRouter `/api/v1/models`.

## Checklist

- [x] No code changes
- [x] No version bump required (config-only)
- [x] Model ID verified against OpenRouter `/api/v1/models`
- [x] YAML valid
