### PR TITLE
fix(cache,tools,docs): must_use on DiskCache methods, tool description updates, AGENTS.md confinement clarification

### DIFF
--- a/crates/aptu-coder-core/src/cache_disk.rs
+++ b/crates/aptu-coder-core/src/cache_disk.rs
@@ -39,12 +39,14 @@ pub struct DiskCache {
 impl DiskCache {
     /// Returns the number of write failures accumulated since the last call and resets the
     /// per-drain counter. The cumulative `total_write_failures` is never reset.
+    #[must_use]
     pub fn drain_write_failures(&self) -> u64 {
         self.write_failures.swap(0, Ordering::Relaxed)
     }
 
     /// Returns true when cumulative write failures have reached `DISK_CACHE_DEGRADED_THRESHOLD`.
     /// Callers can use this to emit a degraded health signal without polling the counter.
+    #[must_use]
     pub fn is_degraded(&self) -> bool {
         self.total_write_failures.load(Ordering::Relaxed) >= DISK_CACHE_DEGRADED_THRESHOLD
     }


### PR DESCRIPTION
## Summary

Adds `#[must_use]` to two `DiskCache` methods so ignored return values are caught at compile time. Trims verbose appends from the `analyze_symbol` and `exec_command` tool descriptions, and restores behavioral wording to the `AGENTS.md` `working_dir` entry.

## Changes

- `DiskCache::drain_write_failures` and `DiskCache::is_degraded` are now annotated `#[must_use]`; callers that discard the result produce a compiler warning. No runtime behavior change.
- `analyze_symbol` description: removed the appended sentences documenting `APTU_CODER_DISK_CACHE_DIR`, `APTU_CODER_DISK_CACHE_DISABLED`, and resource-template warm-up. Operator config and cache topology are not decision signals for the LLM; they inflate every context window without aiding tool selection.
- `exec_command` description: removed the sentence restating `drain_timeout_secs` behavior. That detail is already in the parameter schema; duplicating it in the tool description adds token cost with no benefit.
- `AGENTS.md` `working_dir` entry: reverted from internal function names (`validate_path_relative_to`, `validate_parent_in_root`) to behavioral terms. Agents need observable behavior, not Rust internals.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
