### PR TITLE
feat(kg): MCP Resource surface for knowledge graph (C-full)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ version = "0.26.2"
 dependencies = [
  "aptu-coder-core",
  "axum",
+ "base64 0.23.0",
  "blake3",
  "fs2",
  "opentelemetry",

--- a/crates/aptu-coder-core/src/graph/mod.rs
+++ b/crates/aptu-coder-core/src/graph/mod.rs
@@ -7,3 +7,5 @@ pub mod structural;
 
 #[rustfmt::skip]
 pub use call_graph::{CallGraph, InternalCallChain, GraphError, resolve_symbol};
+pub use store::GraphDiskStore;
+pub use structural::{Edge, Node, StructuralGraph, SymbolKind};

--- a/crates/aptu-coder/Cargo.toml
+++ b/crates/aptu-coder/Cargo.toml
@@ -43,6 +43,7 @@ opentelemetry-appender-tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 schemars = { workspace = true }
 fs2 = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/aptu-coder/src/lib.rs
+++ b/crates/aptu-coder/src/lib.rs
@@ -163,7 +163,8 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     CallToolResponse, CallToolResult, CancelledNotificationParam, CompleteRequestParams,
     CompleteResult, CompletionInfo, ContentBlock, DiscoverResult, ErrorData, Implementation,
-    InitializeRequestParams, InitializeResult, ServerCapabilities,
+    InitializeRequestParams, InitializeResult, ListResourceTemplatesResult, ListResourcesResult,
+    ReadResourceRequestParams, ReadResourceResponse, ServerCapabilities,
 };
 use rmcp::service::{NotificationContext, RequestContext};
 use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -220,6 +221,8 @@ pub struct CodeAnalyzer {
     // Used to detect stale LLM context and return a directive error instead of
     // repeatedly trying an old_text that no longer matches the file content.
     edit_failure_counts: Arc<Mutex<HashMap<(String, String), u8>>>,
+    // On-disk graph store for structural knowledge graph resources.
+    graph_store: std::sync::Arc<aptu_coder_core::graph::GraphDiskStore>,
 }
 
 #[tool_router]
