### PR TITLE
chore: add path_filters to scope PR review to crates/**

### DIFF
--- a/.github/aptu.yml
+++ b/.github/aptu.yml
@@ -8,3 +8,6 @@ ai:
   provider: openrouter
   model: google/gemma-4-26b-a4b-it
   api-key-secret: OPENROUTER_API_KEY
+path_filters:
+  - "crates/**"
+  - "!**/*.md"


### PR DESCRIPTION
Add `path_filters` to `.github/aptu.yml` to scope PR review dispatch to changes under `crates/**`, and suppress Markdown-only changes.

## Changes

- Include `crates/**`: dispatch review only when a PR touches Rust source
- Exclude `!**/*.md`: skip dispatch for doc-only changes

## Context

`path_filters` was introduced in clouatre-labs/aptu-github-app#82, replacing the exclusion-only `exclude_paths` field. Bare patterns scope review to a directory; `!`-prefixed patterns suppress noise within that scope.