### PR TITLE
docs: update documentation for knowledge graph MCP resources and fix stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Rust workspace with two crates:
 
 - `crates/aptu-coder-core` -- parsing, analysis, formatting, graph, pagination, types
-- `crates/aptu-coder` -- MCP server, tool handlers, logging, metrics
+- `crates/aptu-coder` -- MCP server, tool handlers, logging, metrics, MCP Resources surface (list_resources, list_resource_templates, read_resource in crates/aptu-coder/src/tools/resources.rs)
 
 Seven MCP tools: `analyze_directory`, `analyze_file`, `analyze_module`, `analyze_symbol` (analyze_* family); `edit_overwrite`, `edit_replace` (edit_* family); `exec_command` (exec_* family).
 Rust edition 2024, async with tokio, latest MCP protocol via `rmcp`. Supported languages are listed in `crates/aptu-coder-core/src/lang.rs`.
@@ -89,6 +89,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `exec_command` accepts an optional `drain_timeout_secs` (integer >= 0; 0 or omitted means 500ms default, negative = INVALID_PARAMS, positive = drain window in milliseconds). Controls how long the post-exit drain waits for a background subprocess holding pipes open before returning `output_truncated: true`.
 - `analyze_symbol` uses an L2 on-disk call-graph cache in addition to the L1 in-memory LRU. Configure with `APTU_CODER_DISK_CACHE_DIR` (default: `$XDG_DATA_HOME/aptu-coder/analysis-cache`); disable with `APTU_CODER_DISK_CACHE_DISABLED=1`.
 - `call_frequency` on `analyze_symbol` is filtered out when the `Functions` field is not in the projected fields set.
+- MCP Resource URI templates use `{repo_hash}` (blake3 hash of the canonical directory path), `depth` query parameter (integer, default 3), and `cursor` (base64url-encoded `{"g": <page_number>}`). Resources are paginated at 50 nodes per page. Cold cache returns a message recommending `analyze_symbol` first.
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 
 ## Do not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Canonical parameter lists live in the `types` module (`crates/aptu-coder-core/sr
 - `exec_command` accepts an optional `drain_timeout_secs` (integer >= 0; 0 or omitted means 500ms default, negative = INVALID_PARAMS, positive = drain window in milliseconds). Controls how long the post-exit drain waits for a background subprocess holding pipes open before returning `output_truncated: true`.
 - `analyze_symbol` uses an L2 on-disk call-graph cache in addition to the L1 in-memory LRU. Configure with `APTU_CODER_DISK_CACHE_DIR` (default: `$XDG_DATA_HOME/aptu-coder/analysis-cache`); disable with `APTU_CODER_DISK_CACHE_DISABLED=1`.
 - `call_frequency` on `analyze_symbol` is filtered out when the `Functions` field is not in the projected fields set.
-- MCP Resource URI templates use `{repo_hash}` (blake3 hash of the canonical directory path), `depth` query parameter (integer, default 3), and `cursor` (base64url-encoded `{"g": <page_number>}`). Resources are paginated at 50 nodes per page. Cold cache returns a message recommending `analyze_symbol` first.
+- MCP Resource URI templates use `{repo_hash}` (blake3 hash of the canonical directory path), `depth` query parameter (integer, default 3), and `cursor` (opaque pagination token). Resources are paginated. Cold cache returns a message recommending `analyze_symbol` first.
 Escalate to `analyze_symbol` when: (1) you need all callers of a function, (2) you need the full call chain for a symbol, (3) you need all files importing a module path (use `import_lookup=true`).
 
 ## Do not

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -114,8 +114,7 @@ support was removed following
 [MCP SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577),
 which deprecated the Logging protocol feature at the spec level.
 
-To control the log level, set `RUST_LOG` (e.g. `RUST_LOG=warn`) or pass
-`--log-level <level>` on the CLI. The default level is WARN.
+To control the log level, set `RUST_LOG` (e.g. `RUST_LOG=warn`). The default level is WARN.
 
 At DEBUG level, some log events include filesystem paths (from cache and analysis
 operations). These are not secrets, but they do reveal filesystem structure including
@@ -138,4 +137,8 @@ They carry no value payload, only their occurrence:
 - [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status)
 - [OTel MCP semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)
 - [OTel Collector redaction processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)
-- Observability roadmap: [ROADMAP.md](ROADMAP.md), milestone `observability-v1`
+- Observability roadmap: [docs/ROADMAP.md](docs/ROADMAP.md), milestone `observability-v1`
+
+## Resources surface
+
+The MCP Resources surface (`crates/aptu-coder/src/tools/resources.rs`) currently emits no `MetricEvent` spans. Resource reads (`read_resource`) are not instrumented with the same observability as tool calls. This means resource read latency, cache hit rates, and error rates are not recorded in the JSONL metrics or OTel traces. This is a known gap; resource reads will be instrumented in a future wave.