@@ -734,6 +737,7 @@ impl ServerHandler for CodeAnalyzer {
             .enable_tools()
             .enable_tool_list_changed()
             .enable_completions()
+            .enable_resources()
             .build();
         let server_info = Implementation::new("aptu-coder", env!("CARGO_PKG_VERSION"))
             .with_title("Aptu Coder")
@@ -762,6 +766,30 @@ impl ServerHandler for CodeAnalyzer {
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         let router = self.tool_router.read().await;
         router.call(tcc).await
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        tools::resources::list_resources_impl(_request, &_context)
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        tools::resources::list_resource_templates_impl(_request, &_context)
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, ErrorData> {
+        tools::resources::read_resource_impl(request, &self.graph_store)
     }
 
     async fn on_initialized(&self, context: NotificationContext<RoleServer>) {

--- a/crates/aptu-coder/src/tools/mod.rs
+++ b/crates/aptu-coder/src/tools/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod edit_overwrite;
 pub(crate) mod edit_replace;
 pub(crate) mod exec_command;
 pub(crate) mod exec_runtime;
+pub(crate) mod resources;
 pub(crate) mod server;
 pub(crate) mod symbol_focused;
 

--- a/crates/aptu-coder/src/tools/resources.rs
+++ b/crates/aptu-coder/src/tools/resources.rs
@@ -24,30 +24,52 @@ const PAGE_SIZE: usize = 50;
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum GraphQuery {
     BlastRadius {
+        repo_hash: String,
         symbol: String,
         depth: usize,
         cursor_offset: usize,
     },
     ImportClosure {
+        repo_hash: String,
         module: String,
         cursor_offset: usize,
     },
     Subgraph {
+        repo_hash: String,
         symbol: String,
         cursor_offset: usize,
     },
 }
 
-/// Base64url-encode a JSON `{"g":offset}` cursor token.
-/// Uses base64url (no padding) to avoid '+' and '/' in query strings.
+impl GraphQuery {
+    fn repo_hash(&self) -> &str {
+        match self {
+            Self::BlastRadius { repo_hash, .. } => repo_hash,
+            Self::ImportClosure { repo_hash, .. } => repo_hash,
+            Self::Subgraph { repo_hash, .. } => repo_hash,
+        }
+    }
+
+    fn cursor_offset(&self) -> usize {
+        match self {
+            Self::BlastRadius { cursor_offset, .. } => *cursor_offset,
+            Self::ImportClosure { cursor_offset, .. } => *cursor_offset,
+            Self::Subgraph { cursor_offset, .. } => *cursor_offset,
+        }
+    }
+}
+
+/// Base64url-encode a graph cursor offset.
+///
+/// Produces `{"g":N}` JSON encoded as base64url (no padding), which is safe
+/// in URI query strings and cannot be mistaken for a `PaginationMode` cursor
+/// (which uses `{"mode":...,"offset":...}`).
 fn encode_graph_cursor(offset: usize) -> String {
-    let json = serde_json::json!({"g": offset});
-    let json_str = serde_json::to_string(&json).unwrap_or_default();
-    URL_SAFE_NO_PAD.encode(json_str.as_bytes())
+    URL_SAFE_NO_PAD.encode(format!(r#"{{"g":{offset}}}"#).as_bytes())
 }
 
 /// Decode a graph cursor token. Returns `None` if the token is not a valid
-/// graph cursor (e.g. it is a PaginationMode cursor or garbage).
+/// graph cursor (wrong base64, wrong JSON, or missing "g" key).
 fn decode_graph_cursor(s: &str) -> Option<usize> {
     let decoded = URL_SAFE_NO_PAD.decode(s.as_bytes()).ok()?;
     let text = String::from_utf8(decoded).ok()?;
@@ -57,9 +79,10 @@ fn decode_graph_cursor(s: &str) -> Option<usize> {
 
 /// Parse a `aptu-coder://graph/{repo_hash}/{query_type}/{arg}?cursor=...&depth=N` URI.
 ///
-/// Validates scheme, path structure, and query type. The `repo_hash` segment is
-/// extracted and used as the `GraphDiskStore` key in `read_resource_impl`; it is
-/// not re-validated here against disk (the store returns `None` on a stale key).
+/// Validates scheme, path structure, and query type. The `repo_hash` is carried
+/// inside the returned `GraphQuery` and used as the `GraphDiskStore` lookup key
+/// in `read_resource_impl`; a stale hash causes `get` to return `None` which
+/// triggers the cold-cache error.
 fn parse_graph_uri(uri: &str) -> Result<GraphQuery, ErrorData> {
     let rest = uri.strip_prefix("aptu-coder://").ok_or_else(|| {
         ErrorData::new(
@@ -70,10 +93,9 @@ fn parse_graph_uri(uri: &str) -> Result<GraphQuery, ErrorData> {
     })?;
 
     // Split path from query string.
-    let (path_part, qs) = if let Some(pos) = rest.find('?') {
-        (&rest[..pos], Some(&rest[pos + 1..]))
-    } else {
-        (rest, None)
+    let (path_part, qs) = match rest.find('?') {
+        Some(pos) => (&rest[..pos], Some(&rest[pos + 1..])),
+        None => (rest, None),
     };
 
     // Parse query-string params: cursor=<token>&depth=<N>
@@ -113,20 +135,24 @@ fn parse_graph_uri(uri: &str) -> Result<GraphQuery, ErrorData> {
         ));
     }
 
+    let repo_hash = segments[1].to_string();
     let query_type = segments[2];
     let arg = segments[3..].join("/");
 
     match query_type {
         "blast-radius" => Ok(GraphQuery::BlastRadius {
+            repo_hash,
             symbol: arg,
             depth,
             cursor_offset,
         }),
         "import-closure" => Ok(GraphQuery::ImportClosure {
+            repo_hash,
             module: arg,
             cursor_offset,
         }),
         "subgraph" => Ok(GraphQuery::Subgraph {
+            repo_hash,
             symbol: arg,
             cursor_offset,
         }),
@@ -141,40 +167,20 @@ fn parse_graph_uri(uri: &str) -> Result<GraphQuery, ErrorData> {
 }
 
 /// Resolve a query against a graph into a flat list of node JSON values.
+///
+/// Nodes whose serialization fails are silently dropped rather than failing the
+/// entire request; a malformed node in the graph should not prevent the client
+/// from receiving the rest of the result set.
 fn query_to_nodes(graph: &StructuralGraph, query: &GraphQuery) -> Vec<serde_json::Value> {
-    match query {
-        GraphQuery::BlastRadius { symbol, depth, .. } => {
-            let indices = graph.bfs_blast_radius(symbol, *depth);
-            indices
-                .iter()
-                .map(|idx| {
-                    let node = graph.0[*idx].clone();
-                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
-                })
-                .collect()
-        }
-        GraphQuery::ImportClosure { module, .. } => {
-            // Find all nodes that import the given module
-            let indices = graph.bfs_blast_radius(module, 1);
-            indices
-                .iter()
-                .map(|idx| {
-                    let node = graph.0[*idx].clone();
-                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
-                })
-                .collect()
-        }
-        GraphQuery::Subgraph { symbol, .. } => {
-            let indices = graph.bfs_blast_radius(symbol, 2);
-            indices
-                .iter()
-                .map(|idx| {
-                    let node = graph.0[*idx].clone();
-                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
-                })
-                .collect()
-        }
-    }
+    let indices = match query {
+        GraphQuery::BlastRadius { symbol, depth, .. } => graph.bfs_blast_radius(symbol, *depth),
+        GraphQuery::ImportClosure { module, .. } => graph.bfs_blast_radius(module, 1),
+        GraphQuery::Subgraph { symbol, .. } => graph.bfs_blast_radius(symbol, 2),
+    };
+    indices
+        .into_iter()
+        .filter_map(|idx| serde_json::to_value(graph.0[idx].clone()).ok())
+        .collect()
 }
 
 /// Return an empty resources list (concrete graph slices are unbounded;
@@ -222,37 +228,9 @@ pub(crate) fn read_resource_impl(
     request: ReadResourceRequestParams,
     graph_store: &GraphDiskStore,
 ) -> Result<ReadResourceResponse, ErrorData> {
-    // Parse URI to get the query and repo_hash
-    let rest = request.uri.strip_prefix("aptu-coder://").ok_or_else(|| {
-        ErrorData::new(
-            ErrorCode::INVALID_PARAMS,
-            format!(
-                "invalid URI scheme: expected aptu-coder://, got {}",
-                request.uri
-            ),
-            None,
-        )
-    })?;
-    let (path_part, _cursor_offset) = if let Some(pos) = rest.find('?') {
-        (&rest[..pos], 0)
-    } else {
-        (rest, 0)
-    };
-    let segments: Vec<&str> = path_part.split('/').collect();
-    if segments.len() < 4 || segments[0] != "graph" {
-        return Err(ErrorData::new(
-            ErrorCode::INVALID_PARAMS,
-            format!("invalid URI path: {}", request.uri),
-            None,
-        ));
-    }
-    let repo_hash = segments[1];
-
-    // Parse the full query (including cursor from query string)
     let query = parse_graph_uri(&request.uri)?;
 
-    // Load graph from store
-    let graph = graph_store.get(repo_hash).ok_or_else(|| {
+    let graph = graph_store.get(query.repo_hash()).ok_or_else(|| {
         ErrorData::new(
             ErrorCode::RESOURCE_NOT_FOUND,
             "graph not built yet -- call analyze_symbol on this directory first to build the graph cache".to_string(),
@@ -260,29 +238,13 @@ pub(crate) fn read_resource_impl(
         )
     })?;
 
-    // Resolve query to nodes
     let all_nodes = query_to_nodes(&graph, &query);
     let total = all_nodes.len();
+    let offset = query.cursor_offset();
 
-    // Paginate manually
-    let offset = match &query {
-        GraphQuery::BlastRadius { cursor_offset, .. } => *cursor_offset,
-        GraphQuery::ImportClosure { cursor_offset, .. } => *cursor_offset,
-        GraphQuery::Subgraph { cursor_offset, .. } => *cursor_offset,
-    };
-    let page: Vec<serde_json::Value> = all_nodes
-        .iter()
-        .skip(offset)
-        .take(PAGE_SIZE)
-        .cloned()
-        .collect();
+    let page: Vec<serde_json::Value> = all_nodes.into_iter().skip(offset).take(PAGE_SIZE).collect();
 
-    let next_offset = if offset + PAGE_SIZE < total {
-        Some(offset + PAGE_SIZE)
-    } else {
-        None
-    };
-    let next_cursor = next_offset.map(encode_graph_cursor);
+    let next_cursor = (offset + PAGE_SIZE < total).then(|| encode_graph_cursor(offset + PAGE_SIZE));
 
     let payload = serde_json::json!({
         "nodes": page,
@@ -299,19 +261,19 @@ pub(crate) fn read_resource_impl(
     })?;
 
     let contents = ResourceContents::text(text, &request.uri).with_mime_type("application/json");
-
-    let result = ReadResourceResult::new(vec![contents]);
-    Ok(ReadResourceResponse::Complete(result))
+    Ok(ReadResourceResponse::Complete(ReadResourceResult::new(
+        vec![contents],
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use aptu_coder_core::analyze::FileAnalysisOutput;
-    use aptu_coder_core::types::{FunctionInfo, SemanticAnalysis};
+    use aptu_coder_core::types::{CallInfo, FunctionInfo, SemanticAnalysis};
 
-    /// Build a graph with `caller` and `callee` symbols connected by a Calls edge.
-    /// `bfs_blast_radius` on `caller` at depth>=1 will return `callee`.
+    /// Build a graph with `caller` calling `callee` via a Calls edge.
+    /// `bfs_blast_radius` on `caller` at depth >= 1 returns `callee`.
     fn make_graph_with_call(caller: &str, callee: &str) -> StructuralGraph {
         let mut f1 = FunctionInfo::default();
         f1.name = caller.to_string();
@@ -322,7 +284,6 @@ mod tests {
         f2.line = 10;
         f2.end_line = 15;
         // CallInfo is #[non_exhaustive] with no Default or new(); deserialize from JSON.
-        use aptu_coder_core::types::CallInfo;
         let call: CallInfo = serde_json::from_str(&format!(
             r#"{{"caller":"{caller}","callee":"{callee}","line":1,"column":0}}"#
         ))
@@ -340,24 +301,6 @@ mod tests {
         StructuralGraph::build_from_analysis(&[entry])
     }
 
-    fn make_graph_with_node(name: &str) -> StructuralGraph {
-        let mut func = FunctionInfo::default();
-        func.name = name.to_string();
-        func.line = 1;
-        func.end_line = 5;
-        let analysis = SemanticAnalysis::new(
-            vec![func],
-            vec![],
-            vec![],
-            vec![],
-            Default::default(),
-            vec![],
-            vec![],
-        );
-        let entry = FileAnalysisOutput::new("test.rs:1:1:1".to_string(), analysis, 10, None);
-        StructuralGraph::build_from_analysis(&[entry])
-    }
-
     #[test]
     fn test_parse_graph_uri_blast_radius_happy_path() {
         let uri = "aptu-coder://graph/abc123/blast-radius/my_func";
@@ -365,41 +308,32 @@ mod tests {
         assert_eq!(
             query,
             GraphQuery::BlastRadius {
+                repo_hash: "abc123".to_string(),
                 symbol: "my_func".to_string(),
                 depth: 3,
-                cursor_offset: 0
+                cursor_offset: 0,
             }
         );
     }
 
     #[test]
     fn test_parse_graph_uri_invalid_scheme() {
-        let uri = "file:///path/to/file";
-        let result = parse_graph_uri(uri);
-        assert!(result.is_err());
+        let result = parse_graph_uri("file:///path/to/file");
         assert!(result.unwrap_err().message.contains("invalid URI scheme"));
     }
 
     #[test]
     fn test_parse_graph_uri_unknown_query_type() {
-        let uri = "aptu-coder://graph/abc123/unknown/foo";
-        let result = parse_graph_uri(uri);
-        assert!(result.is_err());
+        let result = parse_graph_uri("aptu-coder://graph/abc123/unknown/foo");
         assert!(result.unwrap_err().message.contains("unknown query type"));
     }
 
     #[test]
     fn test_encode_decode_graph_cursor_roundtrip() {
-        let token = encode_graph_cursor(42);
-        assert_eq!(decode_graph_cursor(&token), Some(42));
-
-        // Zero offset
-        let token = encode_graph_cursor(0);
-        assert_eq!(decode_graph_cursor(&token), Some(0));
-
-        // Large offset
-        let token = encode_graph_cursor(9999);
-        assert_eq!(decode_graph_cursor(&token), Some(9999));
+        for offset in [0usize, 42, 9999] {
+            let token = encode_graph_cursor(offset);
+            assert_eq!(decode_graph_cursor(&token), Some(offset));
+        }
     }
 
     #[test]
@@ -410,9 +344,10 @@ mod tests {
         assert_eq!(
             query,
             GraphQuery::BlastRadius {
+                repo_hash: "abc123".to_string(),
                 symbol: "my_func".to_string(),
                 depth: 3,
-                cursor_offset: 50
+                cursor_offset: 50,
             }
         );
     }
@@ -425,21 +360,20 @@ mod tests {
 
     #[test]
     fn test_query_to_nodes_found_symbol() {
-        // bfs_blast_radius returns NEIGHBORS of the start node, not the node itself.
-        // Use a graph with a Calls edge so the BFS returns the callee.
+        // bfs_blast_radius returns neighbors of the start node, not the node itself.
+        // A Calls edge ensures the callee is returned.
         let graph = make_graph_with_call("caller_func", "callee_func");
         let query = GraphQuery::BlastRadius {
+            repo_hash: "x".to_string(),
             symbol: "caller_func".to_string(),
             depth: 3,
             cursor_offset: 0,
         };
-        let nodes = query_to_nodes(&graph, &query);
-        assert!(!nodes.is_empty());
+        assert!(!query_to_nodes(&graph, &query).is_empty());
     }
 
     #[test]
     fn test_read_resource_impl_cold_cache_miss() {
-        // A temp dir for the store (empty, no data)
         let tmp = std::env::temp_dir().join("aptu-coder-test-resources");
         let _ = std::fs::create_dir_all(&tmp);
         let store = GraphDiskStore::new(tmp.clone());
@@ -447,12 +381,10 @@ mod tests {
 
         let request =
             ReadResourceRequestParams::new("aptu-coder://graph/abc123/blast-radius/my_func");
-        let result = read_resource_impl(request, &store);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        let err = read_resource_impl(request, &store).unwrap_err();
         assert!(
             err.message.contains("graph not built yet"),
-            "expected 'graph not built yet' error, got: {}",
+            "unexpected error: {}",
             err.message
         );
     }

--- a/crates/aptu-coder/src/tools/resources.rs
+++ b/crates/aptu-coder/src/tools/resources.rs
@@ -1,0 +1,459 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! MCP Resource surface for the structural knowledge graph.
+//!
+//! Implements `list_resources`, `list_resource_templates`, and `read_resource`
+//! for the `aptu-coder://graph/{repo_hash}/{query_type}/{arg}?cursor=...` URI scheme.
+//! Three resource templates are advertised: blast-radius, import-closure, subgraph.
+
+use aptu_coder_core::graph::{GraphDiskStore, StructuralGraph};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rmcp::RoleServer;
+use rmcp::model::{
+    ErrorCode, ErrorData, ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, ResourceContents,
+    ResourceTemplate,
+};
+use rmcp::service::RequestContext;
+
+const PAGE_SIZE: usize = 50;
+
+/// Graph query variants parsed from resource URIs.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum GraphQuery {
+    BlastRadius {
+        symbol: String,
+        depth: usize,
+        cursor_offset: usize,
+    },
+    ImportClosure {
+        module: String,
+        cursor_offset: usize,
+    },
+    Subgraph {
+        symbol: String,
+        cursor_offset: usize,
+    },
+}
+
+/// Base64url-encode a JSON `{"g":offset}` cursor token.
+/// Uses base64url (no padding) to avoid '+' and '/' in query strings.
+fn encode_graph_cursor(offset: usize) -> String {
+    let json = serde_json::json!({"g": offset});
+    let json_str = serde_json::to_string(&json).unwrap_or_default();
+    URL_SAFE_NO_PAD.encode(json_str.as_bytes())
+}
+
+/// Decode a graph cursor token. Returns `None` if the token is not a valid
+/// graph cursor (e.g. it is a PaginationMode cursor or garbage).
+fn decode_graph_cursor(s: &str) -> Option<usize> {
+    let decoded = URL_SAFE_NO_PAD.decode(s.as_bytes()).ok()?;
+    let text = String::from_utf8(decoded).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+    value.get("g")?.as_u64().map(|n| n as usize)
+}
+
+/// Parse a `aptu-coder://graph/{repo_hash}/{query_type}/{arg}?cursor=...&depth=N` URI.
+///
+/// Validates scheme, path structure, and query type. The `repo_hash` segment is
+/// extracted and used as the `GraphDiskStore` key in `read_resource_impl`; it is
+/// not re-validated here against disk (the store returns `None` on a stale key).
+fn parse_graph_uri(uri: &str) -> Result<GraphQuery, ErrorData> {
+    let rest = uri.strip_prefix("aptu-coder://").ok_or_else(|| {
+        ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("invalid URI scheme: expected aptu-coder://, got {uri}"),
+            None,
+        )
+    })?;
+
+    // Split path from query string.
+    let (path_part, qs) = if let Some(pos) = rest.find('?') {
+        (&rest[..pos], Some(&rest[pos + 1..]))
+    } else {
+        (rest, None)
+    };
+
+    // Parse query-string params: cursor=<token>&depth=<N>
+    let mut cursor_offset: usize = 0;
+    let mut depth: usize = 3;
+    if let Some(qs) = qs {
+        for kv in qs.split('&') {
+            if let Some(token) = kv.strip_prefix("cursor=") {
+                cursor_offset = decode_graph_cursor(token).ok_or_else(|| {
+                    ErrorData::new(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("invalid graph cursor token: {token}"),
+                        None,
+                    )
+                })?;
+            } else if let Some(d) = kv.strip_prefix("depth=") {
+                depth = d.parse::<usize>().map_err(|_| {
+                    ErrorData::new(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("invalid depth parameter: {d}"),
+                        None,
+                    )
+                })?;
+            }
+        }
+    }
+
+    // Path segments: graph/{repo_hash}/{query_type}/{arg}
+    let segments: Vec<&str> = path_part.split('/').collect();
+    if segments.len() < 4 || segments[0] != "graph" {
+        return Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!(
+                "invalid URI path: expected graph/{{repo_hash}}/{{query_type}}/{{arg}}, got {uri}"
+            ),
+            None,
+        ));
+    }
+
+    let query_type = segments[2];
+    let arg = segments[3..].join("/");
+
+    match query_type {
+        "blast-radius" => Ok(GraphQuery::BlastRadius {
+            symbol: arg,
+            depth,
+            cursor_offset,
+        }),
+        "import-closure" => Ok(GraphQuery::ImportClosure {
+            module: arg,
+            cursor_offset,
+        }),
+        "subgraph" => Ok(GraphQuery::Subgraph {
+            symbol: arg,
+            cursor_offset,
+        }),
+        _ => Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!(
+                "unknown query type '{query_type}': expected blast-radius, import-closure, or subgraph"
+            ),
+            None,
+        )),
+    }
+}
+
+/// Resolve a query against a graph into a flat list of node JSON values.
+fn query_to_nodes(graph: &StructuralGraph, query: &GraphQuery) -> Vec<serde_json::Value> {
+    match query {
+        GraphQuery::BlastRadius { symbol, depth, .. } => {
+            let indices = graph.bfs_blast_radius(symbol, *depth);
+            indices
+                .iter()
+                .map(|idx| {
+                    let node = graph.0[*idx].clone();
+                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
+                })
+                .collect()
+        }
+        GraphQuery::ImportClosure { module, .. } => {
+            // Find all nodes that import the given module
+            let indices = graph.bfs_blast_radius(module, 1);
+            indices
+                .iter()
+                .map(|idx| {
+                    let node = graph.0[*idx].clone();
+                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
+                })
+                .collect()
+        }
+        GraphQuery::Subgraph { symbol, .. } => {
+            let indices = graph.bfs_blast_radius(symbol, 2);
+            indices
+                .iter()
+                .map(|idx| {
+                    let node = graph.0[*idx].clone();
+                    serde_json::to_value(node).unwrap_or(serde_json::Value::Null)
+                })
+                .collect()
+        }
+    }
+}
+
+/// Return an empty resources list (concrete graph slices are unbounded;
+/// clients use templates).
+pub(crate) fn list_resources_impl(
+    _params: Option<PaginatedRequestParams>,
+    _context: &RequestContext<RoleServer>,
+) -> Result<ListResourcesResult, ErrorData> {
+    Ok(ListResourcesResult::with_all_items(Vec::new()))
+}
+
+/// Return three ResourceTemplate entries for the graph URI scheme.
+pub(crate) fn list_resource_templates_impl(
+    _params: Option<PaginatedRequestParams>,
+    _context: &RequestContext<RoleServer>,
+) -> Result<ListResourceTemplatesResult, ErrorData> {
+    let templates = vec![
+        ResourceTemplate::new(
+            "aptu-coder://graph/{repo_hash}/blast-radius/{symbol}?depth={depth}",
+            "graph-blast-radius",
+        )
+        .with_description("BFS blast-radius traversal from a symbol")
+        .with_mime_type("application/json"),
+        ResourceTemplate::new(
+            "aptu-coder://graph/{repo_hash}/import-closure/{module}",
+            "graph-import-closure",
+        )
+        .with_description("Import closure for a module path")
+        .with_mime_type("application/json"),
+        ResourceTemplate::new(
+            "aptu-coder://graph/{repo_hash}/subgraph/{symbol}",
+            "graph-subgraph",
+        )
+        .with_description("Subgraph centered on a symbol")
+        .with_mime_type("application/json"),
+    ];
+    Ok(ListResourceTemplatesResult::with_all_items(templates))
+}
+
+/// Read a graph resource identified by URI.
+///
+/// Parses the URI, loads the graph from disk store, dispatches to the query
+/// helper, paginates, and returns a `ReadResourceResponse::Complete`.
+pub(crate) fn read_resource_impl(
+    request: ReadResourceRequestParams,
+    graph_store: &GraphDiskStore,
+) -> Result<ReadResourceResponse, ErrorData> {
+    // Parse URI to get the query and repo_hash
+    let rest = request.uri.strip_prefix("aptu-coder://").ok_or_else(|| {
+        ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!(
+                "invalid URI scheme: expected aptu-coder://, got {}",
+                request.uri
+            ),
+            None,
+        )
+    })?;
+    let (path_part, _cursor_offset) = if let Some(pos) = rest.find('?') {
+        (&rest[..pos], 0)
+    } else {
+        (rest, 0)
+    };
+    let segments: Vec<&str> = path_part.split('/').collect();
+    if segments.len() < 4 || segments[0] != "graph" {
+        return Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("invalid URI path: {}", request.uri),
+            None,
+        ));
+    }
+    let repo_hash = segments[1];
+
+    // Parse the full query (including cursor from query string)
+    let query = parse_graph_uri(&request.uri)?;
+
+    // Load graph from store
+    let graph = graph_store.get(repo_hash).ok_or_else(|| {
+        ErrorData::new(
+            ErrorCode::RESOURCE_NOT_FOUND,
+            "graph not built yet -- call analyze_symbol on this directory first to build the graph cache".to_string(),
+            None,
+        )
+    })?;
+
+    // Resolve query to nodes
+    let all_nodes = query_to_nodes(&graph, &query);
+    let total = all_nodes.len();
+
+    // Paginate manually
+    let offset = match &query {
+        GraphQuery::BlastRadius { cursor_offset, .. } => *cursor_offset,
+        GraphQuery::ImportClosure { cursor_offset, .. } => *cursor_offset,
+        GraphQuery::Subgraph { cursor_offset, .. } => *cursor_offset,
+    };
+    let page: Vec<serde_json::Value> = all_nodes
+        .iter()
+        .skip(offset)
+        .take(PAGE_SIZE)
+        .cloned()
+        .collect();
+
+    let next_offset = if offset + PAGE_SIZE < total {
+        Some(offset + PAGE_SIZE)
+    } else {
+        None
+    };
+    let next_cursor = next_offset.map(encode_graph_cursor);
+
+    let payload = serde_json::json!({
+        "nodes": page,
+        "next_cursor": next_cursor,
+        "total": total,
+    });
+
+    let text = serde_json::to_string(&payload).map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            format!("failed to serialize graph payload: {e}"),
+            None,
+        )
+    })?;
+
+    let contents = ResourceContents::text(text, &request.uri).with_mime_type("application/json");
+
+    let result = ReadResourceResult::new(vec![contents]);
+    Ok(ReadResourceResponse::Complete(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptu_coder_core::analyze::FileAnalysisOutput;
+    use aptu_coder_core::types::{FunctionInfo, SemanticAnalysis};
+
+    /// Build a graph with `caller` and `callee` symbols connected by a Calls edge.
+    /// `bfs_blast_radius` on `caller` at depth>=1 will return `callee`.
+    fn make_graph_with_call(caller: &str, callee: &str) -> StructuralGraph {
+        let mut f1 = FunctionInfo::default();
+        f1.name = caller.to_string();
+        f1.line = 1;
+        f1.end_line = 5;
+        let mut f2 = FunctionInfo::default();
+        f2.name = callee.to_string();
+        f2.line = 10;
+        f2.end_line = 15;
+        // CallInfo is #[non_exhaustive] with no Default or new(); deserialize from JSON.
+        use aptu_coder_core::types::CallInfo;
+        let call: CallInfo = serde_json::from_str(&format!(
+            r#"{{"caller":"{caller}","callee":"{callee}","line":1,"column":0}}"#
+        ))
+        .expect("valid call JSON");
+        let analysis = SemanticAnalysis::new(
+            vec![f1, f2],
+            vec![],
+            vec![],
+            vec![],
+            Default::default(),
+            vec![call],
+            vec![],
+        );
+        let entry = FileAnalysisOutput::new("test.rs:1:1:1".to_string(), analysis, 15, None);
+        StructuralGraph::build_from_analysis(&[entry])
+    }
+
+    fn make_graph_with_node(name: &str) -> StructuralGraph {
+        let mut func = FunctionInfo::default();
+        func.name = name.to_string();
+        func.line = 1;
+        func.end_line = 5;
+        let analysis = SemanticAnalysis::new(
+            vec![func],
+            vec![],
+            vec![],
+            vec![],
+            Default::default(),
+            vec![],
+            vec![],
+        );
+        let entry = FileAnalysisOutput::new("test.rs:1:1:1".to_string(), analysis, 10, None);
+        StructuralGraph::build_from_analysis(&[entry])
+    }
+
+    #[test]
+    fn test_parse_graph_uri_blast_radius_happy_path() {
+        let uri = "aptu-coder://graph/abc123/blast-radius/my_func";
+        let query = parse_graph_uri(uri).unwrap();
+        assert_eq!(
+            query,
+            GraphQuery::BlastRadius {
+                symbol: "my_func".to_string(),
+                depth: 3,
+                cursor_offset: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_graph_uri_invalid_scheme() {
+        let uri = "file:///path/to/file";
+        let result = parse_graph_uri(uri);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("invalid URI scheme"));
+    }
+
+    #[test]
+    fn test_parse_graph_uri_unknown_query_type() {
+        let uri = "aptu-coder://graph/abc123/unknown/foo";
+        let result = parse_graph_uri(uri);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("unknown query type"));
+    }
+
+    #[test]
+    fn test_encode_decode_graph_cursor_roundtrip() {
+        let token = encode_graph_cursor(42);
+        assert_eq!(decode_graph_cursor(&token), Some(42));
+
+        // Zero offset
+        let token = encode_graph_cursor(0);
+        assert_eq!(decode_graph_cursor(&token), Some(0));
+
+        // Large offset
+        let token = encode_graph_cursor(9999);
+        assert_eq!(decode_graph_cursor(&token), Some(9999));
+    }
+
+    #[test]
+    fn test_parse_graph_uri_with_cursor() {
+        let token = encode_graph_cursor(50);
+        let uri = format!("aptu-coder://graph/abc123/blast-radius/my_func?cursor={token}");
+        let query = parse_graph_uri(&uri).unwrap();
+        assert_eq!(
+            query,
+            GraphQuery::BlastRadius {
+                symbol: "my_func".to_string(),
+                depth: 3,
+                cursor_offset: 50
+            }
+        );
+    }
+
+    #[test]
+    fn test_decode_graph_cursor_rejects_garbage() {
+        assert_eq!(decode_graph_cursor("not-valid-base64"), None);
+        assert_eq!(decode_graph_cursor(""), None);
+    }
+
+    #[test]
+    fn test_query_to_nodes_found_symbol() {
+        // bfs_blast_radius returns NEIGHBORS of the start node, not the node itself.
+        // Use a graph with a Calls edge so the BFS returns the callee.
+        let graph = make_graph_with_call("caller_func", "callee_func");
+        let query = GraphQuery::BlastRadius {
+            symbol: "caller_func".to_string(),
+            depth: 3,
+            cursor_offset: 0,
+        };
+        let nodes = query_to_nodes(&graph, &query);
+        assert!(!nodes.is_empty());
+    }
+
+    #[test]
+    fn test_read_resource_impl_cold_cache_miss() {
+        // A temp dir for the store (empty, no data)
+        let tmp = std::env::temp_dir().join("aptu-coder-test-resources");
+        let _ = std::fs::create_dir_all(&tmp);
+        let store = GraphDiskStore::new(tmp.clone());
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let request =
+            ReadResourceRequestParams::new("aptu-coder://graph/abc123/blast-radius/my_func");
+        let result = read_resource_impl(request, &store);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("graph not built yet"),
+            "expected 'graph not built yet' error, got: {}",
+            err.message
+        );
+    }
+}

--- a/crates/aptu-coder/src/tools/resources.rs
+++ b/crates/aptu-coder/src/tools/resources.rs
@@ -179,7 +179,7 @@ fn query_to_nodes(graph: &StructuralGraph, query: &GraphQuery) -> Vec<serde_json
     };
     indices
         .into_iter()
-        .filter_map(|idx| serde_json::to_value(graph.0[idx].clone()).ok())
+        .filter_map(|idx| serde_json::to_value(&graph.0[idx]).ok())
         .collect()
 }
 

--- a/crates/aptu-coder/src/tools/server.rs
+++ b/crates/aptu-coder/src/tools/server.rs
@@ -97,6 +97,13 @@ pub(crate) fn build_analyzer(
 
     let filter_table = Arc::new(load_filter_table(Path::new(".")));
 
+    // Graph disk store uses the same base directory as DiskCache
+    let graph_store_dir = std::env::var("APTU_CODER_DISK_CACHE_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| xdg_data_home.join("aptu-coder").join("analysis-cache"));
+    let graph_store =
+        std::sync::Arc::new(aptu_coder_core::graph::GraphDiskStore::new(graph_store_dir));
+
     crate::CodeAnalyzer {
         tool_router: Arc::new(RwLock::new(crate::CodeAnalyzer::tool_router())),
         cache: AnalysisCache::new(file_cap),
@@ -116,6 +123,7 @@ pub(crate) fn build_analyzer(
             ))
         },
         edit_failure_counts: Arc::new(Mutex::new(HashMap::new())),
+        graph_store,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the MCP Resource surface for the structural knowledge graph built in #1367, as specified in issue #1363 (KG8).

### What this adds

- `resources/list`: returns empty concrete list; clients use resource templates
- `resources/templates/list`: three `ResourceTemplate` entries:
  - `aptu-coder://graph/{repo_hash}/blast-radius/{symbol}?depth={depth}` -- BFS blast-radius
  - `aptu-coder://graph/{repo_hash}/import-closure/{module}` -- import closure
  - `aptu-coder://graph/{repo_hash}/subgraph/{symbol}` -- 2-hop subgraph
- `resources/read`: parses URI, loads `StructuralGraph` from `GraphDiskStore`, dispatches query, paginates (50 nodes/page), returns `ReadResourceResponse::Complete` with graph JSON as `TextResourceContents` (`application/json`)

### URI scheme

`aptu-coder://graph/{repo_hash}/{query_type}/{arg}?cursor=...&depth=N`

- `{repo_hash}`: `GraphDiskStore::cache_key` for the directory; carried inside `GraphQuery` variants and used as the store lookup key in `read_resource_impl`
- `?cursor=`: opaque base64url `{"g":N}` token; namespace-scoped to prevent mixing with `analyze_symbol` cursors; invalid token returns `INVALID_PARAMS`
- `?depth=N`: BFS traversal depth for blast-radius queries (default: 3)

### Cold-cache / stale-hash behavior

`GraphDiskStore::get` returns `None` for any unknown key (including a stale repo_hash). `resources/read` returns: _"graph not built yet -- call analyze_symbol on this directory first"_.

### Deferred (tracked in #998)

- `ttlMs`/`cacheScope` (SEP-2549)
- `subscriptions/listen` invalidation
- Optional JSONL export

### Files changed

- `crates/aptu-coder-core/src/graph/mod.rs`: `pub use` re-exports for `StructuralGraph`, `GraphDiskStore`, `Node`, `Edge`, `SymbolKind`
- `crates/aptu-coder/Cargo.toml`: `base64` dependency
- `crates/aptu-coder/src/tools/resources.rs` (new): `GraphQuery` enum (with `repo_hash` field on each variant), `GraphQuery::repo_hash()` and `cursor_offset()` accessors, cursor encode/decode, `parse_graph_uri`, `query_to_nodes`, `list_resources_impl`, `list_resource_templates_impl`, `read_resource_impl` -- 8 unit tests
- `crates/aptu-coder/src/tools/mod.rs`: `pub(crate) mod resources`
- `crates/aptu-coder/src/tools/server.rs`: `GraphDiskStore` field on `CodeAnalyzer`
- `crates/aptu-coder/src/lib.rs`: `enable_resources()` + three `ServerHandler` shims

### Post-review changes

- `refactor(kg): eliminate DRY violations in resource handler` (8818abb): `repo_hash` moved into `GraphQuery` variants so `read_resource_impl` calls `parse_graph_uri` once; `GraphQuery::repo_hash()` and `cursor_offset()` accessors eliminate repeated match arms; three identical index-to-JSON map bodies in `query_to_nodes` collapsed into a single shared iterator; `encode_graph_cursor` rewritten with `format!()` instead of serde round-trip; unused test helper removed (-147 / +79 lines)
- `perf(kg): avoid clone in query_to_nodes by serializing from reference` (31d3fba): `serde_json::to_value(&graph.0[idx])` -- shared reference, no allocation

### Constraints honored

- No `PaginationMode::GraphQuery` variant
- No private graph-build helper calls from `resources.rs`
- `enable_resources()` only (no subscribe/list-changed)
- `ttl_ms` / `cache_scope` unset
- Graph JSON as `TextResourceContents` (`application/json`)
- Invalid cursor returns `INVALID_PARAMS`
- Cursor in URI query string, namespace-scoped

Closes #1363

## Test plan
- [x] Tests pass
- [x] Linter clean
- [x] Security scan clean
