### PR TITLE
test(resources): integration tests for MCP resource surface via common harness

### DIFF
--- a/crates/aptu-coder/tests/common/mod.rs
+++ b/crates/aptu-coder/tests/common/mod.rs
@@ -12,11 +12,20 @@ pub fn make_test_analyzer() -> aptu_coder::CodeAnalyzer {
     aptu_coder::CodeAnalyzer::new(peer, aptu_coder::MetricsSender(metrics_tx))
 }
 
-pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<serde_json::Value> {
-    let analyzer = make_test_analyzer();
+/// Send a single MCP request over a fresh in-process connection.
+///
+/// Performs the initialize/initialized handshake, sends one request with
+/// `id=2`, and races the response loop against the server task to surface
+/// panics.  This is the canonical helper for one-shot MCP method dispatch;
+/// both `call_tool_raw` (tools) and resource-method tests build on it.
+pub async fn send_raw_request(
+    analyzer: aptu_coder::CodeAnalyzer,
+    method: &str,
+    params: serde_json::Value,
+) -> serde_json::Value {
     let (client, server) = tokio::io::duplex(65536);
 
-    let server_handle = tokio::spawn(async move {
+    let mut server_handle = tokio::spawn(async move {
         let (server_rx, server_tx) = tokio::io::split(server);
         if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
             let _ = service.waiting().await;
@@ -26,7 +35,7 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
     let (client_rx, mut client_tx) = tokio::io::split(client);
     let mut reader = BufReader::new(client_rx).lines();
 
-    // Initialize
+    // Initialize (id=1).
     let init = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -47,13 +56,13 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
         .flush()
         .await
         .expect("failed to flush initialize request");
-    let _resp = reader
+    let _init_resp = reader
         .next_line()
         .await
         .expect("IO error reading initialize response")
         .expect("server closed before sending initialize response");
 
-    // Initialized notification
+    // notifications/initialized (no id).
     let notif = serde_json::json!({
         "jsonrpc": "2.0",
         "method": "notifications/initialized",
@@ -70,12 +79,132 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
         .await
         .expect("failed to flush initialized notification");
 
-    // Send tool calls
+    // The actual request (id=2).
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": method,
+        "params": params
+    })
+    .to_string()
+        + "\n";
+    client_tx
+        .write_all(request.as_bytes())
+        .await
+        .expect("failed to write request");
+    client_tx.flush().await.expect("failed to flush request");
+
+    // Race response loop vs server task to surface panics.
+    tokio::select! {
+        result = async {
+            loop {
+                let line = reader
+                    .next_line()
+                    .await
+                    .expect("IO error reading response")
+                    .expect("server closed before sending response");
+                let v: serde_json::Value =
+                    serde_json::from_str(&line).expect("response is not valid JSON");
+                if v.get("id") == Some(&serde_json::json!(2)) {
+                    return v;
+                }
+            }
+        } => {
+            server_handle.abort();
+            result
+        }
+        outcome = &mut server_handle => {
+            match outcome {
+                Ok(_) => panic!("server task exited unexpectedly before response"),
+                Err(e) => panic!("server task panicked: {e}"),
+            }
+        }
+    }
+}
+
+/// Call a single `tools/call` request. Thin wrapper over `send_raw_request`.
+pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_json::Value {
+    let analyzer = make_test_analyzer();
+    send_raw_request(
+        analyzer,
+        "tools/call",
+        serde_json::json!({
+            "name": tool_name,
+            "arguments": params
+        }),
+    )
+    .await
+}
+
+/// Call multiple `tools/call` requests sequentially on the same MCP connection.
+///
+/// Each request is sent only after the previous response is received, which is
+/// required for cache-ordering tests (e.g. `symbol_cache_tests`).
+pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<serde_json::Value> {
+    let analyzer = make_test_analyzer();
+    let (client, server) = tokio::io::duplex(65536);
+
+    let server_handle = tokio::spawn(async move {
+        let (server_rx, server_tx) = tokio::io::split(server);
+        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
+            let _ = service.waiting().await;
+        }
+    });
+
+    let (client_rx, mut client_tx) = tokio::io::split(client);
+    let mut reader = BufReader::new(client_rx).lines();
+
+    // Initialize (id=1).
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "0.1.0"}
+        }
+    })
+    .to_string()
+        + "\n";
+    client_tx
+        .write_all(init.as_bytes())
+        .await
+        .expect("failed to write initialize request");
+    client_tx
+        .flush()
+        .await
+        .expect("failed to flush initialize request");
+    let _init_resp = reader
+        .next_line()
+        .await
+        .expect("IO error reading initialize response")
+        .expect("server closed before sending initialize response");
+
+    // notifications/initialized (no id).
+    let notif = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+        "params": {}
+    })
+    .to_string()
+        + "\n";
+    client_tx
+        .write_all(notif.as_bytes())
+        .await
+        .expect("failed to write initialized notification");
+    client_tx
+        .flush()
+        .await
+        .expect("failed to flush initialized notification");
+
+    // Sequential tool calls: send each only after the previous response.
     let mut responses = Vec::with_capacity(calls.len());
     for (i, (tool_name, params)) in calls.into_iter().enumerate() {
+        let id = (i + 2) as u64;
         let call = serde_json::json!({
             "jsonrpc": "2.0",
-            "id": (i + 2) as u64,
+            "id": id,
             "method": "tools/call",
             "params": {
                 "name": tool_name,
@@ -101,7 +230,7 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
                 .expect("server closed before sending tool response");
             let v: serde_json::Value =
                 serde_json::from_str(&line).expect("tool response is not valid JSON");
-            if v.get("id") == Some(&serde_json::json!((i + 2) as u64)) {
+            if v.get("id") == Some(&serde_json::json!(id)) {
                 responses.push(v);
                 break;
             }
@@ -110,114 +239,4 @@ pub async fn call_tool_raw_seq(calls: Vec<(&str, serde_json::Value)>) -> Vec<ser
 
     server_handle.abort();
     responses
-}
-
-pub async fn call_tool_raw(tool_name: &str, params: serde_json::Value) -> serde_json::Value {
-    let analyzer = make_test_analyzer();
-    let (client, server) = tokio::io::duplex(65536);
-
-    // Spawn the analyzer server on the server half
-    let mut server_handle = tokio::spawn(async move {
-        let (server_rx, server_tx) = tokio::io::split(server);
-        if let Ok(service) = rmcp::serve_server(analyzer, (server_rx, server_tx)).await {
-            let _ = service.waiting().await;
-        }
-    });
-
-    let (client_rx, mut client_tx) = tokio::io::split(client);
-    let mut reader = BufReader::new(client_rx).lines();
-
-    // Step 1: Send initialize request
-    let init = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": rmcp::model::ProtocolVersion::LATEST.as_str(),
-            "capabilities": {},
-            "clientInfo": {"name": "test-client", "version": "0.1.0"}
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx
-        .write_all(init.as_bytes())
-        .await
-        .expect("failed to write initialize request");
-    client_tx
-        .flush()
-        .await
-        .expect("failed to flush initialize request");
-
-    // Step 2: Read initialize response (discard)
-    let _resp = reader
-        .next_line()
-        .await
-        .expect("IO error reading initialize response")
-        .expect("server closed before sending initialize response");
-
-    // Step 3: Send initialized notification (no id)
-    let notif = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "notifications/initialized",
-        "params": {}
-    })
-    .to_string()
-        + "\n";
-    client_tx
-        .write_all(notif.as_bytes())
-        .await
-        .expect("failed to write initialized notification");
-    client_tx
-        .flush()
-        .await
-        .expect("failed to flush initialized notification");
-
-    // Step 4: Send tools/call
-    let call = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {
-            "name": tool_name,
-            "arguments": params
-        }
-    })
-    .to_string()
-        + "\n";
-    client_tx
-        .write_all(call.as_bytes())
-        .await
-        .expect("failed to write tools/call request");
-    client_tx
-        .flush()
-        .await
-        .expect("failed to flush tools/call request");
-
-    // Step 5: Race response loop against server handle to surface server panics
-    tokio::select! {
-        result = async {
-            loop {
-                let line = reader
-                    .next_line()
-                    .await
-                    .expect("IO error reading tool response")
-                    .expect("server closed before sending tool response");
-                let v: serde_json::Value =
-                    serde_json::from_str(&line).expect("tool response is not valid JSON");
-                if v.get("id") == Some(&serde_json::json!(2)) {
-                    return v;
-                }
-            }
-        } => {
-            server_handle.abort();
-            result
-        }
-        outcome = &mut server_handle => {
-            match outcome {
-                Ok(_) => panic!("server task exited unexpectedly before tool response"),
-                Err(e) => panic!("server task panicked: {e}"),
-            }
-        }
-    }
 }