--- a/README.md
+++ b/README.md
@@ -39,28 +39,26 @@ aptu-coder is a Model Context Protocol server that gives AI agents precise struc
 
 ## Supported Languages
 
-All languages are enabled by default. Disable individual languages at compile time via Cargo feature flags.
-
-| Language | Extensions | Feature flag |
-|----------|------------|--------------|
-| Astro | `.astro` | always-on (regex via TypeScript frontmatter extractor) |
-| C/C++ | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` | `lang-cpp` |
-| C# | `.cs` | `lang-csharp` |
-| CSS | `.css` | `lang-css` (tree-sitter; regex fallback when disabled) |
-| Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` | `lang-fortran` |
-| Go | `.go` | `lang-go` |
-| HTML | `.html`, `.htm` | `lang-html` (stub; no extraction) |
-| Java | `.java` | `lang-java` |
-| JavaScript | `.js`, `.mjs`, `.cjs` | `lang-javascript` |
-| JSON | `.json` | always-on (regex; first-level key extraction) |
-| Kotlin | `.kt`, `.kts` | `lang-kotlin` |
-| Markdown | `.md`, `.mdx` | `lang-markdown` |
-| Python | `.py` | `lang-python` |
-| Rust | `.rs` | `lang-rust` |
-| TOML | `.toml` | always-on (regex; section header extraction) |
-| TSX | `.tsx` | `lang-tsx` |
-| TypeScript | `.ts` | `lang-typescript` |
-| YAML | `.yaml`, `.yml` | `lang-yaml` (tree-sitter; regex fallback when disabled) |
+| Language | Extensions |
+|----------|------------|
+| Astro | `.astro` |
+| C/C++ | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hpp`, `.hxx` |
+| C# | `.cs` |
+| CSS | `.css` |
+| Fortran | `.f`, `.f77`, `.f90`, `.f95`, `.f03`, `.f08`, `.for`, `.ftn` |
+| Go | `.go` |
+| HTML | `.html`, `.htm` |
+| Java | `.java` |
+| JavaScript | `.js`, `.mjs`, `.cjs` |
+| JSON | `.json` |
+| Kotlin | `.kt`, `.kts` |
+| Markdown | `.md`, `.mdx` |
+| Python | `.py` |
+| Rust | `.rs` |
+| TOML | `.toml` |
+| TSX | `.tsx` |
+| TypeScript | `.ts` |
+| YAML | `.yaml`, `.yml` |
 
 ## Installation
 
@@ -180,6 +178,24 @@ All optional parameters may be omitted. Shared optional parameters for `analyze_
 
 Tool parameters, constraints, and examples are available via your MCP client's tool inspector or `tools/list` response.
 
+## MCP Resources
+
+The knowledge graph feature exposes three MCP resource templates for navigating the structural graph built during `analyze_symbol` calls. Resources are URI-addressed; use `resources/templates/list` to discover available templates.
+
+| URI Template | Description |
+|---|---|
+| `aptu-coder://graph/{repo_hash}/blast-radius/{symbol}?depth={depth}` | BFS traversal from a symbol outward to configurable depth (default: 3). Returns caller/callee chains in a radial layout. |
+| `aptu-coder://graph/{repo_hash}/import-closure/{module}` | All files that directly or transitively import the given module path. |
+| `aptu-coder://graph/{repo_hash}/subgraph/{symbol}` | The full subgraph (callers, callees, and their connections) for a single symbol. |
+
+**Pagination:** Responses are paginated at 50 nodes per page. Pass `?cursor=<base64url>` with the cursor value from a previous response to fetch the next page. The cursor encoding is `{"g": <page_number>}` in base64url.
+
+**Depth parameter:** The `blast-radius` template accepts an optional `depth` query parameter (integer, default 3). Higher values expand the BFS radius and may produce proportionally larger responses.
+
+**Cold cache:** If the structural graph has not been built yet (no prior `analyze_symbol` call on the directory), the resource returns a message indicating the graph is not available and recommends calling `analyze_symbol` on the directory first.
+
+**No `subscribe`/`list-changed` support:** Resource content is static once computed; no change notification mechanism is provided.
+
 ## Output Management
 
 For large codebases, several mechanisms prevent context overflow.
@@ -245,11 +261,10 @@ The server's own instructions expose a 4-step recommended workflow for unknown r
 | `APTU_CODER_DIR_CACHE_CAPACITY` | `20` | LRU cache size for directory-analysis results. |
 | `APTU_CODER_DISK_CACHE_DIR` | `$XDG_DATA_HOME/aptu-coder/analysis-cache` | Directory for the L2 on-disk call-graph cache used by `analyze_symbol`. Created automatically if it does not exist. |
 | `APTU_CODER_DISK_CACHE_DISABLED` | unset | Set to `1` to disable the L2 disk cache entirely. |
-| `APTU_CODER_EXEC_CACHE_CAPACITY` | `64` | LRU cache size for `exec_command` results. |
-| `APTU_CODER_EXEC_CACHE_TTL_SECS` | `10` | TTL in seconds for `exec_command` result cache. |
 | `APTU_CODER_FILE_CACHE_CAPACITY` | `100` | LRU cache size for file-analysis results. |
 | `APTU_CODER_METRICS_EXPORT_FILE` | unset | Absolute path for a one-shot JSONL metrics export on shutdown. |
 | `APTU_CODER_PORT` | unset | Port for streamable HTTP mode. Equivalent to `--port N`; `--port` takes precedence. When unset and `--port` is not passed, stdio mode is used. |
+| `APTU_CODER_BEARER_TOKEN` | unset | Bearer token for Streamable HTTP transport authentication. A warning is logged if the value is fewer than 32 characters. |
 | `APTU_SHELL` | unset | Shell for `exec_command`. Defaults to `bash` then `/bin/sh`. |
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -188,13 +188,11 @@ The knowledge graph feature exposes three MCP resource templates for navigating 
 | `aptu-coder://graph/{repo_hash}/import-closure/{module}` | All files that directly or transitively import the given module path. |
 | `aptu-coder://graph/{repo_hash}/subgraph/{symbol}` | The full subgraph (callers, callees, and their connections) for a single symbol. |
 
-**Pagination:** Responses are paginated at 50 nodes per page. Pass `?cursor=<base64url>` with the cursor value from a previous response to fetch the next page. The cursor encoding is `{"g": <page_number>}` in base64url.
+**Pagination:** Results are paginated; pass the opaque `cursor` value from a previous response to fetch the next page.
 
-**Depth parameter:** The `blast-radius` template accepts an optional `depth` query parameter (integer, default 3). Higher values expand the BFS radius and may produce proportionally larger responses.
+**Depth parameter:** The `blast-radius` template accepts an optional `depth` query parameter (integer, default 3).
 
-**Cold cache:** If the structural graph has not been built yet (no prior `analyze_symbol` call on the directory), the resource returns a message indicating the graph is not available and recommends calling `analyze_symbol` on the directory first.
-
-**No `subscribe`/`list-changed` support:** Resource content is static once computed; no change notification mechanism is provided.
+**Cold cache:** Call `analyze_symbol` on the directory first to build the graph. Resources return an informational message until the graph is available.
 
 ## Output Management
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,13 +29,14 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `shell` | `crates/aptu-coder/src/shell.rs` | Login shell detection: `resolve_shell` checks `APTU_SHELL` env, then scans `PATH` for `bash`, falls back to `/bin/sh` (Unix) or `cmd` (Windows) |
 | `shell_write` | `crates/aptu-coder/src/shell_write.rs` | Pre-spawn heredoc guard for `exec_command`: `validate_heredocs` (Phase 1 file-write pattern + stdin-consuming flag + `params.stdin` conflict scan, Phase 2 missing closing-delimiter scan); `scan_backward_for_file_write`, `scan_backward_for_stdin_flag` |
 | `validation` | `crates/aptu-coder/src/validation.rs` | Path resolution and boundary enforcement: `validate_path` (CWD-relative), `validate_path_in_dir` (working_dir-relative with traversal prevention), `io_error_to_path_error` |
+| `resources` | `crates/aptu-coder/src/tools/resources.rs` | MCP Resources surface: `list_resources`, `list_resource_templates`, `read_resource` for the knowledge-graph URI templates (blast-radius, import-closure, subgraph); 391 LOC |
 | **`aptu-coder-core`** | | |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `cache` | `crates/aptu-coder-core/src/cache.rs` | Two-tier caching: L1 in-memory LRU (`AnalysisCache`, `CallGraphCache`) with mtime invalidation and lock_or_recover pattern; L2 on-disk call-graph cache (`DiskCache`) keyed by canonical path + git HEAD SHA, configurable via `APTU_CODER_DISK_CACHE_DIR` and `APTU_CODER_DISK_CACHE_DISABLED` |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
-| `formatter` | `crates/aptu-coder-core/src/formatter.rs` | Output formatting for all seven tools |
-| `graph` | `crates/aptu-coder-core/src/graph.rs` | CallGraph struct and BFS traversal for symbol focus mode |
+| `formatter` | `crates/aptu-coder-core/src/formatter/` (emit.rs, mod.rs, pagination.rs, render.rs, summary.rs) | Output formatting for all seven tools; 1705 LOC |
+| `graph` | `crates/aptu-coder-core/src/graph/` (call_graph.rs, mod.rs, store.rs, structural.rs) | CallGraph struct and BFS traversal for symbol focus mode; StructuralGraph (petgraph DiGraph with 3 node types, 6 edge types) for knowledge-graph resource queries; GraphDiskStore (postcard-encoded, 256 blake3 shards, NamedTempFile atomic writes, FORMAT_VERSION=1) for persistent graph cache; 1641 LOC |
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
 | `languages/fortran` | `crates/aptu-coder-core/src/languages/fortran.rs` | Fortran-specific queries and semantic handlers; supports module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`); registers `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` |
 | `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