--- a/crates/aptu-coder/tests/resources_integration.rs
+++ b/crates/aptu-coder/tests/resources_integration.rs
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 aptu-coder contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the MCP resource surface (`list_resources`,
+//! `list_resource_templates`, `read_resource`) over a real in-process MCP server.
+//!
+//! All MCP dispatch goes through `common::send_raw_request`, which runs the
+//! full initialize/initialized handshake and races the response against the
+//! server task.  No handshake boilerplate lives in this file.
+
+mod common;
+
+use common::{call_tool_raw, make_test_analyzer, send_raw_request};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// 64-char hex string used for cold-miss URIs.  `parse_graph_uri` does not
+/// validate the hash format, so an all-zero hash is a well-formed key that
+/// never matches a real shard.
+const DUMMY_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Process-global graph cache directory.
+///
+/// `APTU_CODER_DISK_CACHE_DIR` must be set before any `CodeAnalyzer` is
+/// constructed.  Using `OnceLock` + a leaked `TempDir` satisfies both the
+/// single-initialization and lifetime requirements for the whole test binary.
+fn graph_cache_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let cwd = std::env::current_dir().expect("must have cwd");
+        let dir = tempfile::TempDir::new_in(&cwd).expect("cache tempdir");
+        let path = dir.path().to_path_buf();
+        // SAFETY: called once via OnceLock before any analyzer is constructed;
+        // no concurrent reader of APTU_CODER_DISK_CACHE_DIR exists at this point.
+        unsafe {
+            std::env::set_var("APTU_CODER_DISK_CACHE_DIR", &path);
+        }
+        std::mem::forget(dir); // keep the directory alive for the whole binary
+        path
+    })
+}
+
+/// Poll until `graph_cache_dir()` contains at least one `.bin` shard, then
+/// return the full path to the first one found.
+///
+/// The production code writes shards asynchronously after `analyze_symbol`
+/// returns, so we poll rather than assume the file exists immediately.
+async fn wait_for_any_shard(base: &Path) -> PathBuf {
+    let deadline = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    loop {
+        // Shards live at <base>/<key[..2]>/<key>.bin.
+        if let Ok(rd) = std::fs::read_dir(base) {
+            for subdir in rd.flatten() {
+                if subdir.file_type().is_ok_and(|t| t.is_dir())
+                    && let Ok(rd2) = std::fs::read_dir(subdir.path())
+                    && let Some(entry) = rd2
+                        .flatten()
+                        .find(|e| e.path().extension().is_some_and(|x| x == "bin"))
+                {
+                    return entry.path();
+                }
+            }
+        }
+        assert!(
+            start.elapsed() < deadline,
+            "no graph shard appeared in {base:?} within 10 s"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Extract the cache key (64-char hex string) from a shard path of the form
+/// `<base>/<key[..2]>/<key>.bin`.
+fn key_from_shard(shard: &Path) -> String {
+    shard
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .expect("shard path has a UTF-8 stem")
+        .to_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_resources_cold_cache() {
+    graph_cache_dir();
+    let analyzer = make_test_analyzer();
+    let resp = send_raw_request(analyzer, "resources/list", serde_json::json!({})).await;
+
+    assert!(
+        resp.get("error").is_none(),
+        "list_resources must not error; got: {resp}"
+    );
+    assert!(
+        resp["result"]["resources"].is_array(),
+        "result.resources must be an array; got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_resource_templates() {
+    graph_cache_dir();
+    let analyzer = make_test_analyzer();
+    let resp = send_raw_request(analyzer, "resources/templates/list", serde_json::json!({})).await;
+
+    assert!(
+        resp.get("error").is_none(),
+        "list_resource_templates must not error; got: {resp}"
+    );
+    let templates = resp["result"]["resourceTemplates"]
+        .as_array()
+        .expect("result.resourceTemplates must be an array");
+    assert!(
+        templates.iter().any(|t| t["uriTemplate"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("aptu-coder://"))),
+        "at least one template must start with aptu-coder://; got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_resource_cold_miss() {
+    graph_cache_dir();
+    let analyzer = make_test_analyzer();
+    let uri = format!("aptu-coder://graph/{DUMMY_HASH}/blast-radius/main");
+    let resp = send_raw_request(analyzer, "resources/read", serde_json::json!({"uri": uri})).await;
+
+    let msg = resp
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .or_else(|| resp["result"]["contents"][0]["text"].as_str())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("graph not built yet") || msg.contains("analyze_symbol"),
+        "cold miss should mention building the graph; got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_resource_warm_cache() {
+    let cache_dir = graph_cache_dir();
+    let cwd = std::env::current_dir().expect("must have cwd");
+
+    // Arrange: a small Rust fixture inside CWD (validate_path confinement).
+    let fixture = tempfile::TempDir::new_in(&cwd).expect("fixture tempdir");
+    std::fs::write(
+        fixture.path().join("lib.rs"),
+        "fn inner() {}\n\nfn outer() {\n    inner();\n}\n",
+    )
+    .expect("write fixture");
+
+    // Act: warm the graph cache via analyze_symbol.
+    let _warm = call_tool_raw(
+        "analyze_symbol",
+        serde_json::json!({
+            "path": fixture.path().to_str().expect("fixture path is UTF-8"),
+            "symbol": "",
+            "follow_depth": 1,
+            "max_depth": 2,
+        }),
+    )
+    .await;
+
+    // Wait for the shard the production code writes asynchronously, then read
+    // the cache key directly from the file name -- no coupling to
+    // compute_cache_key internals.
+    let shard = wait_for_any_shard(cache_dir).await;
+    let repo_hash = key_from_shard(&shard);
+
+    // Read the resource for the warmed hash.
+    let uri = format!("aptu-coder://graph/{repo_hash}/blast-radius/main");
+    let analyzer = make_test_analyzer();
+    let resp = send_raw_request(analyzer, "resources/read", serde_json::json!({"uri": uri})).await;
+
+    assert!(
+        resp.get("error").is_none(),
+        "warm read must not error; got: {resp}"
+    );
+    let text = resp["result"]["contents"][0]["text"]
+        .as_str()
+        .expect("contents[0].text must be a string");
+    let payload: serde_json::Value =
+        serde_json::from_str(text).expect("contents[0].text must be JSON");
+    assert!(
+        payload.get("nodes").is_some(),
+        "payload must contain a nodes key; got: {payload}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_resource_malformed_uri() {
+    graph_cache_dir();
+    let analyzer = make_test_analyzer();
+    let resp = send_raw_request(
+        analyzer,
+        "resources/read",
+        serde_json::json!({"uri": "not-a-valid-uri"}),
+    )
+    .await;
+
+    assert!(
+        resp["error"]["code"].is_number(),
+        "malformed URI must yield a JSON-RPC error with a code; got: {resp}"
+    );
+}


### PR DESCRIPTION
## Summary
Add end-to-end integration coverage for the MCP resource surface over a real in-process server. The tests exercise resource listing, template discovery, cold-cache reads, warm-cache reads, and malformed URI handling.

## Changes
The new integration suite uses a raw-duplex JSON-RPC helper to perform the MCP initialize handshake and dispatch resource requests. It warms the graph through analyze_symbol, reconstructs the public cache key, polls for the cache shard, and verifies the returned resource payload while keeping fixtures and cache state isolated under the server working directory.

## Test plan
- [ ] Tests pass (see 03-build.json test_results)
- [ ] Linter clean
- [ ] Security scan clean (see 04-validation.json security_summary)