@@ -193,8 +194,26 @@ Symbol resolution uses SymbolMatchMode to locate the target symbol: Exact (case-
 
 `AnalysisConfig` provides resource limits for library consumers (exported from `aptu_coder_core`):
 
-- `max_file_bytes`: Skip files exceeding this size in bytes during analysis. `None` = no limit.
+- `max_file_bytes`: Reserved for future use (no-op). `None` = no limit.
 - `parse_timeout_micros`: Reserved for future parse timeout enforcement. `None` = no timeout (no-op in current version).
 - `cache_capacity`: Override the default LRU cache capacity. `None` = use default.
 
 Use `AnalysisConfig::default()` for standard behavior with no limits applied.
+
+## MCP Resources
+
+The server exposes three MCP resource templates that surface the knowledge graph built during `analyze_symbol` calls. Resources are URI-addressed and read-only; no `subscribe` or `list-changed` support is provided.
+
+**URI scheme:** `aptu-coder://graph/{repo_hash}/{type}/{path}?{params}`
+
+| Resource Template | Description |
+|---|---|
+| `blast-radius/{symbol}?depth={depth}` | BFS traversal from a symbol outward; depth defaults to 3 |
+| `import-closure/{module}` | Transitive import closure for a module path |
+| `subgraph/{symbol}` | Full subgraph (callers, callees, connections) for a single symbol |
+
+**Pagination:** 50 nodes per page, base64url cursor `{"g": N}`.
+
+**Persistence:** The `GraphDiskStore` persists the structural graph to disk using postcard encoding across 256 blake3 shards with `NamedTempFile` atomic writes. On restart, the graph is reloaded from disk if available. The store silently degrades on I/O errors (returns a message indicating the graph is not available).
+
+**Warm-up requirement:** Resources return a cold-cache message if `analyze_symbol` has not been called on the directory first. The structural graph is built as a side effect of the `analyze_symbol` cold-cache path alongside the existing `CallGraph`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,14 +29,14 @@ For the reasoning behind these goals, see [DESIGN-GUIDE.md](DESIGN-GUIDE.md).
 | `shell` | `crates/aptu-coder/src/shell.rs` | Login shell detection: `resolve_shell` checks `APTU_SHELL` env, then scans `PATH` for `bash`, falls back to `/bin/sh` (Unix) or `cmd` (Windows) |
 | `shell_write` | `crates/aptu-coder/src/shell_write.rs` | Pre-spawn heredoc guard for `exec_command`: `validate_heredocs` (Phase 1 file-write pattern + stdin-consuming flag + `params.stdin` conflict scan, Phase 2 missing closing-delimiter scan); `scan_backward_for_file_write`, `scan_backward_for_stdin_flag` |
 | `validation` | `crates/aptu-coder/src/validation.rs` | Path resolution and boundary enforcement: `validate_path` (CWD-relative), `validate_path_in_dir` (working_dir-relative with traversal prevention), `io_error_to_path_error` |
-| `resources` | `crates/aptu-coder/src/tools/resources.rs` | MCP Resources surface: `list_resources`, `list_resource_templates`, `read_resource` for the knowledge-graph URI templates (blast-radius, import-closure, subgraph); 391 LOC |
+| `resources` | `crates/aptu-coder/src/tools/resources.rs` | MCP Resources surface: `list_resources`, `list_resource_templates`, `read_resource` for the knowledge-graph URI templates (blast-radius, import-closure, subgraph) |
 | **`aptu-coder-core`** | | |
 | `analyze` | `crates/aptu-coder-core/src/analyze.rs` | High-level analysis orchestration; directory, file, and module analysis |
 | `analyze_str` | `crates/aptu-coder-core/src/analyze.rs` | Public in-memory API; parses source text without filesystem access; `AnalyzeError::UnsupportedLanguage` variant |
 | `cache` | `crates/aptu-coder-core/src/cache.rs` | Two-tier caching: L1 in-memory LRU (`AnalysisCache`, `CallGraphCache`) with mtime invalidation and lock_or_recover pattern; L2 on-disk call-graph cache (`DiskCache`) keyed by canonical path + git HEAD SHA, configurable via `APTU_CODER_DISK_CACHE_DIR` and `APTU_CODER_DISK_CACHE_DISABLED` |
 | `completion` | `crates/aptu-coder-core/src/completion.rs` | Path completion support respecting .gitignore |
-| `formatter` | `crates/aptu-coder-core/src/formatter/` (emit.rs, mod.rs, pagination.rs, render.rs, summary.rs) | Output formatting for all seven tools; 1705 LOC |
-| `graph` | `crates/aptu-coder-core/src/graph/` (call_graph.rs, mod.rs, store.rs, structural.rs) | CallGraph struct and BFS traversal for symbol focus mode; StructuralGraph (petgraph DiGraph with 3 node types, 6 edge types) for knowledge-graph resource queries; GraphDiskStore (postcard-encoded, 256 blake3 shards, NamedTempFile atomic writes, FORMAT_VERSION=1) for persistent graph cache; 1641 LOC |
+| `formatter` | `crates/aptu-coder-core/src/formatter/` (emit.rs, mod.rs, pagination.rs, render.rs, summary.rs) | Output formatting for all seven tools |
+| `graph` | `crates/aptu-coder-core/src/graph/` (call_graph.rs, mod.rs, store.rs, structural.rs) | `CallGraph` and BFS traversal for symbol focus mode; `StructuralGraph` for knowledge-graph resource queries; `GraphDiskStore` for persistent graph cache |
 | `lang` | `crates/aptu-coder-core/src/lang.rs` | Extension-to-language mapping |
 | `languages/fortran` | `crates/aptu-coder-core/src/languages/fortran.rs` | Fortran-specific queries and semantic handlers; supports module extraction, subroutine/function name extraction, Fortran 2003+ OOP bound procedure calls (`obj%method()`); registers `extract_function_name`, `find_receiver_type`, and `find_method_for_receiver` |
 | `languages/kotlin` | `crates/aptu-coder-core/src/languages/kotlin.rs` | Kotlin-specific queries and semantic handlers; supports `.kt` and `.kts` extensions |
@@ -212,8 +212,8 @@ The server exposes three MCP resource templates that surface the knowledge graph
 | `import-closure/{module}` | Transitive import closure for a module path |
 | `subgraph/{symbol}` | Full subgraph (callers, callees, connections) for a single symbol |
 
-**Pagination:** 50 nodes per page, base64url cursor `{"g": N}`.
+**Pagination:** Results are paginated; pass the opaque `cursor` value from a previous response to fetch the next page.
 
-**Persistence:** The `GraphDiskStore` persists the structural graph to disk using postcard encoding across 256 blake3 shards with `NamedTempFile` atomic writes. On restart, the graph is reloaded from disk if available. The store silently degrades on I/O errors (returns a message indicating the graph is not available).
+**Persistence:** `GraphDiskStore` persists the structural graph to disk. On restart the graph is reloaded if available; I/O errors degrade silently.
 
-**Warm-up requirement:** Resources return a cold-cache message if `analyze_symbol` has not been called on the directory first. The structural graph is built as a side effect of the `analyze_symbol` cold-cache path alongside the existing `CallGraph`.
+**Warm-up requirement:** Resources return a cold-cache message if `analyze_symbol` has not been called on the directory first. The structural graph is built as a side effect of the `analyze_symbol` cold-cache path.

--- a/docs/ASSURANCE.md
+++ b/docs/ASSURANCE.md
@@ -12,23 +12,29 @@ aptu-coder is a static analysis server that parses source files using tree-sitte
 |---|---|---|
 | Local file system | Inbound | Source files provided by the MCP client via `path` arguments |
 | stdio (MCP protocol) | Bidirectional | JSON-RPC requests from the client; JSON responses from the server |
+| Streamable HTTP listener | Inbound | When `--port` or `APTU_CODER_PORT` is set, the server binds to `127.0.0.1:PORT` and serves MCP requests over HTTP |
+| OTLP exporter | Outbound | When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the server exports traces, logs, and metrics to the configured collector endpoint via OTLP/HTTP |
 
-The server makes no outbound network calls, holds no credentials, and writes no persistent state. See [ARCHITECTURE.md](ARCHITECTURE.md) for the full data flow.
+In the default stdio transport mode, the server makes no outbound network calls, holds no credentials, and writes no persistent state. See [ARCHITECTURE.md](ARCHITECTURE.md) for the full data flow.
+
+**Outbound network calls:** In the default stdio transport, the server makes no outbound network calls. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the OpenTelemetry exporter sends traces, logs, and metrics to the configured collector endpoint via OTLP/HTTP.
+
+**Network listener:** In the default stdio transport, there is no network listener. When `--port` or `APTU_CODER_PORT` is set, the server binds to `127.0.0.1:PORT` and serves MCP requests over the Streamable HTTP transport.
 
 ## Attack surface
 
 The only meaningful attack surface is **malformed or adversarially crafted source files** fed to tree-sitter. tree-sitter performs error recovery by design and never panics or executes the parsed content. The server does not eval, exec, or interpret any analyzed file.
 
-There is no network listener, no database, no deserialization of untrusted network data, and no privilege escalation path.
+There is no database, no deserialization of untrusted network data, and no privilege escalation path. In stdio mode, there is no network listener. When Streamable HTTP is enabled (`--port` or `APTU_CODER_PORT`), the listener binds to `127.0.0.1` only (loopback, not `0.0.0.0`).
 
 ## Common weaknesses countered
 
 | Weakness | Status |
 |---|---|
 | SQL injection | Not applicable -- no database |
-| Shell injection | Not applicable -- no shell exec |
+| Shell injection | Not applicable -- no shell exec in analysis tools; `exec_command` is intentionally separate and runs only when explicitly called |
 | Deserialization of untrusted data | Not applicable -- no network input; only local files parsed by tree-sitter |
-| Network I/O vulnerabilities | Not applicable -- no network I/O |
+| Network I/O vulnerabilities | Not applicable in stdio mode (default). When Streamable HTTP is enabled, the listener is bound to `127.0.0.1` only. When OTLP export is enabled, outbound HTTP is limited to the configured collector endpoint. |
 | Credential exposure | Not applicable -- no credentials or secrets handled |
 
 ## Supply chain hardening

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -239,7 +239,35 @@ Parameter documentation flows through schemars: `///` doc comments on struct fie
 
 **`format:uint` footgun:** schemars emits `"format": "uint"` or `"format": "uint32"` for unsigned integers by default. These formats are non-standard JSON Schema and are ignored or flagged by strict validators. Override them via `schema_with` (see `crates/aptu-coder-core/src/schema_helpers.rs`) for any numeric field where validator compatibility matters.
 
-## 8. Anti-Patterns
+## 8. MCP Resources Design
+
+MCP Resources provide a URI-addressed read-only data surface alongside tools. The knowledge graph feature in this server (PRs #1367, #1368) introduced three resource templates as a second access path to the structural graph that `analyze_symbol` builds.
+
+### Small-Model-First URI Design
+
+**Principle:** Resource URI templates must be self-documenting. A small model reading the template description should be able to construct a valid URI without examples.
+
+*Example: The three resource templates use flat, descriptive paths: `blast-radius/{symbol}`, `import-closure/{module}`, `subgraph/{symbol}`. The `{repo_hash}` prefix is a technical identifier the model never needs to construct manually -- it is returned by the initial `analyze_symbol` response. Template descriptions include the exact URI pattern and the expected response shape.*
+
+### Prescriptive Resource Template Descriptions
+
+**Principle:** Resource template descriptions must state the URI pattern, the required and optional parameters, and the expected response shape. They must also state when the resource is not available (cold cache) and what action the model should take.
+
+*Example: The blast-radius template description includes: the URI pattern with `{repo_hash}` and `{symbol}` placeholders, the optional `depth` query parameter and its default, the pagination format, and a note that the graph must be built first via `analyze_symbol`.*
+
+### Pagination Conventions
+
+**Principle:** Resource pagination should follow the same cursor-based convention as tool pagination. The cursor encoding must be documented in the template description.
+
+*Example: Resource responses use a base64url-encoded cursor `{"g": N}` (page number), with 50 nodes per page. The `next_cursor` field follows the same shape as tool pagination cursors, so models that already understand pagination from tools can apply the same pattern to resources.*
+
+### New Server Checklist Extension
+
+Add to the New Server checklist (Section 9, step 13):
+
+13. **Add MCP resource templates (if applicable).** Resources are URI-addressed, read-only data surfaces. Follow the same design principles as tools: prescriptive descriptions, cursor pagination, cold-cache guidance. Resource templates are discoverable via `resources/templates/list`; the `resources/list` endpoint may return empty if all resources are template-based.
+
+## 9. Anti-Patterns
 
 The following anti-patterns were identified across benchmark waves and wave post-mortems.
 

--- a/docs/DESIGN-GUIDE.md
+++ b/docs/DESIGN-GUIDE.md
@@ -241,7 +241,7 @@ Parameter documentation flows through schemars: `///` doc comments on struct fie
 
 ## 8. MCP Resources Design
 
-MCP Resources provide a URI-addressed read-only data surface alongside tools. The knowledge graph feature in this server (PRs #1367, #1368) introduced three resource templates as a second access path to the structural graph that `analyze_symbol` builds.
+MCP Resources provide a URI-addressed read-only data surface alongside tools. The knowledge graph feature introduced three resource templates as a second access path to the structural graph that `analyze_symbol` builds.
 
 ### Small-Model-First URI Design
 
@@ -259,7 +259,7 @@ MCP Resources provide a URI-addressed read-only data surface alongside tools. Th
 
 **Principle:** Resource pagination should follow the same cursor-based convention as tool pagination. The cursor encoding must be documented in the template description.
 
-*Example: Resource responses use a base64url-encoded cursor `{"g": N}` (page number), with 50 nodes per page. The `next_cursor` field follows the same shape as tool pagination cursors, so models that already understand pagination from tools can apply the same pattern to resources.*
+*Example: Resource responses use an opaque cursor in the same shape as tool pagination cursors, so models that already understand pagination from tools can apply the same pattern to resources.*
 
 ### New Server Checklist Extension
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,6 +49,26 @@ Key changes:
 
 2x2 factorial design (model x tool_set) on Rust trait implementations (ripgrep). See [v14 methodology](benchmarks/v14/methodology.md).
 
+### [Complete] Wave 9: Editing Tools [Complete]
+
+Added `edit_overwrite` and `edit_replace` to complete the read-analyze-write loop (#664, #665). `analyze_raw`, `edit_rename`, and `edit_insert` were removed in #779 due to limited adoption. Write tools carry `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`; `exec_command` additionally sets `openWorldHint=true`.
+
+### [Complete] Benchmark v15
+
+2x2 factorial design (model x tool_set) on a Python auth migration task (Django). See [v15 methodology](benchmarks/v15/methodology.md). Sonnet savings: 59% fewer tokens, 59% cheaper. Haiku savings: 14% fewer tokens, 21% cheaper. Validated MCP tooling for Python web frameworks.
+
+### [Complete] Benchmark v16
+
+2x2 factorial design (model x tool_set) on a Fortran aeroelastic audit task (AeroDyn). See [v16 methodology](benchmarks/v16/methodology.md). Sonnet savings: 46% fewer tokens, 42% cheaper. Haiku savings: 68% fewer tokens, 68% cheaper. Validated MCP tooling for scientific Fortran HPC repositories.
+
+### [Complete] Benchmark wave10
+
+Benchmark wave targeting the non-Sonnet model performance gap identified in v10. See [wave10 methodology](benchmarks/wave10/methodology.md). Validated that the gap was closed through server-side improvements (pagination, actionable errors, sequential server instructions).
+
+### [Complete] Benchmark wave11
+
+Benchmark wave validating cross-model consistency. See [wave11 methodology](benchmarks/wave11/methodology.md). Confirmed that small-model improvements from wave10 held across additional model families.
+
 ### [Complete] observability-v1
 
 Full observability stack shipped across #820–#824:
@@ -184,16 +204,29 @@ Hardcoded protocol version string replaced with `ProtocolVersion::LATEST`.
 
 `server/discover` RPC implemented (MCP SEP-2575).
 
+### [Complete] Knowledge Graph: structural module (#1367)
+
+Added `StructuralGraph` backed by `petgraph::DiGraph` with three node types (`File`, `Symbol { SymbolKind }`, `Module`) and six edge types (`Contains`, `Calls`, `Imports`, `Implements`, `HasMethod`, `Tests`). Introduced `GraphDiskStore` for persistent graph cache: postcard-encoded, 256 blake3 shards, `NamedTempFile` atomic writes, `FORMAT_VERSION=1` header, silent degrade on I/O errors. New directory `crates/aptu-coder-core/src/graph/` with `call_graph.rs`, `mod.rs`, `store.rs`, `structural.rs`. Wired into `analyze_focused.rs` -- builds `StructuralGraph` on cold cache miss alongside existing `CallGraph`.
+
+### [Complete] Knowledge Graph: MCP resource surface (#1368)
+
+Three MCP resource templates added in `crates/aptu-coder/src/tools/resources.rs` (391 LOC):
+- `aptu-coder://graph/{repo_hash}/blast-radius/{symbol}?depth={depth}` -- BFS traversal, default depth=3
+- `aptu-coder://graph/{repo_hash}/import-closure/{module}` -- transitive import closure
+- `aptu-coder://graph/{repo_hash}/subgraph/{symbol}` -- full subgraph for a symbol
+
+Pagination: 50 nodes/page, base64url cursor `{"g": N}`. Cold cache returns a message recommending `analyze_symbol` first. `enable_resources()` wired into server capabilities; no `subscribe`/`list-changed` support. No new MCP tools.
+
 ---
 
 ## Direction (Tentative)
 
+Shipped (v0.26.x):
+
+- Knowledge graph: structural module (#1367) and MCP resource surface (#1368) shipped in v0.26.x.
+
 Unimplemented and pertinent:
 
 - MCP SEP adoption: #1487 (`trustedHint`), #1561 (`unsafeOutputHint`), #1913 (trust/sensitivity annotations), #1984 (governance annotations) -- open upstream; no action until specs stabilize. #1560 (`secretHint`) closed 2026-03-23; evaluate adoption once merged into spec.
-
-## Wave 9: Editing Tools [Complete]
-
-Added `edit_overwrite` and `edit_replace` to complete the read-analyze-write loop (#664, #665). `analyze_raw`, `edit_rename`, and `edit_insert` were removed in #779 due to limited adoption. Write tools carry `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`; `exec_command` additionally sets `openWorldHint=true`.
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,11 +55,11 @@ Added `edit_overwrite` and `edit_replace` to complete the read-analyze-write loo
 
 ### [Complete] Benchmark v15
 
-2x2 factorial design (model x tool_set) on a Python auth migration task (Django). See [v15 methodology](benchmarks/v15/methodology.md). Sonnet savings: 59% fewer tokens, 59% cheaper. Haiku savings: 14% fewer tokens, 21% cheaper. Validated MCP tooling for Python web frameworks.
+2x2 factorial design (model x tool_set) on a Python auth migration task (Django). See [v15 methodology](benchmarks/v15/methodology.md). Validated MCP tooling for Python web frameworks.
 
 ### [Complete] Benchmark v16
 
-2x2 factorial design (model x tool_set) on a Fortran aeroelastic audit task (AeroDyn). See [v16 methodology](benchmarks/v16/methodology.md). Sonnet savings: 46% fewer tokens, 42% cheaper. Haiku savings: 68% fewer tokens, 68% cheaper. Validated MCP tooling for scientific Fortran HPC repositories.
+2x2 factorial design (model x tool_set) on a Fortran aeroelastic audit task (AeroDyn). See [v16 methodology](benchmarks/v16/methodology.md). Validated MCP tooling for scientific Fortran HPC repositories.
 
 ### [Complete] Benchmark wave10
 
@@ -206,24 +206,22 @@ Hardcoded protocol version string replaced with `ProtocolVersion::LATEST`.
 
 ### [Complete] Knowledge Graph: structural module (#1367)
 
-Added `StructuralGraph` backed by `petgraph::DiGraph` with three node types (`File`, `Symbol { SymbolKind }`, `Module`) and six edge types (`Contains`, `Calls`, `Imports`, `Implements`, `HasMethod`, `Tests`). Introduced `GraphDiskStore` for persistent graph cache: postcard-encoded, 256 blake3 shards, `NamedTempFile` atomic writes, `FORMAT_VERSION=1` header, silent degrade on I/O errors. New directory `crates/aptu-coder-core/src/graph/` with `call_graph.rs`, `mod.rs`, `store.rs`, `structural.rs`. Wired into `analyze_focused.rs` -- builds `StructuralGraph` on cold cache miss alongside existing `CallGraph`.
+Added `StructuralGraph` and `GraphDiskStore` in `crates/aptu-coder-core/src/graph/`. The structural graph models files, symbols, and modules as nodes with typed edges (contains, calls, imports, implements, etc.). The disk store persists the graph alongside the call-graph cache and degrades silently on I/O errors. Built as a side effect of the `analyze_symbol` cold-cache path.
 
 ### [Complete] Knowledge Graph: MCP resource surface (#1368)
 
-Three MCP resource templates added in `crates/aptu-coder/src/tools/resources.rs` (391 LOC):
+Three MCP resource templates added in `crates/aptu-coder/src/tools/resources.rs`:
 - `aptu-coder://graph/{repo_hash}/blast-radius/{symbol}?depth={depth}` -- BFS traversal, default depth=3
 - `aptu-coder://graph/{repo_hash}/import-closure/{module}` -- transitive import closure
 - `aptu-coder://graph/{repo_hash}/subgraph/{symbol}` -- full subgraph for a symbol
 
-Pagination: 50 nodes/page, base64url cursor `{"g": N}`. Cold cache returns a message recommending `analyze_symbol` first. `enable_resources()` wired into server capabilities; no `subscribe`/`list-changed` support. No new MCP tools.
+Results are paginated via an opaque cursor. Cold cache returns a message recommending `analyze_symbol` first. No new MCP tools.
 
 ---
 
 ## Direction (Tentative)
 
-Shipped (v0.26.x):
-
-- Knowledge graph: structural module (#1367) and MCP resource surface (#1368) shipped in v0.26.x.
+Shipped:
 
 Unimplemented and pertinent:
 


### PR DESCRIPTION
## Summary

Documentation-only update addressing gaps identified after merging the knowledge graph feature. Fixes stale references, adds the MCP Resources surface, and trims version numbers and implementation details for lower maintenance overhead.

## Changes

**README.md**
- Remove stale `lang-*` Cargo feature flag column (all languages unconditionally compiled in)
- Remove non-existent env vars `APTU_CODER_EXEC_CACHE_CAPACITY` and `APTU_CODER_EXEC_CACHE_TTL_SECS`
- Add missing `APTU_CODER_BEARER_TOKEN` env var (Streamable HTTP auth)
- Add MCP Resources section: three URI templates, pagination, depth parameter, cold-cache note

**docs/ARCHITECTURE.md**
- Update Module Map: `formatter` and `graph` are now directories
- Mark `max_file_bytes` as reserved/no-op (consistent with `parse_timeout_micros`)
- Add `resources.rs` to the module listing
- Add MCP Resources subsection: URI scheme, persistence, warm-up requirement

**docs/ROADMAP.md**
- Fix Wave 9 (Editing Tools) chronological position
- Add benchmark waves v15, v16, wave10, wave11
- Add entries for the knowledge graph structural module and MCP resource surface
- Update Direction section

**docs/DESIGN-GUIDE.md**
- Add MCP Resources design posture section: URI naming, template descriptions, pagination conventions, New Server checklist extension

**docs/ASSURANCE.md**
- Fix unconditional "no outbound network calls / no network listener" claims (both are transport-conditional)
- Add Streamable HTTP listener and OTLP exporter to trust boundaries table

**AGENTS.md**
- Document the MCP Resources surface in Project structure
- Add graph-query URI parameters and cursor to Tool parameters constraint list

**OBSERVABILITY.md**
- Remove non-existent `--log-level` CLI flag reference
- Fix broken relative link to `ROADMAP.md`
- Note that the resources surface emits no MetricEvent spans

## Related PRs

Documentation follow-up to #1367 and #1368